### PR TITLE
Ric/feat/live deploy example link

### DIFF
--- a/_liveDeploys/candidates.md
+++ b/_liveDeploys/candidates.md
@@ -9,6 +9,7 @@ list:
 -
     name: ITSoneDB
     description:
+    example_URL: http://itsonedb.cloud.ba.infn.it/
     URL: http://itsonedb.cloud.ba.infn.it/
     schema_org:
     bsc_profile:
@@ -17,7 +18,8 @@ list:
 -
     name: Biosamples DataCatalog
     description:
-    URL: https://www.ebi.ac.uk/biosamples/
+    example_URL: https://www.ebi.ac.uk/biosamples/
+    URL: https://www.ebi.ac.uk/
     schema_org:
     bsc_profile:
     bsc_ver:
@@ -25,7 +27,7 @@ list:
 -
     name: EBISC
     description:
-    URL: https://cells.ebisc.org
+    example_URL: https://cells.ebisc.org
     schema_org:
     bsc_profile:
     bsc_ver:
@@ -34,6 +36,15 @@ list:
     name: FAANG
     description:
     URL: http://data.faang.org/home
+    URL: https://cells.ebisc.org
+    schema_org:
+    bsc_profile:
+    bsc_ver:
+    comments: Could implement DataCatalog, DataSet and DataRecord
+-
+    name: FAANG
+    description:
+    URL: http:/
     schema_org:
     bsc_profile:
     bsc_ver:
@@ -41,6 +52,7 @@ list:
 -
     name: HipSci
     description:
+    example_URL: http://www.hipsci.org/
     URL: http://www.hipsci.org/
     schema_org:
     bsc_profile:
@@ -49,6 +61,7 @@ list:
 -
     name: PharmGKB
     description:
+    example_URL: https://www.pharmgkb.org/
     URL: https://www.pharmgkb.org/
     schema_org:
     bsc_profile:
@@ -57,6 +70,7 @@ list:
 -
     name: CDT
     description:
+    example_URL: http://ctdbase.org/
     URL: http://ctdbase.org/
     schema_org:
     bsc_profile:
@@ -65,6 +79,7 @@ list:
 -
     name: EnsemblGenomes
     description:
+    example_URL: http://ensemblgenomes.org/
     URL: http://ensemblgenomes.org/
     schema_org:
     bsc_profile:
@@ -73,6 +88,7 @@ list:
 -
     name: EnsemblProtists
     description:
+    example_URL: http://protists.ensembl.org/
     URL: http://protists.ensembl.org/
     schema_org:
     bsc_profile:
@@ -81,7 +97,8 @@ list:
 -
     name: Edinburgh Genomics
     description:
-    URL: https://genomics.ed.ac.uk/services/training
+    example_URL: https://genomics.ed.ac.uk/services/training
+    URL: https://genomics.ed.ac.uk/
     schema_org:
     bsc_profile:
     bsc_ver:
@@ -89,7 +106,8 @@ list:
 -
     name: Birmingham Metabolomics Centre
     description:
-    URL: https://www.birmingham.ac.uk/facilities/metabolomics-training-centre/course-list.aspx
+    example_URL: https://www.birmingham.ac.uk/facilities/metabolomics-training-centre/course-list.aspx
+    URL: https://www.birmingham.ac.uk/
     schema_org:
     bsc_profile:
     bsc_ver:
@@ -97,7 +115,8 @@ list:
 -
     name: BioComp
     description:
-    URL: http://biocomp.vbcf.ac.at/training/index.html
+    example_URL: http://biocomp.vbcf.ac.at/training/index.html
+    URL: http://biocomp.vbcf.ac.at/
     schema_org:
     bsc_profile:
     bsc_ver:
@@ -105,7 +124,8 @@ list:
 -
     name: BITSVIB
     description:
-    URL: http://dev.bits.vib.be/eulife/all_events.json
+    example_URL: http://dev.bits.vib.be/eulife/all_events.json
+    URL: http://dev.bits.vib.be/
     schema_org:
     bsc_profile:
     bsc_ver:
@@ -113,7 +133,8 @@ list:
 -
     name: EBI
     description:
-    URL: https://www.ebi.ac.uk/sites/ebi.ac.uk/files/data/ebi-events-tess-all.json
+    example_URL: https://www.ebi.ac.uk/sites/ebi.ac.uk/files/data/ebi-events-tess-all.json
+    URL: https://www.ebi.ac.uk/
     schema_org:
     bsc_profile:
     bsc_ver:
@@ -121,7 +142,8 @@ list:
 -
     name: Flemish Super Computing Centre
     description:
-    URL: http://dev.bits.vib.be/eulife/all_events-vrc.json
+    example_URL: http://dev.bits.vib.be/eulife/all_events-vrc.json
+    URL: http://dev.bits.vib.be/
     schema_org:
     bsc_profile:
     bsc_ver:
@@ -129,9 +151,10 @@ list:
 -
     name: FutureLearn
     description:
-    URL: https://www.futurelearn.com/search?utf8=%E2%9C%93&q=bioinformatics
+    example_URL: https://www.futurelearn.com/search?utf8=%E2%9C%93&q=bioinformatics
+    URL: https://www.futurelearn.com/
     schema_org:
     bsc_profile:
     bsc_ver:
-    comments: Could implement Event       
+    comments: Could implement Event      
 ---

--- a/_liveDeploys/candidates.md
+++ b/_liveDeploys/candidates.md
@@ -8,7 +8,7 @@ description: Services/sites in the process of implementing Bioschemas's markup
 list:  
 -
     name: ITSoneDB
-    description:
+    highlight:
     example_URL: http://itsonedb.cloud.ba.infn.it/
     resource_URL: http://itsonedb.cloud.ba.infn.it/
     schema_org:
@@ -17,7 +17,7 @@ list:
     comments:
 -
     name: EBISC
-    description:
+    highlight:
     example_URL: https://cells.ebisc.org
     resource_URL:
     schema_org:
@@ -26,7 +26,7 @@ list:
     comments: Could implement DataCatalog, DataSet and DataRecord
 -
     name: FAANG
-    description:
+    highlight:
     example_URL: http://data.faang.org/home
     resource_URL: https://cells.ebisc.org
     schema_org:
@@ -35,7 +35,7 @@ list:
     comments: Could implement DataCatalog, DataSet and DataRecord
 -
     name: FAANG
-    description:
+    highlight:
     example_URL:
     resource_URL: http:/
     schema_org:
@@ -44,7 +44,7 @@ list:
     comments: Could implement DataCatalog, Dataset and DataRecord
 -
     name: HipSci
