### PR TITLE
New field contact-people for events

### DIFF
--- a/_layouts/meeting.html
+++ b/_layouts/meeting.html
@@ -4,6 +4,18 @@ layout: default
 <h1>{{ page.name }}</h1>
 <p><strong>Dates:</strong> {{page.start_date | date_to_long_string}} To {{page.end_date | date_to_long_string}}</p>
 <p><strong>Venue:</strong> {{page.venue}}</p>
+
+{% if page.contact-people %}
+<strong>Contacts:</strong>
+<ul>
+  {% for contact-person in page.contact-people %}
+  {% assign person-id = "/people/" | append: contact-person %}
+  {% assign person = site.people | where:"id", person-id | first%}
+  <li><a href="{{ person.url }}">{{person.first-name}} {{person.last-name}}</a></li>
+  {% endfor %}
+</ul>
+{% endif %}
+
 {% if page.meeting-url %}
   <p><strong>Meeting page:</strong> <a href="{{page.meeting-url}}">{{page.meeting-url}}</a></p>
 {% endif %}

--- a/_meetings/2018-11_BioHackatonParis.html
+++ b/_meetings/2018-11_BioHackatonParis.html
@@ -8,5 +8,8 @@ end_date: 2018-11-16
 venue: Campus des Berges de Seine (South Paris), 1 Route de Beaulieu, 77240 Seine-Port, France
 meeting-url: http://bh2018paris.info/
 tbc: true
+contact-people: 
+    - RicardoArcila
+    - RafaelJimenez
 ---
 <div class="alert alert-warning" style="width:20em; text-align: center; margin-top: 2em" role="alert">To be confirmed</div>


### PR DESCRIPTION
If the event MD has a field contact-people with the people id information, a contact field will be shown on the event detail.

Addressing ticket https://github.com/BioSchemas/specifications/issues/172
