### PR TITLE
more appropriate example url for "Dataset" type

### DIFF
--- a/_liveDeploys/liveDeploy.md
+++ b/_liveDeploys/liveDeploy.md
@@ -287,7 +287,7 @@ list:
 -
     name: CATH-Gene3D
     highlight: 500,000+ pages
-    example_URL: http://www.cathdb.info/version/latest/domain/1cukA01
+    example_URL: http://www.cathdb.info
     resource_URL: http://www.cathdb.info
     schema_org: Dataset
     bsc_profile: Dataset

--- a/_liveDeploys/liveDeploy.md
+++ b/_liveDeploys/liveDeploy.md
@@ -286,11 +286,20 @@ list:
     comments:
 -
     name: CATH-Gene3D
-    highlight: 500,000+ pages
+    highlight:
     example_URL: http://www.cathdb.info
     resource_URL: http://www.cathdb.info
     schema_org: Dataset
     bsc_profile: Dataset
     bsc_ver: 0.1
     comments:
+-
+    name: CATH-Gene3D
+    highlight:
+    example_URL: http://www.cathdb.info
+    resource_URL: http://www.cathdb.info
+    schema_org: DataCatalog
+    bsc_profile: DataCatalog
+    bsc_ver: 0.1
+    comments:    
 ---


### PR DESCRIPTION
Apologies for the spam - the Dataset specifications are actually on the main home page of CATH (rather than the domain page as originally specified)