-    description:
+    highlight:
     example_URL: http://www.hipsci.org/
     resource_URL: http://www.hipsci.org/
     schema_org:
@@ -53,7 +53,7 @@ list:
     comments: Could implement DataCatalog, Dataset and DataRecord
 -
     name: PharmGKB
-    description:
+    highlight:
     example_URL: https://www.pharmgkb.org/
     resource_URL: https://www.pharmgkb.org/
     schema_org:
@@ -62,7 +62,7 @@ list:
     comments: Could implement DataCatalog, Dataset and DataRecord
 -
     name: CDT
-    description:
+    highlight:
     example_URL: http://ctdbase.org/
     resource_URL: http://ctdbase.org/
     schema_org:
@@ -71,7 +71,7 @@ list:
     comments: Could implement DataCatalog, Dataset and DataRecord
 -
     name: EnsemblGenomes
-    description:
+    highlight:
     example_URL: http://ensemblgenomes.org/
     resource_URL: http://ensemblgenomes.org/
     schema_org:
@@ -80,7 +80,7 @@ list:
     comments: Could implement DataCatalog, Dataset and DataRecord
 -
     name: EnsemblProtists
-    description:
+    highlight:
     example_URL: http://protists.ensembl.org/
     resource_URL: http://protists.ensembl.org/
     schema_org:
@@ -89,7 +89,7 @@ list:
     comments: Could implement DataCatalog, Dataset and DataRecord   
 -
     name: Edinburgh Genomics
-    description:
+    highlight:
     example_URL: https://genomics.ed.ac.uk/services/training
     resource_URL: https://genomics.ed.ac.uk/
     schema_org:
@@ -98,7 +98,7 @@ list:
     comments: Could implement Event
 -
     name: Birmingham Metabolomics Centre
-    description:
+    highlight:
     example_URL: https://www.birmingham.ac.uk/facilities/metabolomics-training-centre/course-list.aspx
     resource_URL: https://www.birmingham.ac.uk/
     schema_org:
@@ -107,7 +107,7 @@ list:
     comments: Could implement Event
 -
     name: BioComp
-    description:
+    highlight:
     example_URL: http://biocomp.vbcf.ac.at/training/index.html
     resource_URL: http://biocomp.vbcf.ac.at/
     schema_org:
@@ -116,7 +116,7 @@ list:
     comments: Could implement Event
 -
     name: BITSVIB
-    description:
+    highlight:
     example_URL: http://dev.bits.vib.be/eulife/all_events.json
     resource_URL: http://dev.bits.vib.be/
     schema_org:
@@ -125,7 +125,7 @@ list:
     comments: Could implement Event
 -
     name: EBI
-    description:
+    highlight:
     example_URL: https://www.ebi.ac.uk/sites/ebi.ac.uk/files/data/ebi-events-tess-all.json
     resource_URL: https://www.ebi.ac.uk/
     schema_org:
@@ -134,7 +134,7 @@ list:
     comments: Could implement Event
 -
     name: Flemish Super Computing Centre
-    description:
+    highlight:
     example_URL: http://dev.bits.vib.be/eulife/all_events-vrc.json
     resource_URL: http://dev.bits.vib.be/
     schema_org:
@@ -143,7 +143,7 @@ list:
     comments: Could implement Event  
 -
     name: FutureLearn
-    description:
+    highlight:
     example_URL: https://www.futurelearn.com/search?utf8=%E2%9C%93&q=bioinformatics
     resource_URL: https://www.futurelearn.com/
     schema_org:

--- a/_liveDeploys/candidates.md
+++ b/_liveDeploys/candidates.md
@@ -16,18 +16,10 @@ list:
     bsc_ver:
     comments:
 -
-    name: Biosamples DataCatalog
-    description:
-    example_URL: https://www.ebi.ac.uk/biosamples/
-    resource_URL: https://www.ebi.ac.uk/
-    schema_org:
-    bsc_profile:
-    bsc_ver:
-    comments: Home page could implement DataCatalog
--
     name: EBISC
     description:
     example_URL: https://cells.ebisc.org
+    resource_URL:
     schema_org:
     bsc_profile:
     bsc_ver:
@@ -35,7 +27,7 @@ list:
 -
     name: FAANG
     description:
-    resource_URL: http://data.faang.org/home
+    example_URL: http://data.faang.org/home
     resource_URL: https://cells.ebisc.org
     schema_org:
     bsc_profile:
@@ -44,6 +36,7 @@ list:
 -
     name: FAANG
     description:
+    example_URL:
     resource_URL: http:/
     schema_org:
     bsc_profile:

--- a/_liveDeploys/candidates.md
+++ b/_liveDeploys/candidates.md
@@ -10,7 +10,7 @@ list:
     name: ITSoneDB
     description:
     example_URL: http://itsonedb.cloud.ba.infn.it/
-    URL: http://itsonedb.cloud.ba.infn.it/
+    resource_URL: http://itsonedb.cloud.ba.infn.it/
     schema_org:
     bsc_profile:
     bsc_ver:
@@ -19,7 +19,7 @@ list:
     name: Biosamples DataCatalog
     description:
     example_URL: https://www.ebi.ac.uk/biosamples/
-    URL: https://www.ebi.ac.uk/
+    resource_URL: https://www.ebi.ac.uk/
     schema_org:
     bsc_profile:
     bsc_ver:
@@ -35,8 +35,8 @@ list:
 -
     name: FAANG
     description:
-    URL: http://data.faang.org/home
-    URL: https://cells.ebisc.org
+    resource_URL: http://data.faang.org/home
+    resource_URL: https://cells.ebisc.org
     schema_org:
     bsc_profile:
     bsc_ver:
@@ -44,7 +44,7 @@ list:
 -
     name: FAANG
     description:
-    URL: http:/
+    resource_URL: http:/
     schema_org:
     bsc_profile:
     bsc_ver:
@@ -53,7 +53,7 @@ list:
     name: HipSci
     description:
     example_URL: http://www.hipsci.org/
-    URL: http://www.hipsci.org/
+    resource_URL: http://www.hipsci.org/
     schema_org:
     bsc_profile:
     bsc_ver:
@@ -62,7 +62,7 @@ list:
     name: PharmGKB
     description:
     example_URL: https://www.pharmgkb.org/
-    URL: https://www.pharmgkb.org/
+    resource_URL: https://www.pharmgkb.org/
     schema_org:
     bsc_profile:
     bsc_ver:
@@ -71,7 +71,7 @@ list:
     name: CDT
     description:
     example_URL: http://ctdbase.org/
