### PR TITLE
Feature/apply template to dev specs

### DIFF
--- a/_devSpecs/Beacon/specification.html
+++ b/_devSpecs/Beacon/specification.html
@@ -1,27 +1,22 @@
 ---
-cross_walk_url: https://docs.google.com/spreadsheets/d/1wLJa4LkCM8oIvBPTFS1IBcygRGBpSrAgNfRSEadVICo/edit#gid=1261485211
-dateModified: 2018-02-27
+name: Beacon
+url: Beacons
+
+status: revision
+spec_type: Profile
 group: beacons
-description: In this document we propose a simple way for a beacons to self-describe
-  their genetic variant cardinality service for better integration with other beacons
-  within the beacon-network. It builds upon the Beacon service API and uses existing
-  schema.org entities and properties.
-g_mapping_file: Beacon Mapping Simp
-gh_examples: https://github.com/BioSchemas/specifications/tree/master/Beacon/examples/
+use_cases_url: /useCases/Beacons/
+cross_walk_url: https://docs.google.com/spreadsheets/d/1wLJa4LkCM8oIvBPTFS1IBcygRGBpSrAgNfRSEadVICo/edit#gid=1261485211
 gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Beacon
+live_deploy: ''
+
+parent_type: DataCatalog
 hierarchy:
 - Thing
 - CreativeWork
 - DataCatalog
-live_deploy: ''
-name: Beacon
-parent_type: DataCatalog
-spec_type: Profile
-status: revision
-subtitle: 'A convention for beacon to self-describe. '
-url: Beacons
-use_cases_url: /useCases/Beacons/
-version: '0.2'
+
+spec_mapping_url: https://docs.google.com/spreadsheets/d/1Hl-K9wBtp8Ys0OJxzj8SC72xDKX_OeKDSs5ioZpPfTw/edit#gid=1483018794
 spec_info:
   title: Beacon
   subtitle: 'A convention for beacon to self-describe. '

--- a/_devSpecs/Beacon/specification.html
+++ b/_devSpecs/Beacon/specification.html
@@ -29,9 +29,10 @@ spec_info:
     their genetic variant cardinality service for better integration with other beacons
     within the beacon-network. It builds upon the Beacon service API and uses existing
     schema.org entities and properties. '
-  version: "0.2"
+  version: 0.2-draft
+  version_date: 20180423T140938
   official_type: ""
-  full_example: ""
+  full_example: https://github.com/BioSchemas/specifications/tree/master/Beacon/examples
 mapping:
 - property: aggregator
   expected_types:
@@ -46,8 +47,8 @@ mapping:
   example: ""
 - property: dataset
   expected_types:
-  - Dataset
-  description: 'A dataset contained in this catalog.Inverse property: includedInDataCatalog.'
+  - DataCatalog
+  description: "A dataset contained in this catalog. \ninverse property: [includedInDataCatalog.](http://schema.org/includedInDataCatalog)"
   type: ""
   type_url: ""
   bsc_description: Datasets served by this Beacon.
@@ -74,7 +75,8 @@ mapping:
   description: The identifier property represents any kind of identifier for any kind
     of Thing, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated
     properties for representing many of these, either as textual strings or as URL