-    URL: http://ctdbase.org/
+    resource_URL: http://ctdbase.org/
     schema_org:
     bsc_profile:
     bsc_ver:
@@ -80,7 +80,7 @@ list:
     name: EnsemblGenomes
     description:
     example_URL: http://ensemblgenomes.org/
-    URL: http://ensemblgenomes.org/
+    resource_URL: http://ensemblgenomes.org/
     schema_org:
     bsc_profile:
     bsc_ver:
@@ -89,7 +89,7 @@ list:
     name: EnsemblProtists
     description:
     example_URL: http://protists.ensembl.org/
-    URL: http://protists.ensembl.org/
+    resource_URL: http://protists.ensembl.org/
     schema_org:
     bsc_profile:
     bsc_ver:
@@ -98,7 +98,7 @@ list:
     name: Edinburgh Genomics
     description:
     example_URL: https://genomics.ed.ac.uk/services/training
-    URL: https://genomics.ed.ac.uk/
+    resource_URL: https://genomics.ed.ac.uk/
     schema_org:
     bsc_profile:
     bsc_ver:
@@ -107,7 +107,7 @@ list:
     name: Birmingham Metabolomics Centre
     description:
     example_URL: https://www.birmingham.ac.uk/facilities/metabolomics-training-centre/course-list.aspx
-    URL: https://www.birmingham.ac.uk/
+    resource_URL: https://www.birmingham.ac.uk/
     schema_org:
     bsc_profile:
     bsc_ver:
@@ -116,7 +116,7 @@ list:
     name: BioComp
     description:
     example_URL: http://biocomp.vbcf.ac.at/training/index.html
-    URL: http://biocomp.vbcf.ac.at/
+    resource_URL: http://biocomp.vbcf.ac.at/
     schema_org:
     bsc_profile:
     bsc_ver:
@@ -125,7 +125,7 @@ list:
     name: BITSVIB
     description:
     example_URL: http://dev.bits.vib.be/eulife/all_events.json
-    URL: http://dev.bits.vib.be/
+    resource_URL: http://dev.bits.vib.be/
     schema_org:
     bsc_profile:
     bsc_ver:
@@ -134,7 +134,7 @@ list:
     name: EBI
     description:
     example_URL: https://www.ebi.ac.uk/sites/ebi.ac.uk/files/data/ebi-events-tess-all.json
-    URL: https://www.ebi.ac.uk/
+    resource_URL: https://www.ebi.ac.uk/
     schema_org:
     bsc_profile:
     bsc_ver:
@@ -143,7 +143,7 @@ list:
     name: Flemish Super Computing Centre
     description:
     example_URL: http://dev.bits.vib.be/eulife/all_events-vrc.json
-    URL: http://dev.bits.vib.be/
+    resource_URL: http://dev.bits.vib.be/
     schema_org:
     bsc_profile:
     bsc_ver:
@@ -152,7 +152,7 @@ list:
     name: FutureLearn
     description:
     example_URL: https://www.futurelearn.com/search?utf8=%E2%9C%93&q=bioinformatics
-    URL: https://www.futurelearn.com/
+    resource_URL: https://www.futurelearn.com/
     schema_org:
     bsc_profile:
     bsc_ver:

--- a/_liveDeploys/liveDeploy.md
+++ b/_liveDeploys/liveDeploy.md
@@ -98,7 +98,7 @@ list:
     comments: Can implement DataRecord type.
 -
     name: Biosamples
-    description: 5 million+ pages
+    description: 
     example_URL: https://www.ebi.ac.uk/biosamples/
     resource_URL: https://www.ebi.ac.uk/biosamples/
     schema_org:
@@ -107,7 +107,7 @@ list:
     comments:
 -
     name: Biosamples
-    description: 
+    description: 5 million+ pages
     example_URL: https://www.ebi.ac.uk/biosamples/samples/SAMEA491372
     resource_URL: https://www.ebi.ac.uk/
     schema_org:

--- a/_liveDeploys/liveDeploy.md
+++ b/_liveDeploys/liveDeploy.md
@@ -8,7 +8,7 @@ description: Services/sites implementing Bioschemas's markup
 list:
 -
     name: Identifiers
-    description:
+    highlight:
     example_URL: http://identifiers.org/
     resource_URL: http://identifiers.org/
     schema_org: DataCatalog
@@ -17,7 +17,7 @@ list:
     comments: Could implement Dataset and DataRecord as well.
 -
     name: Fairsharing
-    description:
+    highlight:
     example_URL: https://fairsharing.org/
     resource_URL: https://fairsharing.org/
     schema_org: DataCatalog
@@ -26,7 +26,7 @@ list:
     comments:
 -
     name: Gigadb
-    description:
+    highlight:
     example_URL: http://gigadb.org/site/index
     resource_URL: http://gigadb.org/
     schema_org: DataCatalog
@@ -35,7 +35,7 @@ list:
     comments:
 -
     name: Human Protein Atlas
-    description:
+    highlight:
     example_URL: https://www.proteinatlas.org/
     resource_URL: https://www.proteinatlas.org/
     schema_org: DataCatalog
@@ -44,7 +44,7 @@ list:
     comments: Could implement Dataset and DataRecord as well.
 -
     name: EGA
-    description:
+    highlight:
     example_URL: https://ega-archive.org/
     resource_URL: https://ega-archive.org/
     schema_org: DataCatalog
@@ -53,7 +53,7 @@ list:
     comments:
 -
     name: Isaexplorer
-    description:
+    highlight:
     example_URL: http://scientificdata.isa-explorer.org/
     resource_URL: http://scientificdata.isa-explorer.org/
     schema_org: DataCatalog
@@ -62,7 +62,7 @@ list:
     comments:
 -
     name: IUPHAR/BPS
-    description:
+    highlight:
     example_URL: http://www.guidetopharmacology.org/
     resource_URL: http://www.guidetopharmacology.org/
     schema_org: DataCatalog
@@ -71,7 +71,7 @@ list:
     comments:
 -
     name: EGA Dataset
-    description:
+    highlight:
     example_URL: https://ega-archive.org/datasets/EGAD00000000001
     resource_URL: https://ega-archive.org/
     schema_org: Dataset
@@ -80,7 +80,7 @@ list:
     comments:
 -
     name: MobiDB
-    description:
+    highlight:
     example_URL: http://mobidb.bio.unipd.it/
     resource_URL: http://mobidb.bio.unipd.it/
     schema_org: DataCatalog
@@ -89,7 +89,7 @@ list:
     comments:
 -
     name: MobiDB
-    description:
+    highlight:
     example_URL: http://mobidb.bio.unipd.it/
     resource_URL: http://mobidb.bio.unipd.it/
     schema_org: Dataset
@@ -98,7 +98,7 @@ list:
     comments: Can implement DataRecord type.
 -
     name: Biosamples
-    description: 
+    highlight: 
     example_URL: https://www.ebi.ac.uk/biosamples/
     resource_URL: https://www.ebi.ac.uk/biosamples/
     schema_org:
@@ -107,7 +107,7 @@ list:
     comments:
 -
     name: Biosamples
-    description: 5 million+ pages
+    highlight: 5 million+ pages
     example_URL: https://www.ebi.ac.uk/biosamples/samples/SAMEA491372
     resource_URL: https://www.ebi.ac.uk/biosamples/
     schema_org:
@@ -116,7 +116,7 @@ list:
     comments:
 -
     name: DataMed
-    description:
+    highlight:
     example_URL: https://datamed.org/display-item.php?repository=0006&id=59139ef65152c62a9fc18ff7
     resource_URL: https://datamed.org/
     schema_org: Dataset
@@ -125,7 +125,7 @@ list:
     comments:
 -
     name: Fairsharing
-    description:
+    highlight:
     example_URL: https://fairsharing.org/
     resource_URL: https://fairsharing.org/
     schema_org: Dataset
@@ -134,7 +134,7 @@ list:
     comments:
 -
     name: Pscan
-    description:
+    highlight:
     example_URL: http://159.149.160.88/pscan/
     resource_URL: http://159.149.160.88/pscan/
     schema_org: SoftwareApplication
@@ -143,7 +143,7 @@ list:
     comments:
 -
     name: PscanChIP
-    description:
+    highlight:
     example_URL: http://159.149.160.88/pscan_chip_dev/
     resource_URL: http://159.149.160.88/pscan_chip_dev/
     schema_org: SoftwareApplication
@@ -152,7 +152,7 @@ list:
     comments:
 -
     name: Cscan
-    description:
+    highlight:
     example_URL: http://159.149.160.88/cscan/
     resource_URL: http://159.149.160.88/cscan/
     schema_org: SoftwareApplication
@@ -161,7 +161,7 @@ list:
     comments:
 -
     name: BAR 3.0
-    description:
+    highlight:
     example_URL: https://bar.biocomp.unibo.it/bar3/
     resource_URL: https://bar.biocomp.unibo.it/bar3/
     schema_org: SoftwareApplication
@@ -170,7 +170,7 @@ list:
     comments:
 -
     name: Elixir TeSS Events
-    description: 8500+ pages
+    highlight: 8500+ pages
     example_URL: https://tess.elixir-europe.org/events
     resource_URL: https://tess.elixir-europe.org/events
     schema_org: Event
@@ -179,7 +179,7 @@ list:
     comments:    
 -
     name: PDBe
-    description: 140,000+ pages
+    highlight: 140,000+ pages
     example_URL: http://www.ebi.ac.uk/pdbe/entry/pdb/4a7l
     resource_URL: http://www.ebi.ac.uk/pdbe/
     schema_org:
@@ -188,7 +188,7 @@ list:
     comments:
 -
     name: PDBe
-    description: 214,000+ pages
+    highlight: 214,000+ pages
     example_URL: https://www.ebi.ac.uk/pdbe/entry/pdb/5hbi/protein/1
     resource_URL: https://www.ebi.ac.uk/pdbe/
     schema_org:
@@ -197,7 +197,7 @@ list:
     comments:    
 -
     name: French Institute of Bioinformatics (IFB) Events
-    description:
+    highlight:
     example_URL: https://www.france-bioinformatique.fr/en/evenements_upcoming
     resource_URL: https://www.france-bioinformatique.fr/en/evenements_upcoming
     schema_org: Event
@@ -206,7 +206,7 @@ list:
     comments:     
 -
     name: ELIXIR Portugal Events
-    description:
+    highlight:
     example_URL: http://elixir-portugal.org/event/embo-practical-course-tree-building-advanced-concepts-and-practice-phylogenetic-analysis
     resource_URL: http://elixir-portugal.org/
     schema_org: Event
@@ -215,7 +215,7 @@ list:
     comments:     
 -
     name: SIB Events
-    description:
+    highlight:
     example_URL: https://www.sib.swiss/training/upcoming-training-events
     resource_URL: https://www.sib.swiss/training/upcoming-training-events
     schema_org: Event
@@ -224,7 +224,7 @@ list:
     comments:   
 -
     name: ELIXIR Events
-    description:
+    highlight:
     example_URL: https://www.elixir-europe.org/events/biohackathon-2018-paris
     resource_URL: https://www.elixir-europe.org/events/
     schema_org: Event
@@ -233,7 +233,7 @@ list:
     comments:
 -
     name: Birmingham Metabolomics Training Centre
-    description:
+    highlight:
     example_URL: https://www.birmingham.ac.uk/facilities/metabolomics-training-centre/courses/q-exactive.aspx
     resource_URL: https://www.birmingham.ac.uk/
     schema_org: Event
@@ -242,7 +242,7 @@ list:
     comments:
 -
     name: HmmerWeb
-    description: Result of searches are annotated (results last 1 week)
+    highlight: Result of searches are annotated (results last 1 week)
     example_URL: 
     resource_URL: https://www.ebi.ac.uk/Tools/hmmer/search/phmmer
     schema_org:
@@ -251,7 +251,7 @@ list:
     comments:
 -
     name: HmmerWeb
-    description: Result of searches are annotated (results last 1 week)
+    highlight: Result of searches are annotated (results last 1 week)
     example_URL: 
     resource_URL: https://www.ebi.ac.uk/Tools/hmmer/search/phmmer
     schema_org:
@@ -260,7 +260,7 @@ list:
     comments:
 -
     name: HmmerWeb
-    description: Result of searches are annotated (results last 1 week)
+    highlight: Result of searches are annotated (results last 1 week)
     example_URL: 
     resource_URL: https://www.ebi.ac.uk/Tools/hmmer/search/phmmer
     schema_org:

--- a/_liveDeploys/liveDeploy.md
+++ b/_liveDeploys/liveDeploy.md
@@ -109,7 +109,7 @@ list:
     name: Biosamples
     description: 5 million+ pages
     example_URL: https://www.ebi.ac.uk/biosamples/samples/SAMEA491372
-    resource_URL: https://www.ebi.ac.uk/
+    resource_URL: https://www.ebi.ac.uk/biosamples/
     schema_org:
     bsc_profile: Sample
     bsc_ver: 0.1