-    (URI) links. See background notes for more details.
+    (URI) links. See [background notes](http://schema.org/docs/datamodel.html#identifierBg)
+    for more details.
   type: ""
   type_url: ""
   bsc_description: Unique identifier of the Beacon.
@@ -111,7 +113,7 @@ mapping:
   - Person
   description: The service provider, service operator, or service performer; the goods
     producer. Another party (a seller) may offer those services or goods on behalf
-    of the provider. A provider may also serve as the seller. Supersedes carrier.
+    of the provider. A provider may also serve as the seller. Supersedes [carrier](http://schema.org/carrier).
   type: ""
   type_url: ""
   bsc_description: Contact information for this Beacon.

--- a/_devSpecs/Chemical/specification.html
+++ b/_devSpecs/Chemical/specification.html
@@ -1,17 +1,19 @@
 ---
-cross_walk_url: ''
-description: ''
-edit_url: https://github.com/BioSchemas/specifications/tree/master/Chemical/specification.html
-gh_examples: ''
-gh_folder: https://github.com/BioSchemas/specifications/tree/master/Chemical
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Chemistry
+name: Chemical
+
+status: revision
+spec_type: Profile
 group: chemicals
+use_cases_url: ''
+cross_walk_url: ''
+gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Chemistry
+live_deploy: ''
+
+parent_type: Thing
 hierarchy:
 - Thing
-live_deploy: ''
-name: Chemical
-spec_type: Profile
-parent_type: Thing
+
+spec_mapping_url: https://docs.google.com/spreadsheets/d/1W67djQ6r0sgv7tdLypUtZqoCTr4mYXEoCY9iez18vrs/edit#gid=1483018794
 spec_info:
   title: Chemical
   subtitle: ""

--- a/_devSpecs/Chemical/specification.html
+++ b/_devSpecs/Chemical/specification.html
@@ -8,43 +8,64 @@ gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Chemistry
 group: chemicals
 hierarchy:
 - Thing
-layout: new_spec_detail
 live_deploy: ''
 name: Chemical
+spec_type: Profile
 parent_type: Thing
-properties:
-- bsc_dec: ''
-  cardinality: ONE
-  controlled_vocab:
-    ontologies: []
-    terms: []
-  expected_type:
+spec_info:
+  title: Chemical
+  subtitle: ""
+  description: ""
+  version: 0.1-draft
+  version_date: 20180423T161624
+  official_type: ""
+  full_example: ""
+mapping:
+- property: identifier
+  expected_types:
   - PropertyValue
   - Text
   - URL
+  description: The identifier property represents any kind of identifier for any kind
+    of Thing, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated
+    properties for representing many of these, either as textual strings or as URL
+    (URI) links. See [background notes](http://schema.org/docs/datamodel.html#identifierBg)
+    for more details.
+  type: ""
+  type_url: ""
+  bsc_description: ""
   marginality: Minimum
-  name: identifier
-  parent: Thing
-  sdo_desc: The identifier property represents any kind of identifier for any kind
-    of <a class="localLink" href="http://schema.org/Thing">Thing</a>, such as ISBNs,
-    GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing
-    many of these, either as textual strings or as URL (URI) links. See <a href="http://schema.org/docs/datamodel.html#identifierBg">background
-    notes</a> for more details.
-- bsc_dec: ''
   cardinality: ONE
-  controlled_vocab:
-    ontologies: []
-    terms: []
-  expected_type:
+  controlled_vocab: ""
+  example: ""
+- property: name
+  expected_types:
   - Text
+  description: The name of the item.
+  type: ""
+  type_url: ""
+  bsc_description: ""
   marginality: Minimum
-  name: name
-  parent: Thing
-  sdo_desc: The name of the item.
-spec_mapping_url: https://docs.google.com/spreadsheets/d/1929wjxexWAQGuXP8qn9dI7HTbRIjGhqjazSnuSJaj0U/edit?usp=drivesdk
-spec_type: Profile
-status: revision
-subtitle: ''
-use_cases_url: ''
-version: '0.1-draft.1'
+  cardinality: ONE
+  controlled_vocab: ""
+  example: ""
 ---
+<!DOCTYPE HTML>
+<html>
+   {% include head.html %}
+   <body>
+      {% include header.html %}
+      {% include navbar.html %}
+      <div class="page-content">
+         <div class="wrapper">
+            <div id="main-content-wrapper" class="outer">
+               <section id="main_content" class="inner">
+                  {% include profile_start.html %}
+                  {% include specification_table.html %}
+               </section>
+            </div>
+         </div>
+      </div>
+      {% include footer.html %}
+   </body>
+</html>

--- a/_devSpecs/ChemicalStructure/specification.html
+++ b/_devSpecs/ChemicalStructure/specification.html
@@ -1,51 +1,73 @@
 ---
+name: ChemicalStructure
+
+status: revision
+spec_type: Profile
+group: chemicals
+use_cases_url: ''
 cross_walk_url: ''
-description: ''
-edit_url: https://github.com/BioSchemas/specifications/tree/master/ChemicalStructure/specification.html
-g_mapping_file: ChemicalStructure Mapping Simp
-gh_examples: ''
-gh_folder: https://github.com/BioSchemas/specifications/tree/master/ChemicalStructure
 gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Chemistry
-group: chemicals  
+live_deploy: ''
+
+parent_type: Thing
 hierarchy:
 - Thing
-layout: new_spec_detail
-live_deploy: ''
-name: ChemicalStructure
-parent_type: Thing
-properties:
-- bsc_dec: ''
-  cardinality: ONE
-  controlled_vocab:
-    ontologies: []
-    terms: []
-  expected_type:
+
+spec_mapping_url: https://docs.google.com/spreadsheets/d/12Ti1KFoP7BSCac3F7jIv2TZqJJ2A5bweYY5gfsnCSs4/edit#gid=1483018794
+spec_info:
+  title: ChemicalStructure
+  subtitle: ""
+  description: ""
+  version: 0.1-draft
+  version_date: 20180425T161624
+  official_type: ""
+  full_example: ""
+mapping:
+- property: identifier
+  expected_types:
   - PropertyValue
   - Text
   - URL
+  description: The identifier property represents any kind of identifier for any kind
+    of Thing, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated
+    properties for representing many of these, either as textual strings or as URL
+    (URI) links. See [background notes](http://schema.org/docs/datamodel.html#identifierBg)
+    for more details.
+  type: ""
+  type_url: ""
+  bsc_description: ""
   marginality: Minimum
-  name: identifier
-  parent: Thing
-  sdo_desc: The identifier property represents any kind of identifier for any kind
-    of <a class="localLink" href="http://schema.org/Thing">Thing</a>, such as ISBNs,
-    GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing
-    many of these, either as textual strings or as URL (URI) links. See <a href="http://schema.org/docs/datamodel.html#identifierBg">background
-    notes</a> for more details.
-- bsc_dec: ''
   cardinality: ONE
-  controlled_vocab:
-    ontologies: []
-    terms: []
-  expected_type:
+  controlled_vocab: ""
+  example: ""
+- property: name
+  expected_types:
   - Text
+  description: The name of the item.
+  type: ""
+  type_url: ""
+  bsc_description: ""
   marginality: Minimum
-  name: name
-  parent: Thing
-  sdo_desc: The name of the item.
-spec_mapping_url: https://docs.google.com/spreadsheets/d/1kgAbxi2iMUKs_tOtDfBt1CQcMYFfBVeuu56Az1ZkJmE/edit?usp=drivesdk
-spec_type: Profile
-status: revision
-subtitle: ''
-use_cases_url: ''
-version: '0.1-draft.1'
+  cardinality: ONE
+  controlled_vocab: ""
+  example: ""
 ---
+<!DOCTYPE HTML>
+<html>
+   {% include head.html %}
+   <body>
+      {% include header.html %}
+      {% include navbar.html %}
+      <div class="page-content">
+         <div class="wrapper">
+            <div id="main-content-wrapper" class="outer">
+               <section id="main_content" class="inner">
+                  {% include profile_start.html %}
+                  {% include specification_table.html %}
+               </section>
+            </div>
+         </div>
+      </div>
+      {% include footer.html %}
+   </body>
+</html>

--- a/_devSpecs/Course/specification.html
+++ b/_devSpecs/Course/specification.html
@@ -1,30 +1,238 @@
 ---
-cross_walk_url: https://docs.google.com/spreadsheets/d/1cQ6mDbsG_cMX2EDAN8xH6-9yMRba8-rErlPeP8HTs8A
-dateModified: 2018-03-11
-description: ''
-edit_url: https://github.com/BioSchemas/specifications/tree/master/Course/specification.html
-gh_examples: ''
-gh_folder: https://github.com/BioSchemas/specifications/tree/master/Course
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Course
+name: Course
+
+status: revision
+spec_type: Profile
 group: trainingmaterials
+use_cases_url: ''
+cross_walk_url: https://docs.google.com/spreadsheets/d/1cQ6mDbsG_cMX2EDAN8xH6-9yMRba8-rErlPeP8HTs8A
+gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Course
+live_deploy: ''
+
+parent_type: Course
 hierarchy:
 - Thing
 - CreativeWork
 - Course
-live_deploy: ''
-name: Course
-parent_type: Course
-properties:
-spec_mapping_url: https://docs.google.com/spreadsheets/d/1-nxYa8fEauokQYFWj6n9dkueL6HolXpqQpVQziARPfE/edit?usp=drivesdk
-spec_type: Profile
-status: revision
-subtitle: ''
-use_cases_url: ''
-version: '0.1-draft.1'
+
+spec_mapping_url: https://docs.google.com/spreadsheets/d/1Nqil3cuNB8XioeG3U8mBzV35IdKfcVVLvVOwuSk9xQk/edit#gid=1483018794
+spec_info:
+  title: Course
+  subtitle: 'Specification describing a course. '
+  description: 'This specification must be used in tandem with a courseInstance. A
+    course is used to describe the broad, common aspects of a recurring training event
+    - whereas a course instance is about the specific times and location of when that
+    course is held. '
+  version: 0.1-draft
+  version_date: 20180425T144349
+  official_type: ""
+  full_example: ""
+mapping:
+- property: audience
+  expected_types:
+  - Audience
+  description: An intended audience, i.e. a group for whom something was created.
+    Supersedes [serviceAudience](http://schema.org/serviceAudience).
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Minimum
+  cardinality: ONE
+  controlled_vocab: ""
+  example: ""
+- property: author
+  expected_types:
+  - Organization
+  - Person
+  description: The author of this content or rating. Please note that author is special
+    in that HTML 5 provides a special mechanism for indicating authorship via the
+    rel tag. That is equivalent to this and may be used interchangeably.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: MANY
+  controlled_vocab: ""
+  example: ""
+- property: courseCode
+  expected_types:
+  - Text
+  description: The identifier for the [Course](http://schema.org/Course) used by the
+    course [provider](http://schema.org/provider) (e.g. CS101 or 6.001).
+  type: ""
+  type_url: ""
+  bsc_description: About this course.
+  marginality: Optional
+  cardinality: ONE
+  controlled_vocab: ""
+  example: ""
+- property: coursePrerequisites
+  expected_types:
+  - AlignmentObject
+  - Course
+  - Text
+  description: Requirements for taking the [Course](http://schema.org/Course). May
+    be completion of another Course or a textual description like "permission of instructor".
+    Requirements may be a pre-requisite competency, referenced using [AlignmentObject](http://schema.org/AlignmentObject).
+  type: ""
+  type_url: ""
+  bsc_description: Pre-requisite requirments before you can take this course.
+  marginality: Minimum
+  cardinality: MANY
+  controlled_vocab: ""
+  example: ""
+- property: description
+  expected_types:
+  - Text
+  description: A description of the item.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Minimum
+  cardinality: ONE
+  controlled_vocab: ""
+  example: ""
+- property: hasCourseInstance
+  expected_types:
+  - CourseInstance
+  description: An offering of the course at a specific time and place or through specific
+    media or mode of study or to a specific section of students.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: MANY
+  controlled_vocab: ""
+  example: ""
+- property: image
+  expected_types:
+  - ImageObject
+  - URL
+  description: An image of the item. This can be a URL or a fully described [ImageObject](http://schema.org/ImageObject).
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: ONE
+  controlled_vocab: ""
+  example: ""
+- property: inLanguage
+  expected_types:
+  - Language
+  - Text
+  description: The language of the content or performance or used in an action. Please
+    use one of the language codes from the [IETF BCP 47](https://tools.ietf.org/html/bcp47)
+    standard. See also [availableLanguage](http://schema.org/availableLanguage). Supersedes
+    language.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: ONE
+  controlled_vocab: ""
+  example: ""
+- property: keywords
+  expected_types:
+  - Text
+  description: Keywords or tags used to describe this content. Multiple entries in
+    a keywords list are typically delimited by commas.
+  type: ""
+  type_url: ""
+  bsc_description: Keywords describing course. Use terms from Controlled Vocabularies
+    where possible, e.g., [EDAM](http://edamontology.org/page).
+  marginality: Minimum
+  cardinality: MANY
+  controlled_vocab: '[EDAM](http://edamontology.org/page)'
+  example: ""
+- property: name
+  expected_types:
+  - Text
+  description: The name of the item.
+  type: ""
+  type_url: ""
+  bsc_description: Title of the course
+  marginality: Minimum
+  cardinality: ONE
+  controlled_vocab: ""
+  example: ""
+- property: producer
+  expected_types:
+  - Organization
+  - Person
+  description: The person or organization who produced the work (e.g. music album,
+    movie, tv/radio series etc.).
+  type: ""
+  type_url: ""
+  bsc_description: Faciliator/contact person.
+  marginality: Recommended
+  cardinality: MANY
+  controlled_vocab: ""
+  example: ""
+- property: provider
+  expected_types:
+  - Organization
+  - Person
+  description: The service provider, service operator, or service performer; the goods
+    producer. Another party (a seller) may offer those services or goods on behalf
+    of the provider. A provider may also serve as the seller. Supersedes carrier.
+  type: ""
+  type_url: ""
+  bsc_description: Host organization.
+  marginality: Optional
+  cardinality: MANY
+  controlled_vocab: ""
+  example: ""
+- property: rdf:type
+  expected_types:
+  - URL
+  description: This is used by validation tools to indentify the profile used. You
+    must use the value specified in the Controlled Vocabulary column.
+  type: external
+  type_url: https://www.w3.org/1999/02/22-rdf-syntax-ns#type
+  bsc_description: This is used by validation tools to indentify the profile used.
+    You must use the value specified in the Controlled Vocabulary column.
+  marginality: Minimum
+  cardinality: ONE
+  controlled_vocab: ""
+  example: ""
+- property: sponsor
+  expected_types:
+  - Organization
+  - Person
+  description: A person or organization that supports a thing through a pledge, promise,
+    or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor
+    of an event.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: MANY
+  controlled_vocab: ""
+  example: ""
+- property: thumbnailUrl
+  expected_types:
+  - URL
+  description: A thumbnail image relevant to the Thing.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: ONE
+  controlled_vocab: ""
+  example: ""
+- property: url
+  expected_types:
+  - URL
+  description: URL of the item.
+  type: ""
+  type_url: ""
+  bsc_description: URL fo the course page.
+  marginality: Minimum
+  cardinality: ONE
+  controlled_vocab: ""
+  example: ""
+
 ---
-
-
-
 <!DOCTYPE HTML>
 <html>
    {% include head.html %}
@@ -36,224 +244,11 @@ version: '0.1-draft.1'
             <div id="main-content-wrapper" class="outer">
                <section id="main_content" class="inner">
                   {% include profile_start.html %}
-                  <table class="bioschemas_properties bsc_type">
-                     <thead>
-                        <tr>
-                           <th>Property</th>
-                           <th>Expected Type</th>
-                           <th>Description</th>
-                           <th>CD</th>
-                           <th>Controlled Vocabulary</th>
-                        </tr>
-                     </thead>
-                     <tbody>
-<!-- MINIMUM -->    <tr class="cardinality"><td colspan="5">Marginality: <b>Minimum</b></td></tr>
-                    <tr>
-                       <th><a href="http://schema.org/audience">audience</a></th>
-                       <td>
-                          <a href="http://schema.org/Audience">Audience</a>
-                       </td>
-                       <td>
-                         <strong>Schema</strong>: An intended audience, i.e. a group for whom something was created. Supersedes serviceAudience.<br />
-                         <strong>Bioschemas</strong>: Intended audience of course.
-                       </td>
-                       <td>ONE</td>
-                       <td></td>
-                    </tr>
-                    <tr>
-                       <th><a href="http://schema.org/coursePrerequisites">coursePrerequisites</a></th>
-                       <td>
-                         <a href="http://schema.org/AlignmentObject">AlignmentObject</a><br />
-                         <a href="http://schema.org/Course">Course</a><br />
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         <strong>Schema</strong>: Requirements for taking the <a href="http://schema.org/Course">Course</a>. May be completion of another Course or a textual description like "permission of instructor". Requirements may be a pre-requisite competency, referenced using <a href="http://schema.org/AlignmentObject">AlignmentObject</a>.<br />
-                         <strong>Bioschemas</strong>: Pre-requisite requirments before you can take this course.
-                       <td>MANY</td>
-                       <td></td>
-                    </tr>
-                       <tr>
-                          <th><a href="http://schema.org/description">description</a></th>
-                          <td>
-                            <a href="http://schema.org/Text">Text</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: A description of the item.
-                          <td>ONE</td>
-                          <td></td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/keywords">keywords</a></th>
-                          <td>
-                            <a href="http://schema.org/Text">Text</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.<br />
-                            <strong>Bioschemas</strong>: Keywords describing course. Use terms from Controlled Vocabularies where possible, e.g., <a class="externalProp" href="http://edamontology.org/">EDAM</a>.
-                          <td>ONE</td>
-                          <td><a class="externalProp" href="http://edamontology.org/">EDAM</a></td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/name">name</a></th>
-                          <td>
-                            <a href="http://schema.org/Text">Text</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: The name of the item.<br />
-                            <strong>Bioschemas</strong>: Title of the course.
-                          <td>ONE</td>
-                          <td></td>
-                       </tr>
-                       <tr>
-                          <th><a class="externalProp" href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">rdf:type</a></th>
-                          <td>
-                            <a href="http://schema.org/URL">URL</a>
-                          </td>
-                          <td>
-                            <strong>Bioschemas</strong>: This is used by validation tools to indentify the profile used. You must use the value specified in the Controlled Vocabulary column.
-                          </td>
-                          <td>ONE</td>
-                          <td>
-                             <strong>Missing!</strong>
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/url">url</a></th>
-                          <td>
-                            <a href="http://schema.org/URL">URL</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: URL of the item.<br />
-                            <strong>Bioschemas</strong>: URL of the course page.
-                          <td>ONE</td>
-                          <td></td>
-                       </tr>
-
-
-                       <tr class="cardinality">
-                          <td colspan="5">
-                             Marginality: <b>Recommended</b>
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/producer">producer</a></th>
-                          <td>
-                            <a href="http://schema.org/Organization">Organization</a><br />
-                            <a href="http://schema.org/Person">Person</a><br />
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.).<br />
-                            <strong>Bioschemas</strong>: Faciliator/contact person.
-                          <td>MANY</td>
-                          <td></td>
-                       </tr>
-
-<!-- OPTIONAL -->
-                       <tr class="cardinality"><td colspan="5">Marginality: <b>Optional</b></td></tr>
-                       <tr>
-                          <th><a href="http://schema.org/author">author</a></th>
-                          <td>
-                            <a href="http://schema.org/Organization">Organization</a><br />
-                            <a href="http://schema.org/Person">Person</a><br />
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.<br />
-                            <strong>Bioschemas</strong>: Course contact?
-                          </td>
-                          <td>MANY</td>
-                          <td></td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/courseCode">courseCode</a></th>
-                          <td>
-                            <a href="http://schema.org/Text">Text</a><br />
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: The identifier for the <a href="http://schema.org/Course">Course</a> used by the course <a href="http://schema.org/provider">provider</a> (e.g. CS101 or 6.001).<br />
-                            <strong>Bioschemas</strong>: About this course.
-                          </td>
-                          <td>ONE</td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/hasCourseInstance">hasCourseInstance</a></th>
-                          <td>
-                            <a href="http://schema.org/CourseInstance">CourseInstance</a><br />
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: An offering of the course at a specific time and place or through specific media or mode of study or to a specific section of students.
-                          </td>
-                          <td>MANY</td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/image">image</a></th>
-                          <td>
-                            <a href="http://schema.org/ImageObject">ImageObject</a><br />
-                            <a href="http://schema.org/URL">URL</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: An image of the item. This can be a <a href="http://schema.or/URL">URL</a> or a fully described <a href="http://schema.or/ImageObject">ImageObject</a>.<br />
-                            <strong>Bioschemas</strong>: Same as thumbnailURL.
-                          </td>
-                          <td>ONE</td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/inLanguage">inLanguage</a></th>
-                          <td>
-                            <a href="http://schema.org/Language">Language</a><br />
-                            <a href="http://schema.org/Text">Text</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: The language of the content or performance or used in an action. Please use one of the language codes from the <a href="http://tools.ietf.org/html/bcp47">IETF BCP 47 standard</a>. See also <a href="http://schema.org/availableLanguage">availableLanguage</a>.
-                          </td>
-                          <td>ONE</td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/provider">provider</a></th>
-                          <td>
-                            <a href="http://schema.org/Organization">Organization</a><br />
-                            <a href="http://schema.org/Person">Person</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: The service provider, service operator, or service performer; the goods producer. Another party (a seller)
-                            may offer those services or goods on behalf of the provider. A provider may also serve as the seller.<br />
-                            <strong>Bioschemas</strong>: Host organization.
-                          </td>
-                          <td>MANY</td>
-                          <td></td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/sponsor">sponsor</a></th>
-                          <td>
-                            <a href="http://schema.org/Organization">Organization</a><br />
-                            <a href="http://schema.org/Person">Person</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
-                          </td>
-                          <td>MANY</td>
-                          <td></td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/thumbnailUrl">thumbnailUrl</a></th>
-                          <td>
-                            <a href="http://schema.org/URL">URL</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: A thumbnail image relevant to the Thing.
-                          </td>
-                          <td>ONE</td>
-                          <td></td>
-                       </tr>
-                     </tbody>
-                  </table>
+                  {% include specification_table.html %}
                </section>
             </div>
          </div>
       </div>
       {% include footer.html %}
-      
-      
-      
    </body>
 </html>

--- a/_devSpecs/DataCatalog/specification.html
+++ b/_devSpecs/DataCatalog/specification.html
@@ -15,6 +15,7 @@ hierarchy:
 - CreativeWork
 - DataCatalog
 
+spec_mapping_url: https://docs.google.com/spreadsheets/d/1rEQEnSXRnjMwK-27bGvDXmi01KzgaqQr1-p2uWoTFwU/edit#gid=1483018794
 spec_info:
   title: DataCatalog
   subtitle: Bioschemas specification for describing data repositories and data catalogues

--- a/_devSpecs/DataCatalog/specification.html
+++ b/_devSpecs/DataCatalog/specification.html
@@ -1,26 +1,235 @@
 ---
-cross_walk_url: https://docs.google.com/spreadsheets/d/1H12h5VpVNJFzNs2RQJWjXkauCEn3qEsVFzKRoiHHffY
-dateModified: 2018-02-25
-description: "A guide for how to describe data catalogs/repositories in the life-sciences using Schema.org-like annotation."
+name: DataCatalog
+
+status: revision
+spec_type: Profile
 group: datarepositories
-gh_examples: https://github.com/BioSchemas/specifications/tree/master/DataCatalog/examples/
+use_cases_url: /useCases/DataRepositories/
+cross_walk_url: https://docs.google.com/spreadsheets/d/1H12h5VpVNJFzNs2RQJWjXkauCEn3qEsVFzKRoiHHffY
 gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20DataCatalogue
+live_deploy: /liveDeploys/
+
+parent_type: DataCatalog
 hierarchy:
 - Thing
 - CreativeWork
 - DataCatalog
-live_deploy: /liveDeploys/
-name: DataCatalog
-parent_type: DataCatalog
-spec_type: Profile
-status: revision
-subtitle: Bioschemas specification for describing data repositories and data catalogs in the life-sciences.
-use_cases_url: /useCases/DataRepositories
-version: 0.1
 
+spec_info:
+  title: DataCatalog
+  subtitle: Bioschemas specification for describing data repositories and data catalogues
+    in the life-sciences
+  description: A guide for how to describe data catalogs/repositories in the life-sciences using Schema.org-like annotation.
+  version: 0.1-draft
+  version_date: 20180425T160608
+  official_type: ""
+  full_example: https://github.com/BioSchemas/specifications/tree/master/DataCatalog/examples/
+mapping:
+- property: alternateName
+  expected_types:
+  - Text
+  description: An alias for the item.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Recommended
+  cardinality: MANY
+  controlled_vocab: ""
+  example: ""
+- property: citation
+  expected_types:
+  - CreativeWork
+  - Text
+  description: A citation or reference to another creative work, such as another publication,
+    web page, scholarly article, etc.
+  type: ""
+  type_url: ""
+  bsc_description: CreativeWork:Name,URL
+  marginality: Recommended
+  cardinality: MANY
+  controlled_vocab: ""
+  example: ""
+- property: dataset
+  expected_types:
+  - Dataset
+  description: |-
+    A dataset contained in this catalog.
+    Inverse property: [includedInDataCatalog](http://schema.org/includedDataCatalog).
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Recommended
+  cardinality: MANY
+  controlled_vocab: ""
+  example: ""
+- property: dateCreated
+  expected_types:
+  - Date
+  - DateTime
+  description: The date on which the CreativeWork was created or the item was added
+    to a DataFeed.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Recommended
+  cardinality: ONE
+  controlled_vocab: ""
+  example: ""
+- property: dateModified
+  expected_types:
+  - Date
+  - DateTime
+  description: The date on which the CreativeWork was most recently modified or when
+    the item's entry was modified within a DataFeed.
+  type: ""
+  type_url: ""
+  bsc_description: The date on which the data catalog/repository was most recently
+    modified.
+  marginality: Optional
+  cardinality: ONE
+  controlled_vocab: ""
+  example: ""
+- property: description
+  expected_types:
+  - Text
+  description: A description of the item.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Minimum
+  cardinality: ONE
+  controlled_vocab: ""
+  example: ""
+- property: fileFormat
+  expected_types:
+  - Text
+  - URL
+  description: Media type, typically MIME format (see IANA site) of the content e.g.
+    application/zip of a SoftwareApplication binary. In cases where a CreativeWork
+    has several media type representations, 'encoding' can be used to indicate each
+    MediaObject alongside particular fileFormat information. Unregistered or niche
+    file formats can be indicated instead via the most appropriate URL, e.g. defining
+    Web page or a Wikipedia entry.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: MANY
+  controlled_vocab: ""
+  example: ""
+- property: identifier
+  expected_types:
+  - PropertyValue
+  - Text
+  - URL
+  description: The identifier property represents any kind of identifier for any kind
+    of Thing, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated
+    properties for representing many of these, either as textual strings or as URL
+    (URI) links. See [background notes](http://schema.org/docs/datamodel.html#identifierBg)
+    for more details.
+  type: ""
+  type_url: ""
+  bsc_description: Unique identifier for the data catalog.
+  marginality: Recommended
+  cardinality: ONE
+  controlled_vocab: ""
+  example: ""
+- property: keywords
+  expected_types:
+  - Text
+  description: Keywords or tags used to describe this content. Multiple entries in
+    a keywords list are typically delimited by commas.
+  type: ""
+  type_url: ""
+  bsc_description: Use terms from Controlled Vocabularies where possible.
+  marginality: Minimum
+  cardinality: ONE
+  controlled_vocab: ""
+  example: ""
+- property: license
+  expected_types:
+  - CreativeWork
+  - URL
+  description: A license document that applies to this content, typically indicated
+    by URL.
+  type: ""
+  type_url: ""
+  bsc_description: CreativeWork:Name,URL
+  marginality: Recommended
+  cardinality: ONE
+  controlled_vocab: ""
+  example: ""
+- property: name
+  expected_types:
+  - Text
+  description: The name of the item.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Minimum
+  cardinality: ONE
+  controlled_vocab: ""
+  example: ""
+- property: provider
+  expected_types:
+  - Organization
+  - Person
+  description: The service provider, service operator, or service performer; the goods
+    producer. Another party (a seller) may offer those services or goods on behalf
+    of the provider. A provider may also serve as the seller. Supersedes carrier.
+  type: ""
+  type_url: ""
+  bsc_description: Contact information for this data repository/catalog.
+  marginality: Minimum
+  cardinality: MANY
+  controlled_vocab: ""
+  example: ""
+- property: publication
+  expected_types:
+  - PublicationEvent
+  description: A publication event associated with the item.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Recommended
+  cardinality: MANY
+  controlled_vocab: ""
+  example: ""
+- property: rdf:type
+  expected_types:
+  - URL
+  description: ""
+  type: external
+  type_url: https://www.w3.org/1999/02/22-rdf-syntax-ns#type
+  bsc_description: This is used by validation tools to indentify the profile used.
+    You must use the value specified in the Controlled Vocabulary column.
+  marginality: Minimum
+  cardinality: ONE
+  controlled_vocab: ""
+  example: ""
+- property: sourceOrganization
+  expected_types:
+  - Organization
+  description: The Organization on whose behalf the creator was working.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Recommended
+  cardinality: MANY
+  controlled_vocab: ""
+  example: ""
+- property: url
+  expected_types:
+  - URL
+  description: URL of the item.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Minimum
+  cardinality: ONE
+  controlled_vocab: ""
+  example: ""
 ---
-
-
 <!DOCTYPE HTML>
 <html>
    {% include head.html %}
@@ -32,221 +241,11 @@ version: 0.1
             <div id="main-content-wrapper" class="outer">
                <section id="main_content" class="inner">
                   {% include profile_start.html %}
-                  <table class="bioschemas_properties bsc_type">
-                     <thead>
-                        <tr>
-                           <th>Property</th>
-                           <th>Expected Type</th>
-                           <th>Description</th>
-                           <th>CD</th>
-                           <th>Controlled Vocabulary</th>
-                        </tr>
-                     </thead>
-                     <tbody>
-                       <tr class="cardinality">
-                          <td colspan="5">
-                             Marginality: <b>Minimum</b>
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/description">description</a></th>
-                          <td>
-                            <a href="http://schema.org/Text">Text</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: A description of the item.
-                          <td>ONE</td>
-                          <td></td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/keywords">keywords</a></th>
-                          <td>
-                            <a href="http://schema.org/Text">Text</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.<br />
-                            <strong>Bioschemas</strong>: Use terms from Controlled Vocabularies where possible.
-                          <td>ONE</td>
-                          <td></td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/provider">provider</a></th>
-                          <td>
-                            <a href="http://schema.org/Organization">Organization</a><br />
-                            <a href="http://schema.org/Person">Person</a><br />
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: The service provider, service operator, or service performer; the goods producer. Another party (a seller)
-                            may offer those services or goods on behalf of the provider. A provider may also serve as the seller.<br />
-                            <strong>Bioschemas</strong>: Contact information for this data repository/catalog.
-                          </td>
-                          <td>MANY</td>
-                          <td></td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/name">name</a></th>
-                          <td>
-                            <a href="http://schema.org/Text">Text</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: The name of the item.
-                          <td>ONE</td>
-                          <td></td>
-                       </tr>
-                       <tr>
-                          <th><a class="externalProp" href="http://www.w3.org/1999/02/22-rdf-syntax-ns#type">rdf:type</a></th>
-                          <td>
-                            <a href="http://schema.org/URL">URL</a>
-                          </td>
-                          <td>
-                            <strong>Bioschemas</strong>: This is used by validation tools to indentify the profile used. You must use the value specified in the Controlled Vocabulary column.
-                          </td>
-                          <td>ONE</td>
-                          <td>
-                             <strong>Missing!</strong>
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/url">url</a></th>
-                          <td>
-                            <a href="http://schema.org/URL">URL</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: URL of the item.
-                          <td>ONE</td>
-                          <td></td>
-                       </tr>
-
-
-                       <tr class="cardinality">
-                          <td colspan="5">
-                             Marginality: <b>Recommended</b>
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/alternateName">alternateName</a></th>
-                          <td>
-                            <a href="http://schema.org/Text">Text</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: An alias for the item.
-                          <td>MANY</td>
-                          <td></td>
-                       </tr>
-                       <tr>
-                       <tr>
-                          <th><a href="http://schema.org/citation">citation</a></th>
-                          <td>
-                            <a href="http://schema.org/CreativeWork">CreativeWork</a><br />
-                            <a href="http://schema.org/Text">Text</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: A citation or reference to another creative work, such as another publication, web page, scholarly article, etc.<br />
-                          <td>MANY</td>
-                          <td></td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/dateModified">dateModified</a></th>
-                          <td>
-                            <a href="http://schema.org/Date">Date</a><br />
-                            <a href="http://schema.org/DateTime">DateTime</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.<br />
-                            <strong>BioSchemas</strong>: The date on which the data catalog/repository was most recently modified.
-                          <td>ONE</td>
-                          <td></td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/dataset">dataset</a></th>
-                          <td>
-                            <a href="http://schema.org/Dataset">Dataset</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: A dataset contained in this catalog. <em>Inverse-property: <a href="includedInDataCatalog">includedInDataCatalog</a>.</em>
-                          <td>MANY</td>
-                          <td></td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/identifier">identifier</a></th>
-                          <td>
-                            <a href="http://schema.org/PropertyValue">PropertyValue</a><br /><a href="http://schema.org/Text">Text</a><br /><a href="http://schema.org/URL">URL</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: The identifier property represents any kind of identifier for any kind of Thing, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides
-                            dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.<br />
-                            <strong>Bioschema</strong>: Unique identifier for the data catalog.
-                          <td>ONE</td>
-                          <td></td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/license">license</a></th>
-                          <td>
-                            <a href="http://schema.org/CreativeWork">CreativeWork</a><br /><a href="http://schema.org/URL">URL</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: A license document that applies to this content, typically indicated by URL.
-                          <td>ONE</td>
-                          <td></td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/publication">publication</a></th>
-                          <td>
-                            <a href="http://schema.org/PublicationEvent">PublicationEvent</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: A publication event associated with the item.
-                          <td>MANY</td>
-                          <td></td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/sourceOrganization">sourceOrganization</a></th>
-                          <td>
-                            <a href="http://schema.org/Organization">Organization</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: The Organization on whose behalf the creator was working.
-                          <td>MANY</td>
-                          <td></td>
-                       </tr>
-
-
-                       <tr class="cardinality">
-                          <td colspan="5">
-                             Marginality: <b>Optional</b>
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/datePublished">datePublished</a></th>
-                          <td>
-                            <a href="http://schema.org/Date">Date</a><br />
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: Date of first broadcast/publication.
-                          <td>ONE</td>
-                          <td></td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/fileFormat">fileFormat</a></th>
-                          <td>
-                            <a href="http://schema.org/Text">Text</a><br /><a href="http://schema.org/URL">URL</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: Media type, typically MIME format (see IANA site) of the content e.g. application/zip of a SoftwareApplication binary.
-                            In cases where a CreativeWork has several media type representations, 'encoding' can be used to indicate each MediaObject alongside particular
-                            fileFormat information. Unregistered or niche file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia entry.
-                          <td>MANY</td>
-                          <td></td>
-                       </tr>
-                     </tbody>
-                  </table>
+                  {% include specification_table.html %}
                </section>
             </div>
          </div>
       </div>
       {% include footer.html %}
-      
-      
-      
    </body>
 </html>

--- a/_devSpecs/DataRecord/specification.html
+++ b/_devSpecs/DataRecord/specification.html
@@ -1,28 +1,267 @@
 ---
-cross_walk_url: https://docs.google.com/spreadsheets/d/1XzrZxFIuG3TS9RU8vACoUjAvaADLmI_FrIk7O3BEkxY/
-dateModified: 2018-02-25
-description: "A Record acts itself as a dataset although it refers to what could be
-  seen as the minimum compact, complete and auto-descriptive unit in a dataset, i.e.,
-  a record.\n\nBioschemas usage\n\nIn Life Sciences, records will represent a BioChemEntity."
-gh_examples: https://github.com/BioSchemas/specifications/tree/master/DataRecord/examples/
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20DataRecord
+name: DataRecord
+
+status: revision
+spec_type: Profile
 group: data
+use_cases_url: /useCases/Datasets
+cross_walk_url: https://docs.google.com/spreadsheets/d/1XzrZxFIuG3TS9RU8vACoUjAvaADLmI_FrIk7O3BEkxY/
+gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20DataRecord
+live_deploy: ''
+
+parent_type: Dataset
 hierarchy:
 - Thing
 - CreativeWork
 - Dataset
-live_deploy: ''
-name: DataRecord
-parent_type: Dataset
-spec_type: Profile
-status: revision
-subtitle: Bioschemas specification describing a record in a dataset.
-use_cases_url: /useCases/Datasets
-version: '0.1'
 
-bsc: #0B794B;
-pending: #0000CC;
-external: #454547;
+spec_mapping_url: https://docs.google.com/spreadsheets/d/1ZVeMSCNCE9ZwezZa0fCiX02Yyt5jRE4DUVP04UXyhNA/edit#gid=292464567
+spec_info:
+  title: DataRecord
+  subtitle: Bioschemas specification describing a record in a dataset.
+  description: A Record acts itself as a dataset although it refers to what could
+    be seen as the minimum compact, complete and auto-descriptive unit in a dataset,
+    i.e., a record. Bioschemas usage In Life Sciences, records will represent a BioChemEntity.
+  version: "0.1"
+  version_date: 20180425T170205
+  official_type: ""
+  full_example: https://github.com/BioSchemas/specifications/tree/master/DataRecord/examples/
+mapping:
+- property: additionalProperty
+  expected_types:
+  - PropertyValue
+  description: 'A property-value pair representing an additional characteristics of
+    the entitity, e.g. a product feature or another characteristic for which there
+    is no matching property in schema.org. Note: Publishers should be aware that applications
+    designed to use specific schema.org properties (e.g. http://schema.org/width,
+    http://schema.org/color, http://schema.org/gtin13, ...) will typically expect
+    such data to be provided using those properties, rather than using the generic
+    property/value mechanism.'
+  type: ""
+  type_url: ""
+  bsc_description: Additional to the use of [name](http://schema.org/name) and [description](http://schema.org/description)
+    to describe this property in a human-readable way, [additionalType](http://schema.org/additionalType)
+    should be used to specify the nature of the property/relation. For instance, if
+    the property refers to a gene/protein disease association, you could use [SIO:000983
+    (gene-disease association)](http://semanticscience.org/resource/SIO_000983.rdf)
+    as the [additionalType](http://schema.org/additionalType) for the additionalProperty.
+  marginality: Optional
+  cardinality: MANY
+  controlled_vocab: ""
+  example: ""
+- property: additionalType
+  expected_types:
+  - URL
+  description: An additional type for the item, typically used for adding more specific
+    types from external vocabularies in microdata syntax. This is a relationship between
+    something and a class that the thing is in. In RDFa syntax, it is better to use
+    the native RDFa syntax - the 'typeof' attribute - for multiple types. Schema.org
+    tools may have only weaker understanding of extra types, in particular those defined
+    externally.
+  type: ""
+  type_url: ""
+  bsc_description: Although not required, additionalType can be used to specify the
+    nature of the record. For instance, a UniProt protein record would have [UP:Protein](http://www.uniprot.org/core/Protein)
+    as type.
+  marginality: Recommended
+  cardinality: MANY
+  controlled_vocab: ""
+  example: ""
+- property: citation
+  expected_types:
+  - CreativeWork
+  - Text
+  description: A citation or reference to another creative work, such as another publication,
+    web page, scholarly article, etc.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: MANY
+  controlled_vocab: ""
+  example: ""
+- property: dateCreated
+  expected_types:
+  - Date
+  - DateTime
+  description: The date on which the CreativeWork was created or the item was added
+    to a DataFeed.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: ONE
+  controlled_vocab: ""
+  example: ""
+- property: dateModified
+  expected_types:
+  - Date
+  - DateTime
+  description: The date on which the CreativeWork was most recently modified or when
+    the item's entry was modified within a DataFeed.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: ONE
+  controlled_vocab: ""
+  example: ""
+- property: datePublished
+  expected_types:
+  - Date
+  description: Date of first broadcast/publication.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: ONE
+  controlled_vocab: ""
+  example: ""
+- property: distribution
+  expected_types:
+  - DataDownload
+  description: A downloadable form of this dataset, at a specific location, in a specific
+    format.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: MANY
+  controlled_vocab: ""
+  example: ""
+- property: identifier
+  expected_types:
+  - PropertyValue
+  - Text
+  - URL
+  description: The identifier property represents any kind of identifier for any kind
+    of [Thing](http://schema.org/Thing), such as ISBNs, GTIN codes, UUIDs etc. Schema.org
+    provides dedicated properties for representing many of these, either as textual
+    strings or as URL (URI) links. See [background notes](http://schema.org/docs/datamodel.html#identifierBg)
+    for more details.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Minimum
+  cardinality: ONE
+  controlled_vocab: ""
+  example: ""
+- property: image
+  expected_types:
+  - ImageObject
+  - URL
+  description: An image of the item. This can be a [URL](http://schema.org/URL) or
+    a fully described [ImageObject](http://schema.org/ImageObject).
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: MANY
+  controlled_vocab: ""
+  example: ""
+- property: isBasedOn
+  expected_types:
+  - CreativeWork
+  - Product
+  - URL
+  description: A resource that was used in the creation of this resource. This term
+    can be repeated for multiple sources. For example, [http://example.com/great-multiplication-intro.html](http://example.com/great-multiplication-intro.html).
+    Supersedes isBasedOnUrl.
+  type: ""
+  type_url: ""
+  bsc_description: Whenever possible use Evidence Codes (ECO)
+  marginality: Optional
+  cardinality: MANY
+  controlled_vocab: '[ECO](https://www.ebi.ac.uk/ols/ontologies/eco)'
+  example: ""
+- property: isBasisFor
+  expected_types:
+  - CreativeWork
+  - Product
+  - URL
+  description: ""
+  type: bioschemas
+  type_url: http://bioschemas.org/devSpecs/DataRecord/specification/#
+  bsc_description: 'A resource for which this resource is basis for. Inverse property:  [isBasedOn](http://schema.org/isBasedOn).'
+  marginality: Optional
+  cardinality: MANY
+  controlled_vocab: '[ECO](https://www.ebi.ac.uk/ols/ontologies/eco)'
+  example: ""
+- property: keywords
+  expected_types:
+  - Text
+  description: Keywords or tags used to describe this content. Multiple entries in
+    a keywords list are typically delimited by commas.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: ONE
+  controlled_vocab: ""
+  example: ""
+- property: mainEntity
+  expected_types:
+  - Thing
+  description: |-
+    Indicates the primary entity described in some page or other CreativeWork.
+    Inverse property: [mainEntityOfPage](http://schema.org/mainEntityOfPage).
+  type: ""
+  type_url: ""
+  bsc_description: Bioschemas usage. Link to the BioChemEntity represented by this
+    record.
+  marginality: Minimum
+  cardinality: ONE
+  controlled_vocab: ""
+  example: ""
+- property: rdf:type
+  expected_types:
+  - URL
+  description: ""
+  type: external
+  type_url: https://www.w3.org/1999/02/22-rdf-syntax-ns#type
+  bsc_description: This is used by validation tools to indentify the profile used.
+    You must use the value specified in the Controlled Vocabulary column.
+  marginality: Minimum
+  cardinality: ONE
+  controlled_vocab: ""
+  example: ""
+- property: sameAs
+  expected_types:
+  - URL
+  description: URL of a reference Web page that unambiguously indicates the item's
+    identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official
+    website.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: MANY
+  controlled_vocab: ""
+  example: ""
+- property: seeAlso
+  expected_types:
+  - Thing orURL
+  description: ""
+  type: bioschemas
+  type_url: http://bioschemas.org/devSpecs/DataRecord/specification/#
+  bsc_description: A pointer to any (somehow related) Thing. To be used whenever you
+    are not so sure about the nature of the relation. Otherwise, use more precise
+    terms from pre-existing Controlled Vocabularies.
+  marginality: Optional
+  cardinality: MANY
+  controlled_vocab: ""
+  example: ""
+- property: url
+  expected_types:
+  - URL
+  description: URL of the item.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: MANY
+  controlled_vocab: ""
+  example: ""
 
 ---
 

--- a/_devSpecs/Dataset/specification.html
+++ b/_devSpecs/Dataset/specification.html
@@ -1,24 +1,29 @@
 ---
-cross_walk_url: https://docs.google.com/spreadsheets/d/1XzrZxFIuG3TS9RU8vACoUjAvaADLmI_FrIk7O3BEkxY/
-dateModified: 2018-02-25
-description: 'A guide for how to describe datasets in the life-sciences using Schema.org-like annotation.'
-gh_examples: https://github.com/BioSchemas/specifications/tree/master/Dataset/examples/
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Dataset
+name: Dataset
+
+status: revision
+spec_type: Profile
 group: data
+use_cases_url: /useCases/Datasets
+cross_walk_url: https://docs.google.com/spreadsheets/d/1XzrZxFIuG3TS9RU8vACoUjAvaADLmI_FrIk7O3BEkxY/
+gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Dataset
+live_deploy: /liveDeploys/
+
+parent_type: Dataset
 hierarchy:
 - Thing
 - CreativeWork
 - Dataset
-live_deploy: /liveDeploys/
-name: Dataset
-parent_type: Dataset
-spec_type: Profile
-status: revision
-subtitle: Bioschemas specification for describing a dataset in the life-science.
-use_cases_url: /useCases/Datasets
-version: 0.2
 
-
+spec_mapping_url: https://docs.google.com/spreadsheets/d/1QIGPv1ULH9Swvyq7BhopNVkbq7zWW5SUkekFXHDHOj4/edit#gid=1261485211
+spec_info:
+  title: Dataset
+  subtitle: 'Bioschemas specification for describing a dataset in the life-science.'
+  description: 'A guide for how to describe datasets in the life-sciences using Schema.org-like annotation.'
+  version: 0.2
+  version_date: 20180225T144349
+  official_type: ""
+  full_example: "https://github.com/BioSchemas/specifications/tree/master/Dataset/examples/"
 ---
 
 <!DOCTYPE HTML>

--- a/_devSpecs/Event/specification.html
+++ b/_devSpecs/Event/specification.html
@@ -1,22 +1,29 @@
 ---
-cross_walk_url: https://docs.google.com/spreadsheets/d/1Hu1dmrS7jPgHWp8hUQWve9BzaYZi_EzTj9-gDuI9sBM/
-dateModified: 2018-03-10
-description: 'Specification for describing a Life Science event. This includes conferences,
-  workshops, meetings, courses, receptions, networking and prizegivings.        '
+name: Event
+
+status: revision
+spec_type: Profile
 group: events
-gh_examples: https://github.com/BioSchemas/specifications/tree/master/Event/examples/
+use_cases_url: /useCases/Events/
+cross_walk_url: https://docs.google.com/spreadsheets/d/1Hu1dmrS7jPgHWp8hUQWve9BzaYZi_EzTj9-gDuI9sBM/
 gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Event
+live_deploy: ''
+
+parent_type: Event
 hierarchy:
 - Thing
 - Event
-live_deploy: ''
-name: Event
-parent_type: Event
-spec_type: Profile
-status: revision
-subtitle: Specification for describing an event in the Life Sciences
-use_cases_url: /useCases/Events/
-version: '0.1'
+
+spec_mapping_url: https://docs.google.com/spreadsheets/d/1QIGPv1ULH9Swvyq7BhopNVkbq7zWW5SUkekFXHDHOj4/edit#gid=1261485211
+spec_info:
+  title: Event
+  subtitle: 'Specification for describing an event in the Life Sciences.'
+  description: 'Specification for describing a Life Science event. This includes conferences,
+    workshops, meetings, courses, receptions, networking and prizegivings.'
+  version: 0.1
+  version_date: 20180310T144349
+  official_type: ""
+  full_example: "https://github.com/BioSchemas/specifications/tree/master/Event/examples/"
 ---
 
 <!DOCTYPE HTML>

--- a/_devSpecs/Gene/specification.html
+++ b/_devSpecs/Gene/specification.html
@@ -397,8 +397,5 @@ mapping:
          </div>
       </div>
       {% include footer.html %}
-      
-      
-      
    </body>
 </html>

--- a/_devSpecs/Gene/specification.html
+++ b/_devSpecs/Gene/specification.html
@@ -1,32 +1,29 @@
 ---
-cross_walk_url: 
-dateModified: 2018-03-23
-description: This Gene profile specification presents the BioChemEntity usage when
-  describing a Gene.
-g_mapping_file: Genes Mapping Simp
-gh_examples: https://github.com/BioSchemas/bioschemas.github.io/tree/master/_devSpecs/Gene/examples
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Gene
+name: Gene
+url: Gene
+
+status: revision
+spec_type: Profile
 group: genes
+use_cases_url: /useCases/Genes/
+cross_walk_url: 
+gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Gene
+live_deploy: ''
+
+parent_type: Thing
 hierarchy:
 - Thing
 - BioChemEntity
-live_deploy: ''
-name: Gene
-parent_type: Thing
-spec_type: Profile
-status: revision
-subtitle: Bioschemas specification describing a Gene (BioChemEntity profile) in
-  Life Sciences
-url: Beacons
-use_cases_url: /useCases/Genes/
-version: '0.1'
+
+spec_mapping_url: https://docs.google.com/spreadsheets/d/1WGP1VPElboWsKnASQwbp19wcvTg-_piOCoIJ6Xe7rB8/edit#gid=1483018794
 spec_info:
   title: Gene
   subtitle: Bioschemas specification describing a Gene (BioChemEntity profile) in
     Life Sciences
   description: This Gene profile specification presents the BioChemEntity usage when
     describing a Gene.
-  version: "0.1"
+  version: 0.2-draft
+  version_date: 20180323T100649
   official_type: http://purl.obolibrary.org/obo/SO_0000704
   full_example: https://github.com/BioSchemas/bioschemas.github.io/tree/master/_devSpecs/Gene/examples
 mapping:

--- a/_devSpecs/LabProtocol/specification.html
+++ b/_devSpecs/LabProtocol/specification.html
@@ -1,25 +1,31 @@
 ---
-cross_walk_url: https://docs.google.com/spreadsheets/d/1RWYIphvcBMHl8SLJl5-xRMZI0YaYrtJtClBSoOPL4xQ
-dateModified: 2018-03-09
-description: 'An experimental protocol is a sequence of tasks and operations executed to perform experimental research in biological and biomedical areas.
-Experimental protocols are fundamental information structures that support the description of the processes by means of which results are generated in experimental research [1]. Experimental protocols describe how the data were produced, the steps undertaken and conditions under which these steps were carried out.
-<br />
-[1]  Giraldo, O., García, A., López, F., & Corcho, O. (2017). Using semantics for representing experimental protocols. Journal of Biomedical Semantics, 8, 52. <a href="http://doi.org/10.1186/s13326-017-0160-y">http://doi.org/10.1186/s13326-017-0160-y</a>'
-gh_examples: https://github.com/BioSchemas/specifications/tree/master/LabProtocol/examples/
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20LabProtocol
+name: LabProtocol
+
+status: revision
+spec_type: Profile
 group: labprotocols
+use_cases_url: /useCases/LabProtocols/
+cross_walk_url: https://docs.google.com/spreadsheets/d/1RWYIphvcBMHl8SLJl5-xRMZI0YaYrtJtClBSoOPL4xQ
+gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20LabProtocol
+live_deploy: ''
+
+parent_type: CreativeWork
 hierarchy:
 - Thing
 - CreativeWork
-live_deploy: ''
-name: LabProtocol
-parent_type: CreativeWork
-spec_type: Profile
-status: revision
-subtitle: Bioschemas specification describing LabProtocol in the life-science.
-use_cases_url: /useCases/LabProtocols/
-version: '0.2'
 
+spec_mapping_url: https://docs.google.com/spreadsheets/d/11TB7hdjkxBqVJd-PGKDY5-6_RoWIIcMq49LF0vkg8CM/edit#gid=1261485211
+spec_info:
+  title: LabProtocol
+  subtitle: 'Bioschemas specification for describing a dataset in the life-science.'
+  description: 'An experimental protocol is a sequence of tasks and operations executed to perform experimental research in biological and biomedical areas.
+    Experimental protocols are fundamental information structures that support the description of the processes by means of which results are generated in experimental research [1]. Experimental protocols describe how the data were produced, the steps undertaken and conditions under which these steps were carried out.
+    <br />
+    [1]  Giraldo, O., García, A., López, F., & Corcho, O. (2017). Using semantics for representing experimental protocols. Journal of Biomedical Semantics, 8, 52. <a href="http://doi.org/10.1186/s13326-017-0160-y">http://doi.org/10.1186/s13326-017-0160-y</a>'
+  version: 0.2
+  version_date: 20180309T144349
+  official_type: ""
+  full_example: "https://github.com/BioSchemas/specifications/tree/master/LabProtocol/examples/"
 ---
 
 <!DOCTYPE HTML>

--- a/_devSpecs/Organization/specification.html
+++ b/_devSpecs/Organization/specification.html
@@ -1,30 +1,33 @@
 ---
-cross_walk_url: ''
-dateModified: 2018-03-13
-description: 'Provides a way to describe bioscience organizations on the World Wide
-  Web. It defines metadata terms that can be used in the code of web pages and applications,
-  and builds on top of existing technologies and standards. The goal of the specification
-  is to make it easier to discover, exchange and integrate life science organization
-  profiles across the Internet.'
-edit_url: https://github.com/BioSchemas/specifications/tree/master/Organization/specification.html
-gh_examples: https://gist.github.com/kcmcleod/1d09603a6dd2c409678a4376dbc4da3c
-gh_folder: https://github.com/BioSchemas/specifications/tree/master/Organization
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Organization
+name: Organization
+
+status: revision
+spec_type: Profile
 group: organizations
+use_cases_url: /useCases/Organizations/
+cross_walk_url: ''
+gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Organization
+live_deploy: ''
+
+parent_type: Organization
 hierarchy:
 - Thing
 - Organization
-live_deploy: ''
-name: Organization
-parent_type: Organization
-spec_mapping_url: https://docs.google.com/spreadsheets/d/14UoeVmh2eRRWlyQgOJWAuCIW7DMuwhLH6O3CBeXfoTI/edit?usp=drivesdk
-spec_type: Profile
-status: revision
-subtitle: ''
-use_cases_url: /useCases/Organizations/
-version: '0.1'
----
 
+spec_mapping_url: https://docs.google.com/spreadsheets/d/14UoeVmh2eRRWlyQgOJWAuCIW7DMuwhLH6O3CBeXfoTI/edit#gid=1261485211
+spec_info:
+  title: Organization
+  subtitle: 'Bioschemas specification for describing a dataset in the life-science.'
+  description: 'Provides a way to describe bioscience organizations on the World Wide
+    Web. It defines metadata terms that can be used in the code of web pages and applications,
+    and builds on top of existing technologies and standards. The goal of the specification
+    is to make it easier to discover, exchange and integrate life science organization
+    profiles across the Internet.'
+  version: 0.1
+  version_date: 20180313T144349
+  official_type: ""
+  full_example: "https://gist.github.com/kcmcleod/1d09603a6dd2c409678a4376dbc4da3c"
+---
 
 <!DOCTYPE HTML>
 <html>

--- a/_devSpecs/Person/specification.html
+++ b/_devSpecs/Person/specification.html
@@ -1,29 +1,32 @@
 ---
-cross_walk_url: https://docs.google.com/spreadsheets/d/1_Hc_RD0GvdxuuO921ZGoQGZEFkcEjcS5J6dQVD2cwiQ
-dateModified: 2018-03-14
-description: The Life Science Person specification provides a way to describe bioscience
-  people on the World Wide Web. It defines a set of metadata and vocabularies, built
-  on top of existing technologies and standards, that can be used to represent the
-  profile information of people in Web pages and applications. The goal of the specification
-  is to make it easier to discover, life science profile information.
-edit_url: https://github.com/BioSchemas/specifications/tree/master/Person/specification.html
-g_mapping_file: Person Mapping Simp
-gh_examples: https://gist.github.com/kcmcleod/26b4392ec1ff48aabaf61f98586d177e
-gh_folder: https://github.com/BioSchemas/specifications/tree/master/Person
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20person
+name: Person
+
+status: revision
+spec_type: Profile
 group: people
+use_cases_url: /useCases/Persons/
+cross_walk_url: https://docs.google.com/spreadsheets/d/1_Hc_RD0GvdxuuO921ZGoQGZEFkcEjcS5J6dQVD2cwiQ
+gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20person
+live_deploy: ''
+
+parent_type: Person
 hierarchy:
 - Thing
 - Person
-live_deploy: ''
-name: Person
-parent_type: Person
-spec_mapping_url: https://docs.google.com/spreadsheets/d/17scwe6fx9-WHBDqxTdD20F0Ji8kX9S7TMN6tNuw-0jY/edit?usp=drivesdk
-spec_type: Profile
-status: revision
-subtitle: A specification for describing people in life sciences
-use_cases_url: /useCases/Persons/
-version: '0.1'
+
+spec_mapping_url: https://docs.google.com/spreadsheets/d/17scwe6fx9-WHBDqxTdD20F0Ji8kX9S7TMN6tNuw-0jY/edit#gid=1261485211
+spec_info:
+  title: Person
+  subtitle: 'A specification for describing people in life sciences.'
+  description: 'The Life Science Person specification provides a way to describe bioscience
+    people on the World Wide Web. It defines a set of metadata and vocabularies, built
+    on top of existing technologies and standards, that can be used to represent the
+    profile information of people in Web pages and applications. The goal of the specification
+    is to make it easier to discover, life science profile information.'
+  version: 0.1
+  version_date: 20180314T144349
+  official_type: ""
+  full_example: "https://gist.github.com/kcmcleod/26b4392ec1ff48aabaf61f98586d177e"
 ---
 
 

--- a/_devSpecs/Protein/specification.html
+++ b/_devSpecs/Protein/specification.html
@@ -1,21 +1,18 @@
 ---
-cross_walk_url: https://docs.google.com/spreadsheets/d/1QQH4AkzdwPT1Qt5OLmH5HosLpkFU7khwE4Ql9_Cb9ZQ
-dateModified: 2018-03-01
-description: This Protein profile specification presents the BioChemEntity usage when describing a Protein.
-gh_examples: https://github.com/BioSchemas/specifications/tree/master/Protein/examples/
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Protein
+name: Protein
+
+status: revision
+spec_type: Profile
 group: proteins
+use_cases_url: /useCases/Proteins/
+cross_walk_url: https://docs.google.com/spreadsheets/d/1QQH4AkzdwPT1Qt5OLmH5HosLpkFU7khwE4Ql9_Cb9ZQ
+gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Protein
+live_deploy: ''
+
+parent_type: BioChemEntity
 hierarchy:
 - Thing
 - BioChemEntity
-live_deploy: ''
-name: Protein
-parent_type: BioChemEntity
-spec_type: Profile
-status: revision
-subtitle: Bioschemas specification describing a Protein (BioChemEntity profile) in Life Sciences
-use_cases_url: /useCases/Proteins/
-version: '0.5'
 
 spec_info:
   title: Protein
@@ -23,9 +20,10 @@ spec_info:
     in Life Sciences.
   description: This Protein profile specification presents the BioChemEntity usage
     when describing a Protein.
+  version_date: 20180405T144349
   version: "0.5"
   official_type: http://purl.obolibrary.org/obo/PR_000000001
-  full_example: https://github.com/BioSchemas/bioschemas.github.io/tree/master/_devSpecs/Protein/examples
+  full_example: https://github.com/BioSchemas/specifications/tree/master/Protein/examples/
 mapping:
 - property: additionalProperty
   expected_types:

--- a/_devSpecs/ProteinAnnotation/specification.html
+++ b/_devSpecs/ProteinAnnotation/specification.html
@@ -1,21 +1,27 @@
 ---
-cross_walk_url: https://docs.google.com/spreadsheets/d/1KNVv3xedOpckk3ZcILnPmlys2DTzpk8KnkRwVFR2SL0
-dateModified: 2018-02-25
-description: This profile specification presents the BioChemEntity usage when describing a Protein annotation.
-gh_examples: https://gist.github.com/kcmcleod/474f3a25d5b4b3a902552a88301d747b
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20ProteinAnnotation
+name: ProteinAnnotation
+
+status: revision
+spec_type: Profile
 group: proteins
+cross_walk_url: https://docs.google.com/spreadsheets/d/1KNVv3xedOpckk3ZcILnPmlys2DTzpk8KnkRwVFR2SL0
+gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20ProteinAnnotation
+live_deploy: ''
+
+parent_type: BioChemEntity
 hierarchy:
 - Thing
 - BioChemEntity
-live_deploy: ''
-name: ProteinAnnotation
-parent_type: BioChemEntity
-spec_type: Profile
-status: revision
-subtitle: Bioschemas specification describing a Protein annotation (BioChemEntity profile) in Life Sciences
-use_cases_url: /useCases/Proteins/
-version: '0.4'
+
+spec_mapping_url: https://docs.google.com/spreadsheets/d/1I0_i-j3MHedhLD53RIugEOSJtfF9CIN4Nm1eqsaHmxg/edit#gid=1261485211
+spec_info:
+  title: ProteinAnnotation
+  subtitle: 'Bioschemas specification describing a Protein annotation (BioChemEntity profile) in Life Sciences.'
+  description: 'This profile specification presents the BioChemEntity usage when describing a Protein annotation.'
+  version: 0.4
+  version_date: 20180225T144349
+  official_type: ""
+  full_example: "https://gist.github.com/kcmcleod/474f3a25d5b4b3a902552a88301d747b"
 ---
 
 

--- a/_devSpecs/ProteinStructure/specification.html
+++ b/_devSpecs/ProteinStructure/specification.html
@@ -1,21 +1,28 @@
 ---
-cross_walk_url: https://docs.google.com/spreadsheets/d/1VaqJUGPUtGvUZgzXskI2VQTfhX23uQJ83GOybjIg6xw
-dateModified: 2018-02-25
-description: This profile specification presents the BioChemEntity usage when describing a Protein structure.
-gh_examples: https://gist.github.com/kcmcleod/8b14caeeb7fa0cae2242af18c97c6690
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20ProteinStructure
+name: ProteinStructure
+
+status: revision
+spec_type: Profile
 group: proteins
+use_cases_url: /useCases/Proteins/
+cross_walk_url: https://docs.google.com/spreadsheets/d/1VaqJUGPUtGvUZgzXskI2VQTfhX23uQJ83GOybjIg6xw
+gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20ProteinStructure
+live_deploy: ''
+
+parent_type: BioChemEntity
 hierarchy:
 - Thing
 - BioChemEntity
-live_deploy: ''
-name: ProteinStructure
-parent_type: BioChemEntity
-spec_type: Profile
-status: revision
-subtitle: Bioschemas specification describing a Protein structure (BioChemEntity profile) in Life Sciences
-use_cases_url: /useCases/Proteins/
-version: '0.4'
+
+spec_mapping_url: https://docs.google.com/spreadsheets/d/1_DP1w1kbgoFUzShVI3_v9USC96EVw5u_bk5lXLYj64U/edit#gid=1261485211
+spec_info:
+  title: ProteinStructure
+  subtitle: 'Bioschemas specification describing a Protein structure (BioChemEntity profile) in Life Sciences.'
+  description: 'This profile specification presents the BioChemEntity usage when describing a Protein structure.'
+  version: 0.4
+  version_date: 20180225T144349
+  official_type: ""
+  full_example: "https://gist.github.com/kcmcleod/8b14caeeb7fa0cae2242af18c97c6690"
 ---
 
 

--- a/_devSpecs/Sample/specification.html
+++ b/_devSpecs/Sample/specification.html
@@ -1,25 +1,31 @@
 ---
-cross_walk_url: https://docs.google.com/spreadsheets/d/1NltFMzjqezpKhobmqEBEvASLziZjq73a_AqWnNi3IOs/
-dateModified: 2018-02-25
-description: "To deliver on the identified use cases for samples, we have identified a minimal set of properties to encapsulate identification, linking, and metadata descriptions.
-Some of these properties are existing standard schema.org properties, others require Bioschemas extensions.  Table 1 outlines the minimal set of properties for the ‘Sample’ concept and
-Table 2 shows our recommendations for use of the ‘PropertyValue’ concept to markup additional characteristics of a sample described within a sample page. We also propose a new concept, ‘Biomedical Code’,
-which is a generalisation of the existing ‘Medical Code’ concept defined in the health-lifesci.schema.org extension."
-gh_examples: https://gist.github.com/kcmcleod/bf09c3ce3d6916dea793d6c4e7a1087c
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Sample
+name: Sample
+
+status: revision
+spec_type: Profile
 group: samples
+use_cases_url: /useCases/Samples/
+cross_walk_url: https://docs.google.com/spreadsheets/d/1NltFMzjqezpKhobmqEBEvASLziZjq73a_AqWnNi3IOs/
+gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Sample
+live_deploy: /liveDeploys/
+
+parent_type: BioChemEntity
 hierarchy:
 - Thing
 - BioChemEntity
-live_deploy: /liveDeploys/
-name: Sample
-parent_type: BioChemEntity
-spec_type: Profile
-status: revision
-subtitle: Bioschemas specification for describing Samples in the life-science
-use_cases_url: /useCases/Samples/
-version: 0.1
 
+spec_mapping_url: https://docs.google.com/spreadsheets/d/18SOwk3gDGDOgC0Aym8X-0seCZIopv4pUMNKpzCheiJE/edit#gid=1261485211
+spec_info:
+  title: Sample
+  subtitle: 'Bioschemas specification for describing Samples in the life-science.'
+  description: 'To deliver on the identified use cases for samples, we have identified a minimal set of properties to encapsulate identification, linking, and metadata descriptions.
+    Some of these properties are existing standard schema.org properties, others require Bioschemas extensions.  Table 1 outlines the minimal set of properties for the ‘Sample’ concept and
+    Table 2 shows our recommendations for use of the ‘PropertyValue’ concept to markup additional characteristics of a sample described within a sample page. We also propose a new concept, ‘Biomedical Code’,
+    which is a generalisation of the existing ‘Medical Code’ concept defined in the health-lifesci.schema.org extension.'
+  version: 0.1
+  version_date: 20180225T144349
+  official_type: ""
+  full_example: "https://gist.github.com/kcmcleod/bf09c3ce3d6916dea793d6c4e7a1087c"
 ---
 
 

--- a/_devSpecs/Standard/specification.html
+++ b/_devSpecs/Standard/specification.html
@@ -1,15 +1,41 @@
 ---
-cross_walk_url: ''
+name: Standard
+
+status: revision
+spec_type: Profile
 group: standards
-description: ""
-gh_examples: ''
+use_cases_url: ''
+cross_walk_url: ''
 gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Protein
 live_deploy: ''
-layout: new_spec_detail
-name: Standard
-spec_type: Profile
-status: revision
-subtitle: Bioschemas specification for describing Standards in the life-science
-use_cases_url: ''
-version: 0.1-draft.1
+
+
+spec_mapping_url: https://docs.google.com/spreadsheets/d/1PxT-H3l_HmpjvbPZgk0jKWKikMgWMSL17KLDcBULbxA/edit#gid=1261485211
+spec_info:
+  title: Standard
+  subtitle: 'Bioschemas specification for describing Standards in the life-science.'
+  description: ''
+  version: 0.1-draft
+  version_date: 20180101T000000
+  official_type: ""
+  full_example: ""
 ---
+<!DOCTYPE HTML>
+<html>
+   {% include head.html %}
+   <body>
+      {% include header.html %}
+      {% include navbar.html %}
+      <div class="page-content">
+         <div class="wrapper">
+            <div id="main-content-wrapper" class="outer">
+               <section id="main_content" class="inner">
+                  {% include profile_start.html %}
+                  {% include specification_table.html %}
+               </section>
+            </div>
+         </div>
+      </div>
+      {% include footer.html %}
+   </body>
+</html>

--- a/_devSpecs/Tool/specification.html
+++ b/_devSpecs/Tool/specification.html
@@ -1,22 +1,31 @@
 ---
-cross_walk_url: https://docs.google.com/spreadsheets/d/1s342mMwfXAGl5uwgTCcwsVLQztxRIDwTi92zEouP33o/edit#gid=1063339077
-dateModified: 2018-03-07
-description: 'The Life Science Tools specification provides a way to describe bioscience tools and software on the World Wide Web. It defines a set of metadata and vocabularies, built on top of existing technologies and standards, that can be used to represent such tools in Web pages and applications. The goal of the specification is to make it easier to discover, exchange and integrate information about life science tools across the Internet.'
+name: Tool
+
+status: revision
+spec_type: Profile
 group: tools
-gh_examples: https://github.com/BioSchemas/specifications/tree/master/Tool/examples/
+use_cases_url: ''
+cross_walk_url: https://docs.google.com/spreadsheets/d/1s342mMwfXAGl5uwgTCcwsVLQztxRIDwTi92zEouP33o/edit#gid=1063339077
 gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Tool
+live_deploy: ''
+
+parent_type: SoftwareApplication
 hierarchy:
 - Thing
 - CreativeWork
 - SoftwareApplication
-live_deploy: ''
-name: Tool
-parent_type: SoftwareApplication
-spec_type: Profile
-status: revision
-subtitle: Bioschemas specification for describing a SoftwareApplication in the life-science.
-use_cases_url: ''
-version: '0.1'
+
+spec_mapping_url: https://docs.google.com/spreadsheets/d/1s342mMwfXAGl5uwgTCcwsVLQztxRIDwTi92zEouP33o/edit#gid=1063339077
+spec_info:
+  title: Tool
+  subtitle: 'Bioschemas specification for describing a SoftwareApplication in the life-science.'
+  description: 'The Life Science Tools specification provides a way to describe bioscience tools and software on the World Wide Web.
+    It defines a set of metadata and vocabularies, built on top of existing technologies and standards, that can be used to represent such tools in Web pages and applications.
+    The goal of the specification is to make it easier to discover, exchange and integrate information about life science tools across the Internet.'
+  version: 0.1
+  version_date: 20180307T144349
+  official_type: ""
+  full_example: "https://github.com/BioSchemas/specifications/tree/master/Tool/examples/"
 ---
 
 

--- a/_devSpecs/TrainingMaterial/specification.html
+++ b/_devSpecs/TrainingMaterial/specification.html
@@ -1,30 +1,34 @@
 ---
-cross_walk_url: https://docs.google.com/spreadsheets/d/1cQ6mDbsG_cMX2EDAN8xH6-9yMRba8-rErlPeP8HTs8A
-dateModified: 2018-03-07
-description: The Life Science Training Materials specification provides a way to describe
-  bioscience training material on the World Wide Web. It defines a set of metadata
-  and vocabularies, built on top of existing technologies and standards, that can
-  be used to represent events in Web pages and applications. The goal of the specification
-  is to make it easier to discover, exchange and integrate life science training material
-  information across the Internet.
-gh_examples: https://github.com/BioSchemas/specifications/tree/master/TrainingMaterial/examples/
-gh_folder: https://github.com/BioSchemas/specifications/tree/master/TrainingMaterial
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Training%20material
+name: TrainingMaterial
+
+status: revision
+spec_type: Profile
 group: trainingmaterials
+use_cases_url: /useCases/TrainingMaterials/
+cross_walk_url: https://docs.google.com/spreadsheets/d/1cQ6mDbsG_cMX2EDAN8xH6-9yMRba8-rErlPeP8HTs8A
+gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Training%20material
+live_deploy: ''
+
+parent_type: CreativeWork
 hierarchy:
 - Thing
 - CreativeWork
-live_deploy: ''
-name: TrainingMaterial
-parent_type: CreativeWork
-spec_type: Profile
-status: revision
-subtitle: A specification for describing training materials in life sciences
-use_cases_url: /useCases/TrainingMaterials/
-version: '0.2'
+
+spec_mapping_url: https://docs.google.com/spreadsheets/d/17scwe6fx9-WHBDqxTdD20F0Ji8kX9S7TMN6tNuw-0jY/edit#gid=1261485211
+spec_info:
+  title: TrainingMaterial
+  subtitle: 'A specification for describing training materials in life sciences.'
+  description: 'The Life Science Training Materials specification provides a way to describe
+    bioscience training material on the World Wide Web. It defines a set of metadata
+    and vocabularies, built on top of existing technologies and standards, that can
+    be used to represent events in Web pages and applications. The goal of the specification
+    is to make it easier to discover, exchange and integrate life science training material
+    information across the Internet.'
+  version: 0.2
+  version_date: 20180307T144349
+  official_type: ""
+  full_example: "https://github.com/BioSchemas/specifications/tree/master/TrainingMaterial/examples/"
 ---
-
-
 
 <!DOCTYPE HTML>
 <html>

--- a/_includes/profile_start.html
+++ b/_includes/profile_start.html
@@ -57,7 +57,16 @@
 <section id="description" class="tabs">
    <!-- Bioschemas <a href="/specifications/">specifications and types list.</a> -->
    <h3>Description</h3>
+   <!-- 
+       ToDo: Remove this validation after all the specs
+            are updated to the new specification_table template.
+    -->
+   {% assign description_prev = page.description %}
+   {% if description_prev != null%}
+   <p>{{page.description}}</p>
+   {% else %}
    <p>{{page.spec_info.description}}</p>
+   {% endif %}
    <br />
    <h3>Schema.org hierarchy</h3>
    This is a new {{page.spec_type}} that fits into the schema.org hierarchy as follows:
@@ -114,7 +123,7 @@
                <img src="/images/cross_walk.png" alt="View BioSchemas {{ page.name }} Cross Walk"  style="filter: grayscale(100%);">
                </a>
                {%else%}
-               <a href="{{page.cross_walk_url}}">
+               <a href="{{page.cross_walk_url}}" target="_blank">
                <img src="/images/cross_walk.png" alt="View BioSchemas {{ page.name }} Cross Walk">
                </a>
                {%endif%}
@@ -125,18 +134,18 @@
                <img src="/images/specs_tasks.png" alt="BioSchemas {{ page.name }} Github Tasks or Issues" style="filter: grayscale(100%);">
                </a>
                {% else %}
-               <a href="{{page.gh_tasks}}">
+               <a href="{{page.gh_tasks}}" target="_blank">
                <img src="/images/specs_tasks.png" alt="BioSchemas {{ page.name }} Github Tasks or Issues">
                </a>
                {% endif %}
             </td>
-            <td class="spec_links">
+            <td class="spec_links" target="_blank">
                {% if page.spec_info.full_example == '' %}
                <a>
                <img src="/images/spec_examples.png" alt="View BioSchemas {{ page.name }} Examples" style="filter: grayscale(100%);">
                </a>
                {% else %}
-               <a href="{{page.spec_info.full_example}}">
+               <a href="{{page.spec_info.full_example}}" target="_blank">
                <img src="/images/spec_examples.png" alt="View BioSchemas {{ page.name }} Examples">
                </a>
                {% endif %}

--- a/_includes/profile_start.html
+++ b/_includes/profile_start.html
@@ -1,9 +1,9 @@
 {% if page.status == 'release' %}
-<h1>{{page.name}} Specification v. {{page.version}}</h1>
+<h1>{{page.spec_info.title}} Specification v. {{page.spec_info.version}}</h1>
 {% else %}
-<h1>{{page.name}} <u>DRAFT</u> Specification v. {{page.version}}</h1>
+<h1>{{page.spec_info.title}} <u>DRAFT</u> Specification v. {{page.spec_info.version}}</h1>
 {% endif %}
-<h2>{{page.subtitle}}</h2>
+<h2>{{page.spec_info.subtitle}}</h2>
 <br />
 <input id="tab1" type="radio" name="tabs" checked>
 <label for="tab1">Description</label>
@@ -57,7 +57,7 @@
 <section id="description" class="tabs">
    <!-- Bioschemas <a href="/specifications/">specifications and types list.</a> -->
    <h3>Description</h3>
-   <p>{{page.description}}</p>
+   <p>{{page.spec_info.description}}</p>
    <br />
    <h3>Schema.org hierarchy</h3>
    This is a new {{page.spec_type}} that fits into the schema.org hierarchy as follows:
@@ -131,12 +131,12 @@
                {% endif %}
             </td>
             <td class="spec_links">
-               {% if page.gh_examples == '' %}
+               {% if page.spec_info.full_example == '' %}
                <a>
                <img src="/images/spec_examples.png" alt="View BioSchemas {{ page.name }} Examples" style="filter: grayscale(100%);">
                </a>
                {% else %}
-               <a href="{{page.gh_examples}}">
+               <a href="{{page.spec_info.full_example}}">
                <img src="/images/spec_examples.png" alt="View BioSchemas {{ page.name }} Examples">
                </a>
                {% endif %}

--- a/_includes/specification_table.html
+++ b/_includes/specification_table.html
@@ -1,4 +1,5 @@
 <div class="spec-table-wrapper">
+    {% if page.mapping != null %}  
     <div class="example-button">
         <span class="tooltiptext">View all examples</span>
         <button type="button" class="btn btn-bioschema" data-toggle="modal" data-target="#all-examples-modal">Examples  <i class="fas fa-file-code"></i></button>
@@ -27,7 +28,7 @@
             </div>
             </div>
         </div>
-    </div>            
+    </div>         
     <table class="spec-prof-table">
         <thead>
             <tr>
@@ -39,14 +40,11 @@
                 <th class="example-column">Example</th>
             </tr>
         </thead>
-        <tbody>    
+        <tbody>
             {% assign  marginality_list = "Minimum,Recommended,Optional" | split: ',' %}
             {% for current_mg in marginality_list %}
-            {% if page.mapping != null %}
-            {% assign props_list = page.mapping | where: 'marginality', current_mg | sort: 'name' %}
-            {% else %}
-            {% assign props_list = page.mapping | where: 'marginality', current_mg  %}
-            {% endif %}
+            {% assign props_list = page.mapping | where: 'marginality', current_mg | sort: 'property' %}
+
             {%if props_list.size > 0%}
             <tr class="cardinality">
                 <td colspan="6">
@@ -54,6 +52,7 @@
                 </td>
             </tr>
             {%endif%}
+
             {% for prop in props_list %}
             <tr>
                 {% if prop.type == "bioschemas" %}
@@ -69,9 +68,9 @@
                     {% for temp_exp_type in prop.expected_types %}
                     {% assign expected_type_type = temp_exp_type | split: ':' %}
                     {% if temp_exp_type == "LabProtocol" or temp_exp_type == "DataRecord" or temp_exp_type == "BioChemEntity" %}
-                    <a href="http://bioschemas.org/types/{{temp_exp_type}}/specification/" target="_blank">{{temp_exp_type}}</a><br>
+                    <a href="http://bioschemas.org/types/{{temp_exp_type}}/specification/" class="bioschema" target="_blank">{{temp_exp_type}}</a><br>
                     {% elsif expected_type_type[0] == "bioschemas" %}
-                    <a href="http://bioschemas.org/specifications/{{expected_type_type[1]}}/specification/" target="_blank">{{expected_type_type[1]}}</a><br>
+                    <a href="http://bioschemas.org/specifications/{{expected_type_type[1]}}/specification/" class="bioschema" target="_blank">{{expected_type_type[1]}}</a><br>
                     {% else %}
                     <a href="http://schema.org/{{temp_exp_type}}" target="_blank">{{temp_exp_type}}</a><br>
                     {% endif %}
@@ -119,8 +118,11 @@
                     {% endunless %}                 
                 </td>
             </tr>
-            {% endfor %}
-            {% endfor %}
+            {% endfor %}        
+            {% endfor %}          
         </tbody>
     </table>
+    {% else %}
+    <span class="alert alert-warning" role="alert">Mapping in progress.</span>
+    {% endif %}      
  </div>

--- a/_includes/specification_table.html
+++ b/_includes/specification_table.html
@@ -67,8 +67,11 @@
                 {% endif %}
                 <td>
                     {% for temp_exp_type in prop.expected_types %}
+                    {% assign expected_type_type = temp_exp_type | split: ':' %}
                     {% if temp_exp_type == "LabProtocol" or temp_exp_type == "DataRecord" or temp_exp_type == "BioChemEntity" %}
                     <a href="http://bioschemas.org/types/{{temp_exp_type}}/specification/" target="_blank">{{temp_exp_type}}</a><br>
+                    {% elsif expected_type_type[0] == "bioschemas" %}
+                    <a href="http://bioschemas.org/specifications/{{expected_type_type[1]}}/specification/" target="_blank">{{expected_type_type[1]}}</a><br>
                     {% else %}
                     <a href="http://schema.org/{{temp_exp_type}}" target="_blank">{{temp_exp_type}}</a><br>
                     {% endif %}

--- a/_sass/_spec-tables.scss
+++ b/_sass/_spec-tables.scss
@@ -175,25 +175,5 @@ $external-property-color: #454547;
             border-color: black transparent transparent transparent;
         }
 
-        // button {
-        //     height: 25px;
-        //     width: 25px;
-        //     text-align: center;
-        //     text-decoration: none;
-        //     border-radius: 50%;
-        //     border-style: none;
-        //     cursor: pointer;
-        //     padding-left: 1px;
-
-        //     color: #ffffff;
-        //     background-color: #0B794B;
-            
-        //     &:hover,
-        //     &:focus,
-        //     &:active {
-        //         color: $bioschemas-base-color;
-        //         background-color: $bioschemas-tea-green-color;     
-        //     }
-        // }
     }    
 }

--- a/_sass/_spec-tables.scss
+++ b/_sass/_spec-tables.scss
@@ -76,7 +76,7 @@ $external-property-color: #454547;
     }    
     .description-column {
         word-wrap: break-word;
-        max-width: 50em;
+        max-width: 35em;
     }
     .control-vocabulary-column {
         max-width: 10em;

--- a/_sass/_spec-tables.scss
+++ b/_sass/_spec-tables.scss
@@ -43,7 +43,7 @@ $external-property-color: #454547;
         vertical-align: top;
         font-size: 100%;
         display: table-cell;
-        max-width: 30em;
+        // max-width: 30em;
         word-break: keep-all;
     }
     a {
@@ -76,6 +76,7 @@ $external-property-color: #454547;
     }    
     .description-column {
         word-wrap: break-word;
+        max-width: 50em;
     }
     .control-vocabulary-column {
         max-width: 10em;
@@ -88,7 +89,7 @@ $external-property-color: #454547;
 }
 
 .spec-table-wrapper {
-    overflow-x: none;
+    overflow-x: auto;
 
     .example-code {
         text-align: initial;

--- a/specifications/drafts.html
+++ b/specifications/drafts.html
@@ -50,7 +50,7 @@ title: Draft BioSchemas Specifications
                   <img src="/images/cross_walk.png" alt="View BioSchemas {{ spec.spec_info.title }} Cross Walk"  style="filter: grayscale(100%);">
                   </a>
                   {%else%}
-                  <a href="{{spec.cross_walk_url}}">
+                  <a href="{{spec.cross_walk_url}}" target="_blank">
                   <img src="/images/cross_walk.png" alt="View BioSchemas {{ spec.spec_info.title }} Cross Walk">
                   </a>
                   {%endif%}
@@ -61,7 +61,7 @@ title: Draft BioSchemas Specifications
                   <img src="/images/specs_tasks.png" alt="BioSchemas {{ spec.spec_info.title }} Github Tasks or Issues" style="filter: grayscale(100%);">
                   </a>
                   {% else %}
-                  <a href="{{spec.gh_tasks}}">
+                  <a href="{{spec.gh_tasks}}" target="_blank">
                   <img src="/images/specs_tasks.png" alt="BioSchemas {{ spec.spec_info.title }} Github Tasks or Issues">
                   </a>
                   {% endif %}
@@ -72,7 +72,7 @@ title: Draft BioSchemas Specifications
                   <img src="/images/spec_examples.png" alt="View BioSchemas {{ spec.spec_info.title }} Examples" style="filter: grayscale(100%);">
                   </a>
                   {% else %}
-                  <a href="{{spec.spec_info.full_example}}">
+                  <a href="{{spec.spec_info.full_example}}" target="_blank">
                   <img src="/images/spec_examples.png" alt="View BioSchemas {{ spec.spec_info.title }} Examples">
                   </a>
                   {% endif %}

--- a/specifications/drafts.html
+++ b/specifications/drafts.html
@@ -26,7 +26,7 @@ title: Draft BioSchemas Specifications
             {% for spec in prof_specs %}
             <tr>
                 {% assign date_time = spec.spec_info.version_date %}
-               <th><a href="/devSpecs/{{spec.name}}/specification" title="{{spec.subtitle}}">{{ spec.name }}</a><br />(v{{spec.spec_info.version}})<br />{{date_time | date_to_long_string }}</th>
+               <th><a href="/devSpecs/{{spec.name}}/specification" title="{{ spec.spec_info.subtitle }}">{{ spec.spec_info.title }}</a><br />(v{{spec.spec_info.version}})<br />{{ date_time | date_to_long_string }}</th>
                <td>
                   {% assign group = site.groups | where:"identifier", spec.group %}
                   {% for g in group %}
@@ -36,55 +36,55 @@ title: Draft BioSchemas Specifications
                <td class="spec_links">
                   {% if spec.use_cases_url == '' %}
                   <a>
-                  <img src="/images/use_case_spec.png" alt="View BioSchemas {{ spec.name }} Use Cases"  style="filter: grayscale(100%);">
+                  <img src="/images/use_case_spec.png" alt="View BioSchemas {{ spec.spec_info.title }} Use Cases"  style="filter: grayscale(100%);">
                   </a>
                   {%else%}
                   <a href="{{spec.use_cases_url}}">
-                  <img src="/images/use_case_spec.png" alt="View BioSchemas {{ spec.name }} Use Cases">
+                  <img src="/images/use_case_spec.png" alt="View BioSchemas {{ spec.spec_info.title }} Use Cases">
                   </a>
                   {%endif%}
                </td>
                <td class="spec_links">
                   {% if spec.cross_walk_url == '' %}
                   <a>
-                  <img src="/images/cross_walk.png" alt="View BioSchemas {{ spec.name }} Cross Walk"  style="filter: grayscale(100%);">
+                  <img src="/images/cross_walk.png" alt="View BioSchemas {{ spec.spec_info.title }} Cross Walk"  style="filter: grayscale(100%);">
                   </a>
                   {%else%}
                   <a href="{{spec.cross_walk_url}}">
-                  <img src="/images/cross_walk.png" alt="View BioSchemas {{ spec.name }} Cross Walk">
+                  <img src="/images/cross_walk.png" alt="View BioSchemas {{ spec.spec_info.title }} Cross Walk">
                   </a>
                   {%endif%}
                </td>
                <td class="spec_links">
                   {% if spec.gh_tasks == '' %}
                   <a>
-                  <img src="/images/specs_tasks.png" alt="BioSchemas {{ spec.name }} Github Tasks or Issues" style="filter: grayscale(100%);">
+                  <img src="/images/specs_tasks.png" alt="BioSchemas {{ spec.spec_info.title }} Github Tasks or Issues" style="filter: grayscale(100%);">
                   </a>
                   {% else %}
                   <a href="{{spec.gh_tasks}}">
-                  <img src="/images/specs_tasks.png" alt="BioSchemas {{ spec.name }} Github Tasks or Issues">
+                  <img src="/images/specs_tasks.png" alt="BioSchemas {{ spec.spec_info.title }} Github Tasks or Issues">
                   </a>
                   {% endif %}
                </td>
                <td class="spec_links">
                   {% if spec.spec_info.full_example == '' %}
                   <a>
-                  <img src="/images/spec_examples.png" alt="View BioSchemas {{ spec.name }} Examples" style="filter: grayscale(100%);">
+                  <img src="/images/spec_examples.png" alt="View BioSchemas {{ spec.spec_info.title }} Examples" style="filter: grayscale(100%);">
                   </a>
                   {% else %}
                   <a href="{{spec.spec_info.full_example}}">
-                  <img src="/images/spec_examples.png" alt="View BioSchemas {{ spec.name }} Examples">
+                  <img src="/images/spec_examples.png" alt="View BioSchemas {{ spec.spec_info.title }} Examples">
                   </a>
                   {% endif %}
                </td>
                <td class="spec_links">
                   {% if spec.live_deploy == '' %}
                   <a>
-                  <img src="/images/live_deploy.png" alt="View BioSchemas {{ spec.name }} Examples" style="filter: grayscale(100%);">
+                  <img src="/images/live_deploy.png" alt="View BioSchemas {{ spec.spec_info.title }} Examples" style="filter: grayscale(100%);">
                   </a>
                   {% else %}
                   <a href="{{spec.live_deploy}}">
-                  <img src="/images/live_deploy.png" alt="View BioSchemas {{ spec.name }} Examples">
+                  <img src="/images/live_deploy.png" alt="View BioSchemas {{ spec.spec_info.title }} Examples">
                   </a>
                   {% endif %}
                </td>

--- a/specifications/drafts.html
+++ b/specifications/drafts.html
@@ -25,7 +25,8 @@ title: Draft BioSchemas Specifications
             {% assign prof_specs = site.devSpecs | where: 'spec_type', 'Profile'%}
             {% for spec in prof_specs %}
             <tr>
-               <th><a href="/devSpecs/{{spec.name}}/specification" title="{{spec.subtitle}}">{{ spec.name }}</a><br />(v{{spec.version}})<br />{{spec.dateModified}}</th>
+                {% assign date_time = spec.spec_info.version_date %}
+               <th><a href="/devSpecs/{{spec.name}}/specification" title="{{spec.subtitle}}">{{ spec.name }}</a><br />(v{{spec.spec_info.version}})<br />{{date_time | date_to_long_string }}</th>
                <td>
                   {% assign group = site.groups | where:"identifier", spec.group %}
                   {% for g in group %}
@@ -66,12 +67,12 @@ title: Draft BioSchemas Specifications
                   {% endif %}
                </td>
                <td class="spec_links">
-                  {% if spec.gh_examples == '' %}
+                  {% if spec.spec_info.full_example == '' %}
                   <a>
                   <img src="/images/spec_examples.png" alt="View BioSchemas {{ spec.name }} Examples" style="filter: grayscale(100%);">
                   </a>
                   {% else %}
-                  <a href="{{spec.gh_examples}}">
+                  <a href="{{spec.spec_info.full_example}}">
                   <img src="/images/spec_examples.png" alt="View BioSchemas {{ spec.name }} Examples">
                   </a>
                   {% endif %}

--- a/specifications/index.html
+++ b/specifications/index.html
@@ -57,7 +57,7 @@ title: BioSchemas Specifications
                         <img src="/images/cross_walk.png" alt="View BioSchemas {{ spec.name }} Cross Walk"  style="filter: grayscale(100%);">
                       </a>
                     {%else%}
-                      <a href="{{spec.cross_walk_url}}">
+                      <a href="{{spec.cross_walk_url}}" target="_blank">
                         <img src="/images/cross_walk.png" alt="View BioSchemas {{ spec.name }} Cross Walk">
                       </a>
                     {%endif%}
@@ -69,7 +69,7 @@ title: BioSchemas Specifications
                         <img src="/images/specs_tasks.png" alt="BioSchemas {{ spec.name }} Github Tasks or Issues" style="filter: grayscale(100%);">
                       </a>
                     {% else %}
-                      <a href="{{spec.gh_tasks}}">
+                      <a href="{{spec.gh_tasks}}" target="_blank">
                         <img src="/images/specs_tasks.png" alt="BioSchemas {{ spec.name }} Github Tasks or Issues">
                       </a>
                     {% endif %}
@@ -81,7 +81,7 @@ title: BioSchemas Specifications
                         <img src="/images/spec_examples.png" alt="View BioSchemas {{ spec.name }} Examples" style="filter: grayscale(100%);">
                       </a>
                     {% else %}
-                      <a href="{{spec.gh_examples}}">
+                      <a href="{{spec.gh_examples}}" target="_blank">
                         <img src="/images/spec_examples.png" alt="View BioSchemas {{ spec.name }} Examples">
                       </a>
                     {% endif %}


### PR DESCRIPTION
Went through all the draft specification and adjusted the YAML information, removing the parameters that were not used, and arranged them consistently.

Dev Specifications using the new template (Updated spreadsheet mapping):
- [x] Beacon
- [x] Chemical
- [x] ChemicalStructure
- [x] Course
- [x] DataCatalog
- [x] DataRecord
- [ ] Dataset
- [ ] Event
- [x] Gene
- [ ] LabProtocol
- [ ] Organization
- [ ] Person
- [x] Protein
- [ ] ProteinAnnotation
- [ ] ProteinStructure
- [ ] Sample
- [ ] Standard
- [ ] Tool
- [ ] TrainingMaterial