--- a/_liveDeploys/liveDeploy.md
+++ b/_liveDeploys/liveDeploy.md
@@ -10,7 +10,7 @@ list:
     name: Identifiers
     description:
     example_URL: http://identifiers.org/
-    URL: http://identifiers.org/
+    resource_URL: http://identifiers.org/
     schema_org: DataCatalog
     bsc_profile: DataCatalog
     bsc_ver: 0.1
@@ -19,7 +19,7 @@ list:
     name: Fairsharing
     description:
     example_URL: https://fairsharing.org/
-    URL: https://fairsharing.org/
+    resource_URL: https://fairsharing.org/
     schema_org: DataCatalog
     bsc_profile: DataCatalog
     bsc_ver: 0.1
@@ -28,7 +28,7 @@ list:
     name: Gigadb
     description:
     example_URL: http://gigadb.org/site/index
-    URL: http://gigadb.org/
+    resource_URL: http://gigadb.org/
     schema_org: DataCatalog
     bsc_profile: DataCatalog
     bsc_ver: 0.1
@@ -37,7 +37,7 @@ list:
     name: Human Protein Atlas
     description:
     example_URL: https://www.proteinatlas.org/
-    URL: https://www.proteinatlas.org/
+    resource_URL: https://www.proteinatlas.org/
     schema_org: DataCatalog
     bsc_profile: DataCatalog
     bsc_ver: 0.1
@@ -46,7 +46,7 @@ list:
     name: EGA
     description:
     example_URL: https://ega-archive.org/
-    URL: https://ega-archive.org/
+    resource_URL: https://ega-archive.org/
     schema_org: DataCatalog
     bsc_profile: DataCatalog
     bsc_ver: 0.1
@@ -55,7 +55,7 @@ list:
     name: Isaexplorer
     description:
     example_URL: http://scientificdata.isa-explorer.org/
-    URL: http://scientificdata.isa-explorer.org/
+    resource_URL: http://scientificdata.isa-explorer.org/
     schema_org: DataCatalog
     bsc_profile: DataCatalog
     bsc_ver: 0.1
@@ -64,7 +64,7 @@ list:
     name: IUPHAR/BPS
     description:
     example_URL: http://www.guidetopharmacology.org/
-    URL: http://www.guidetopharmacology.org/
+    resource_URL: http://www.guidetopharmacology.org/
     schema_org: DataCatalog
     bsc_profile: DataCatalog
     bsc_ver: 0.1
@@ -73,7 +73,7 @@ list:
     name: EGA Dataset
     description:
     example_URL: https://ega-archive.org/datasets/EGAD00000000001
-    URL: https://ega-archive.org/
+    resource_URL: https://ega-archive.org/
     schema_org: Dataset
     bsc_profile: Dataset
     bsc_ver: 0.1
@@ -82,7 +82,7 @@ list:
     name: MobiDB
     description:
     example_URL: http://mobidb.bio.unipd.it/
-    URL: http://mobidb.bio.unipd.it/
+    resource_URL: http://mobidb.bio.unipd.it/
     schema_org: DataCatalog
     bsc_profile: DataCatalog
     bsc_ver: 0.1
@@ -91,7 +91,7 @@ list:
     name: MobiDB
     description:
     example_URL: http://mobidb.bio.unipd.it/
-    URL: http://mobidb.bio.unipd.it/
+    resource_URL: http://mobidb.bio.unipd.it/
     schema_org: Dataset
     bsc_profile: Dataset
     bsc_ver: 0.2
@@ -100,7 +100,7 @@ list:
     name: Biosamples
     description: 5 million+ pages
     example_URL: https://www.ebi.ac.uk/biosamples/
-    URL: https://www.ebi.ac.uk/biosamples/
+    resource_URL: https://www.ebi.ac.uk/biosamples/
     schema_org:
     bsc_profile: DataCatalog
     bsc_ver: 0.1
@@ -109,7 +109,7 @@ list:
     name: Biosamples
     description: 
     example_URL: https://www.ebi.ac.uk/biosamples/samples/SAMEA491372
-    URL: https://www.ebi.ac.uk/
+    resource_URL: https://www.ebi.ac.uk/
     schema_org:
     bsc_profile: Sample
     bsc_ver: 0.1
@@ -118,7 +118,7 @@ list:
     name: DataMed
     description:
     example_URL: https://datamed.org/display-item.php?repository=0006&id=59139ef65152c62a9fc18ff7
-    URL: https://datamed.org/
+    resource_URL: https://datamed.org/
     schema_org: Dataset
     bsc_profile: Dataset
     bsc_ver: 0.1
@@ -127,7 +127,7 @@ list:
     name: Fairsharing
     description:
     example_URL: https://fairsharing.org/
-    URL: https://fairsharing.org/
+    resource_URL: https://fairsharing.org/
     schema_org: Dataset
     bsc_profile: Dataset
     bsc_ver: 0.1
@@ -136,7 +136,7 @@ list:
     name: Pscan
     description:
     example_URL: http://159.149.160.88/pscan/
-    URL: http://159.149.160.88/pscan/
+    resource_URL: http://159.149.160.88/pscan/
     schema_org: SoftwareApplication
     bsc_profile: Tool
     bsc_ver: 0.1
@@ -145,7 +145,7 @@ list:
     name: PscanChIP
     description:
     example_URL: http://159.149.160.88/pscan_chip_dev/
-    URL: http://159.149.160.88/pscan_chip_dev/
+    resource_URL: http://159.149.160.88/pscan_chip_dev/
     schema_org: SoftwareApplication
     bsc_profile: Tool
     bsc_ver: 0.1
@@ -154,7 +154,7 @@ list:
     name: Cscan
     description:
     example_URL: http://159.149.160.88/cscan/
-    URL: http://159.149.160.88/cscan/
+    resource_URL: http://159.149.160.88/cscan/
     schema_org: SoftwareApplication
     bsc_profile: Tool
     bsc_ver: 0.1
@@ -163,7 +163,7 @@ list:
     name: BAR 3.0
     description:
     example_URL: https://bar.biocomp.unibo.it/bar3/
-    URL: https://bar.biocomp.unibo.it/bar3/
+    resource_URL: https://bar.biocomp.unibo.it/bar3/
     schema_org: SoftwareApplication
     bsc_profile: Tool
     bsc_ver: 0.1
@@ -172,7 +172,7 @@ list:
     name: Elixir TeSS Events
     description: 8500+ pages
     example_URL: https://tess.elixir-europe.org/events
-    URL: https://tess.elixir-europe.org/events
+    resource_URL: https://tess.elixir-europe.org/events
     schema_org: Event
     bsc_profile: Event
     bsc_ver: 0.1
@@ -181,7 +181,7 @@ list:
     name: PDBe
     description: 140,000+ pages
     example_URL: http://www.ebi.ac.uk/pdbe/entry/pdb/4a7l
-    URL: http://www.ebi.ac.uk/pdbe/
+    resource_URL: http://www.ebi.ac.uk/pdbe/
     schema_org:
     bsc_profile: ProteinStructure
     bsc_ver: 0.1
@@ -190,7 +190,7 @@ list:
     name: PDBe
     description: 214,000+ pages
     example_URL: https://www.ebi.ac.uk/pdbe/entry/pdb/5hbi/protein/1
-    URL: https://www.ebi.ac.uk/pdbe/
+    resource_URL: https://www.ebi.ac.uk/pdbe/
     schema_org:
     bsc_profile: Protein
     bsc_ver: 0.1
@@ -199,7 +199,7 @@ list:
     name: French Institute of Bioinformatics (IFB) Events
     description:
     example_URL: https://www.france-bioinformatique.fr/en/evenements_upcoming
-    URL: https://www.france-bioinformatique.fr/en/evenements_upcoming
+    resource_URL: https://www.france-bioinformatique.fr/en/evenements_upcoming
     schema_org: Event
     bsc_profile: Event
     bsc_ver: 0.1
@@ -208,7 +208,7 @@ list:
     name: ELIXIR Portugal Events
     description:
     example_URL: http://elixir-portugal.org/event/embo-practical-course-tree-building-advanced-concepts-and-practice-phylogenetic-analysis
-    URL: http://elixir-portugal.org/
+    resource_URL: http://elixir-portugal.org/
     schema_org: Event
     bsc_profile: Event
     bsc_ver: 0.1
@@ -217,7 +217,7 @@ list:
     name: SIB Events
     description:
     example_URL: https://www.sib.swiss/training/upcoming-training-events
-    URL: https://www.sib.swiss/training/upcoming-training-events
+    resource_URL: https://www.sib.swiss/training/upcoming-training-events
     schema_org: Event
     bsc_profile: Event
     bsc_ver: 0.1
@@ -226,7 +226,7 @@ list:
     name: ELIXIR Events
     description:
     example_URL: https://www.elixir-europe.org/events/biohackathon-2018-paris
-    URL: https://www.elixir-europe.org/events/
+    resource_URL: https://www.elixir-europe.org/events/
     schema_org: Event
     bsc_profile: Event
     bsc_ver: 0.1
@@ -235,9 +235,36 @@ list:
     name: Birmingham Metabolomics Training Centre
     description:
     example_URL: https://www.birmingham.ac.uk/facilities/metabolomics-training-centre/courses/q-exactive.aspx
-    URL: https://www.birmingham.ac.uk/
+    resource_URL: https://www.birmingham.ac.uk/
     schema_org: Event
     bsc_profile: Event
     bsc_ver: 0.1
     comments:
+-
+    name: HmmerWeb
+    description: Result of searches are annotated (results last 1 week)
+    example_URL: 
+    resource_URL: https://www.ebi.ac.uk/Tools/hmmer/search/phmmer
+    schema_org:
+    bsc_profile: Protein
+    bsc_ver: 0.1
+    comments:
+-
+    name: HmmerWeb
+    description: Result of searches are annotated (results last 1 week)
+    example_URL: 
+    resource_URL: https://www.ebi.ac.uk/Tools/hmmer/search/phmmer
+    schema_org:
+    bsc_profile: ProteinStructure
+    bsc_ver: 0.1
+    comments:
+-
+    name: HmmerWeb
+    description: Result of searches are annotated (results last 1 week)
+    example_URL: 
+    resource_URL: https://www.ebi.ac.uk/Tools/hmmer/search/phmmer
+    schema_org:
+    bsc_profile: ProteinAnnotation
+    bsc_ver: 0.1
+    comments:         
 ---

--- a/_liveDeploys/liveDeploy.md
+++ b/_liveDeploys/liveDeploy.md
@@ -99,6 +99,15 @@ list:
 -
     name: Biosamples
     description: 5 million+ pages
+    example_URL: https://www.ebi.ac.uk/biosamples/
+    URL: https://www.ebi.ac.uk/biosamples/
+    schema_org:
+    bsc_profile: DataCatalog
+    bsc_ver: 0.1
+    comments:
+-
+    name: Biosamples
+    description: 
     example_URL: https://www.ebi.ac.uk/biosamples/samples/SAMEA491372
     URL: https://www.ebi.ac.uk/
     schema_org:
@@ -127,7 +136,7 @@ list:
     name: Pscan
     description:
     example_URL: http://159.149.160.88/pscan/
-    URL: http://159.149.160.88/
+    URL: http://159.149.160.88/pscan/
     schema_org: SoftwareApplication
     bsc_profile: Tool
     bsc_ver: 0.1
@@ -136,7 +145,7 @@ list:
     name: PscanChIP
     description:
     example_URL: http://159.149.160.88/pscan_chip_dev/
-    URL: http://159.149.160.88/
+    URL: http://159.149.160.88/pscan_chip_dev/
     schema_org: SoftwareApplication
     bsc_profile: Tool
     bsc_ver: 0.1
@@ -145,7 +154,7 @@ list:
     name: Cscan
     description:
     example_URL: http://159.149.160.88/cscan/
-    URL: http://159.149.160.88/
+    URL: http://159.149.160.88/cscan/
     schema_org: SoftwareApplication
     bsc_profile: Tool
     bsc_ver: 0.1
@@ -154,7 +163,7 @@ list:
     name: BAR 3.0
     description:
     example_URL: https://bar.biocomp.unibo.it/bar3/
-    URL: https://bar.biocomp.unibo.it/
+    URL: https://bar.biocomp.unibo.it/bar3/
     schema_org: SoftwareApplication
     bsc_profile: Tool
     bsc_ver: 0.1
@@ -163,7 +172,7 @@ list:
     name: Elixir TeSS Events
     description: 8500+ pages
     example_URL: https://tess.elixir-europe.org/events
-    URL: https://tess.elixir-europe.org/
+    URL: https://tess.elixir-europe.org/events
     schema_org: Event
     bsc_profile: Event
     bsc_ver: 0.1
@@ -172,7 +181,7 @@ list:
     name: PDBe
     description: 140,000+ pages
     example_URL: http://www.ebi.ac.uk/pdbe/entry/pdb/4a7l
-    URL: http://www.ebi.ac.uk/
+    URL: http://www.ebi.ac.uk/pdbe/
     schema_org:
     bsc_profile: ProteinStructure
     bsc_ver: 0.1
@@ -181,7 +190,7 @@ list:
     name: PDBe
     description: 214,000+ pages
     example_URL: https://www.ebi.ac.uk/pdbe/entry/pdb/5hbi/protein/1
-    URL: https://www.ebi.ac.uk/
+    URL: https://www.ebi.ac.uk/pdbe/
     schema_org:
     bsc_profile: Protein
     bsc_ver: 0.1
@@ -190,7 +199,7 @@ list:
     name: French Institute of Bioinformatics (IFB) Events
     description:
     example_URL: https://www.france-bioinformatique.fr/en/evenements_upcoming
-    URL: https://www.france-bioinformatique.fr/
+    URL: https://www.france-bioinformatique.fr/en/evenements_upcoming
     schema_org: Event
     bsc_profile: Event
     bsc_ver: 0.1
@@ -208,7 +217,7 @@ list:
     name: SIB Events
     description:
     example_URL: https://www.sib.swiss/training/upcoming-training-events
-    URL: https://www.sib.swiss/
+    URL: https://www.sib.swiss/training/upcoming-training-events
     schema_org: Event
     bsc_profile: Event
     bsc_ver: 0.1
@@ -217,7 +226,7 @@ list:
     name: ELIXIR Events
     description:
     example_URL: https://www.elixir-europe.org/events/biohackathon-2018-paris
-    URL: https://www.elixir-europe.org/
+    URL: https://www.elixir-europe.org/events/
     schema_org: Event
     bsc_profile: Event
     bsc_ver: 0.1

--- a/_liveDeploys/liveDeploy.md
+++ b/_liveDeploys/liveDeploy.md
@@ -9,6 +9,7 @@ list:
 -
     name: Identifiers
     description:
+    example_URL: http://identifiers.org/
     URL: http://identifiers.org/
     schema_org: DataCatalog
     bsc_profile: DataCatalog
@@ -17,6 +18,7 @@ list:
 -
     name: Fairsharing
     description:
+    example_URL: https://fairsharing.org/
     URL: https://fairsharing.org/
     schema_org: DataCatalog
     bsc_profile: DataCatalog
@@ -25,7 +27,8 @@ list:
 -
     name: Gigadb
     description:
-    URL: http://gigadb.org/site/index
+    example_URL: http://gigadb.org/site/index
+    URL: http://gigadb.org/
     schema_org: DataCatalog
     bsc_profile: DataCatalog
     bsc_ver: 0.1
@@ -33,6 +36,7 @@ list:
 -
     name: Human Protein Atlas
     description:
+    example_URL: https://www.proteinatlas.org/
     URL: https://www.proteinatlas.org/
     schema_org: DataCatalog
     bsc_profile: DataCatalog
@@ -41,6 +45,7 @@ list:
 -
     name: EGA
     description:
+    example_URL: https://ega-archive.org/
     URL: https://ega-archive.org/
     schema_org: DataCatalog
     bsc_profile: DataCatalog
@@ -49,6 +54,7 @@ list:
 -
     name: Isaexplorer
     description:
+    example_URL: http://scientificdata.isa-explorer.org/
     URL: http://scientificdata.isa-explorer.org/
     schema_org: DataCatalog
     bsc_profile: DataCatalog
@@ -57,6 +63,7 @@ list:
 -
     name: IUPHAR/BPS
     description:
+    example_URL: http://www.guidetopharmacology.org/
     URL: http://www.guidetopharmacology.org/
     schema_org: DataCatalog
     bsc_profile: DataCatalog
@@ -65,7 +72,8 @@ list:
 -
     name: EGA Dataset
     description:
-    URL: https://ega-archive.org/datasets/EGAD00000000001
+    example_URL: https://ega-archive.org/datasets/EGAD00000000001
+    URL: https://ega-archive.org/
     schema_org: Dataset
     bsc_profile: Dataset
     bsc_ver: 0.1
@@ -73,6 +81,7 @@ list:
 -
     name: MobiDB
     description:
+    example_URL: http://mobidb.bio.unipd.it/
     URL: http://mobidb.bio.unipd.it/
     schema_org: DataCatalog
     bsc_profile: DataCatalog
@@ -81,6 +90,7 @@ list:
 -
     name: MobiDB
     description:
+    example_URL: http://mobidb.bio.unipd.it/
     URL: http://mobidb.bio.unipd.it/
     schema_org: Dataset
     bsc_profile: Dataset
@@ -89,7 +99,8 @@ list:
 -
     name: Biosamples
     description: 5 million+ pages
-    URL: https://www.ebi.ac.uk/biosamples/samples/SAMEA491372
+    example_URL: https://www.ebi.ac.uk/biosamples/samples/SAMEA491372
+    URL: https://www.ebi.ac.uk/
     schema_org:
     bsc_profile: Sample
     bsc_ver: 0.1
@@ -97,7 +108,8 @@ list:
 -
     name: DataMed
     description:
-    URL: https://datamed.org/display-item.php?repository=0006&id=59139ef65152c62a9fc18ff7
+    example_URL: https://datamed.org/display-item.php?repository=0006&id=59139ef65152c62a9fc18ff7
+    URL: https://datamed.org/
     schema_org: Dataset
     bsc_profile: Dataset
     bsc_ver: 0.1
@@ -105,6 +117,7 @@ list:
 -
     name: Fairsharing
     description:
+    example_URL: https://fairsharing.org/
     URL: https://fairsharing.org/
     schema_org: Dataset
     bsc_profile: Dataset
@@ -113,7 +126,8 @@ list:
 -
     name: Pscan
     description:
-    URL: http://159.149.160.88/pscan/
+    example_URL: http://159.149.160.88/pscan/
+    URL: http://159.149.160.88/
     schema_org: SoftwareApplication
     bsc_profile: Tool
     bsc_ver: 0.1
@@ -121,7 +135,8 @@ list:
 -
     name: PscanChIP
     description:
-    URL: http://159.149.160.88/pscan_chip_dev/
+    example_URL: http://159.149.160.88/pscan_chip_dev/
+    URL: http://159.149.160.88/
     schema_org: SoftwareApplication
     bsc_profile: Tool
     bsc_ver: 0.1
@@ -129,7 +144,8 @@ list:
 -
     name: Cscan
     description:
-    URL: http://159.149.160.88/cscan/
+    example_URL: http://159.149.160.88/cscan/
+    URL: http://159.149.160.88/
     schema_org: SoftwareApplication
     bsc_profile: Tool
     bsc_ver: 0.1
@@ -137,7 +153,8 @@ list:
 -
     name: BAR 3.0
     description:
-    URL: https://bar.biocomp.unibo.it/bar3/
+    example_URL: https://bar.biocomp.unibo.it/bar3/
+    URL: https://bar.biocomp.unibo.it/
     schema_org: SoftwareApplication
     bsc_profile: Tool
     bsc_ver: 0.1
@@ -145,7 +162,8 @@ list:
 -
     name: Elixir TeSS Events
     description: 8500+ pages
-    URL: https://tess.elixir-europe.org/events
+    example_URL: https://tess.elixir-europe.org/events
+    URL: https://tess.elixir-europe.org/
     schema_org: Event
     bsc_profile: Event
     bsc_ver: 0.1
@@ -153,7 +171,8 @@ list:
 -
     name: PDBe
     description: 140,000+ pages
-    URL: http://www.ebi.ac.uk/pdbe/entry/pdb/4a7l
+    example_URL: http://www.ebi.ac.uk/pdbe/entry/pdb/4a7l
+    URL: http://www.ebi.ac.uk/
     schema_org:
     bsc_profile: ProteinStructure
     bsc_ver: 0.1
@@ -161,7 +180,8 @@ list:
 -
     name: PDBe
     description: 214,000+ pages
-    URL: https://www.ebi.ac.uk/pdbe/entry/pdb/5hbi/protein/1
+    example_URL: https://www.ebi.ac.uk/pdbe/entry/pdb/5hbi/protein/1
+    URL: https://www.ebi.ac.uk/
     schema_org:
     bsc_profile: Protein
     bsc_ver: 0.1
@@ -169,7 +189,8 @@ list:
 -
     name: French Institute of Bioinformatics (IFB) Events
     description:
-    URL: https://www.france-bioinformatique.fr/en/evenements_upcoming
+    example_URL: https://www.france-bioinformatique.fr/en/evenements_upcoming
+    URL: https://www.france-bioinformatique.fr/
     schema_org: Event
     bsc_profile: Event
     bsc_ver: 0.1
@@ -177,7 +198,8 @@ list:
 -
     name: ELIXIR Portugal Events
     description:
-    URL: http://elixir-portugal.org/event/embo-practical-course-tree-building-advanced-concepts-and-practice-phylogenetic-analysis
+    example_URL: http://elixir-portugal.org/event/embo-practical-course-tree-building-advanced-concepts-and-practice-phylogenetic-analysis
+    URL: http://elixir-portugal.org/
     schema_org: Event
     bsc_profile: Event
     bsc_ver: 0.1
@@ -185,7 +207,8 @@ list:
 -
     name: SIB Events
     description:
-    URL: https://www.sib.swiss/training/upcoming-training-events
+    example_URL: https://www.sib.swiss/training/upcoming-training-events
+    URL: https://www.sib.swiss/
     schema_org: Event
     bsc_profile: Event
     bsc_ver: 0.1
@@ -193,7 +216,8 @@ list:
 -
     name: ELIXIR Events
     description:
-    URL: https://www.elixir-europe.org/events/biohackathon-2018-paris
+    example_URL: https://www.elixir-europe.org/events/biohackathon-2018-paris
+    URL: https://www.elixir-europe.org/
     schema_org: Event
     bsc_profile: Event
     bsc_ver: 0.1
@@ -201,9 +225,10 @@ list:
 -
     name: Birmingham Metabolomics Training Centre
     description:
-    URL: https://www.birmingham.ac.uk/facilities/metabolomics-training-centre/courses/q-exactive.aspx
+    example_URL: https://www.birmingham.ac.uk/facilities/metabolomics-training-centre/courses/q-exactive.aspx
+    URL: https://www.birmingham.ac.uk/
     schema_org: Event
     bsc_profile: Event
     bsc_ver: 0.1
-    comments:         
+    comments:
 ---

--- a/liveDeploys/index.html
+++ b/liveDeploys/index.html
@@ -59,7 +59,7 @@ description: |-
                     {% else %}
                     <div class="collapse collapse{{profile.name}}">
                     {% endif %}
-                        <a href="{{live.URL}}" target="_blank">{{live.name}}</a>
+                        <a href="{{live.resource_URL}}" target="_blank">{{live.name}}</a>
                         <p>{{live.description}}</p>
                     </div>
                 </td>
@@ -73,6 +73,7 @@ description: |-
                     </div>
                 </td>
                 <td class="structured-data-column hidden-row">
+                    {% if !live.example_URL %}
                     {% if profile_index == 1%}
                     <div class="collapse show collapse{{profile.name}}">
                     {% else %}
@@ -83,6 +84,7 @@ description: |-
                         <a href="https://search.google.com/structured-data/testing-tool#url={{live.example_URL}}" class="btn btn-bioschema btn-block" target="_blank">visualise</a>
                     </div>
                     </div>
+                    {% endif %}
                 </td>
             </tr>
             {% endfor %}

--- a/liveDeploys/index.html
+++ b/liveDeploys/index.html
@@ -60,7 +60,7 @@ description: |-
                     <div class="collapse collapse{{profile.name}}">
                     {% endif %}
                         <a href="{{live.resource_URL}}" target="_blank">{{live.name}}</a>
-                        <p>{{live.description}}</p>
+                        <p>{{live.highlight}}</p>
                     </div>
                 </td>
                 <td class="profile-version hidden-row">

--- a/liveDeploys/index.html
+++ b/liveDeploys/index.html
@@ -80,7 +80,7 @@ description: |-
                     {% endif %}                    
                     <div class="google-sdtt-button">
                         <span class="tooltiptext">Visualise on GTest tool</span>
-                        <a href="https://search.google.com/structured-data/testing-tool#url={{live.URL}}" class="btn btn-bioschema btn-block" target="_blank">visualise</a>
+                        <a href="https://search.google.com/structured-data/testing-tool#url={{live.example_URL}}" class="btn btn-bioschema btn-block" target="_blank">visualise</a>
                     </div>
                     </div>
                 </td>


### PR DESCRIPTION
Few improvements to Live deploy page:

- Livedeploys.md now has an example_URL field for the Visualisation button.
- Added Biosamples with Datacatalog profile to the list
- Added HMMER to the list. No visualisation option will be displayed since the example link changes periodically. 

This addresses the PR https://github.com/BioSchemas/bioschemas.github.io/pull/91 and the Issue https://github.com/BioSchemas/specifications/issues/173