### PR TITLE
Feat/deployment stories

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -48,7 +48,9 @@ collections:
     permalink: /:collection/:path/
   useCases:
     output: true
-    permalink: /:collection/:path/     
+    permalink: /:collection/:path/
   liveDeploys:
     output: true
     permalink: /:collection/:path/
+  stories:
+    output: true

--- a/_sass/_live-deploys.scss
+++ b/_sass/_live-deploys.scss
@@ -153,4 +153,10 @@
         font-size: 14px;
     }
 
+    .deployment-story {
+        margin-top: 1em;
+        border-radius: 5px;
+        box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
+        padding: 1em;
+    }
 }

--- a/_stories/marRef.html
+++ b/_stories/marRef.html
@@ -1,0 +1,10 @@
+---
+layout: default
+name: MarRef Demonstration
+date-added: 2018-05-17
+specs:
+  - BioChemEntity
+  - Sample
+external-url: https://github.com/EBIBioSamples/bioschemas_marref_demo/blob/master/Summary.md
+description: This demonstration shows how Bioschemas can be used to support lightweight data exchange without needing to use an API.
+---

--- a/_stories/marRef.html
+++ b/_stories/marRef.html
@@ -3,7 +3,6 @@ layout: default
 name: MarRef Demonstration
 date-added: 2018-05-17
 specs:
-  - BioChemEntity
   - Sample
 external-url: https://github.com/EBIBioSamples/bioschemas_marref_demo/blob/master/Summary.md
 description: This demonstration shows how Bioschemas can be used to support lightweight data exchange without needing to use an API.

--- a/_stories/toxTutTeSS.html
+++ b/_stories/toxTutTeSS.html
@@ -1,0 +1,10 @@
+---
+layout: default
+name: Toxicology data management tutorials automatically collected by European training portal TeSS
+date-added: 2018-07-19
+specs:
+  - Event
+  - TrainingMaterial
+external-url: https://www.dtls.nl/2018/07/19/toxicology-data-management-tutorials-automatically-collected-by-european-training-portal-tess/
+description: BioSchemas used to create a system that automatically pulls toxicology-related training materials from the eNanoMapper project into the European training portal TeSS.
+---

--- a/liveDeploys/index.html
+++ b/liveDeploys/index.html
@@ -104,11 +104,11 @@ description: |-
 
   <div class="col-md-4 right-column">
 
-      <section class="upcoming-events">
+      <section>
         <h3>Deployment Stories</h3>
           {% assign sorted_stories = (site.stories | sort: 'date-added' | reverse ) %}
           {% for story in sorted_stories %}
-          <div class="event">
+          <div>
               <strong><a href="{{ story.external-url }}">{{ story.name }}</a></strong>
               <p> <strong>{{ story.date-added }}</strong> </p>
               <ul>
@@ -119,7 +119,7 @@ description: |-
               <p>
                 {{ story.description }}
               </p>
-          </div class="event">
+          </div>
           {% endfor %}
         </section>
     </div>

--- a/liveDeploys/index.html
+++ b/liveDeploys/index.html
@@ -113,7 +113,7 @@ description: |-
               <p> <strong>{{ story.date-added }}</strong> </p>
               <ul>
                 {% for spec in story.specs %}
-                  <li>{{ spec }}</li>
+                  <li><a href="/specifications/{{ spec }}/specification/">{{ spec }}</a></li>
                 {% endfor %}
               </ul>
               <p>

--- a/liveDeploys/index.html
+++ b/liveDeploys/index.html
@@ -108,7 +108,7 @@ description: |-
         <h3>Deployment Stories</h3>
           {% assign sorted_stories = (site.stories | sort: 'date-added' | reverse ) %}
           {% for story in sorted_stories %}
-          <div>
+          <div class="deployment-story">
               <strong><a href="{{ story.external-url }}">{{ story.name }}</a></strong>
               <p> <strong>{{ story.date-added }}</strong> </p>
               <ul>

--- a/liveDeploys/index.html
+++ b/liveDeploys/index.html
@@ -2,17 +2,22 @@
 layout: default
 title: Live Deploys
 description: |-
-    Below we list the services/sites that use [Bioschemas](http://bioschemas.org) markup to describe what they are offering. We provide a direct link to the site and also a link to Google's [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool) visualisation of the site's markup. 
+    Below we list the services/sites that use [Bioschemas](http://bioschemas.org) markup to describe what they are offering. We provide a direct link to the site and also a link to Google's [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool) visualisation of the site's markup.
     The link to Google’s SDTT shows one example from the site; however, many more may exist. For example, Biosamples have marked up all of their content (currently over 5 million samples).
     Please remember that Google sets minimum requirements for [schema.org](http://schema.org) markup, which may conflict with those of [Bioschemas](http://bioschemas.org). As such, Google's [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool) may provide warnings or errors when the markup is perfectly compliant with both [schema.org](http://schema.org) and [Bioschemas](http://bioschemas.org).
     If your Bioschemas compliant site is not listed below, please email us at [community@bioschemas.org](mailto:community@bioschemas.org).
 ---
 <div class="live-deploys">
+
     <h1>Live deploys</h1>
     <p>{{page.description | markdownify}}</p>
     <br>
     {% assign liveDeploys = site.liveDeploys | where:"name", 'Live Deploys' | first %}
     {% assign candidates = site.liveDeploys | where:"name", 'Candidates' | first %}
+    <div class="container-flow">
+        <div class="row">
+
+            <div class="col-md-8">
     <section class="live-deploy-table">
         <h5>{{liveDeploys.description}}</h5>
         <p><strong>{{liveDeploys.list | size}}</strong> resources using Bioschemas.</p>
@@ -39,7 +44,7 @@ description: |-
                     {% endif %}
                     <div class="plus-icon"><i class="fas fa-minus fa-lg"></i></div>
                 </td>
-            </tr>                
+            </tr>
             {% else %}
             <tr class="profile-row collapsed" style="cursor: pointer;" data-toggle="collapse" data-target=".collapse{{profile.name}}" aria-expanded="false" aria-controls="collapse{{profile.name}}">
                 <td colspan="3">
@@ -71,7 +76,7 @@ description: |-
                     <div class="collapse show collapse{{profile.name}}">
                     {% else %}
                     <div class="collapse collapse{{profile.name}}">
-                    {% endif %}                    
+                    {% endif %}
                     {{live.bsc_ver}}
                     </div>
                 </td>
@@ -81,7 +86,7 @@ description: |-
                     <div class="collapse show collapse{{profile.name}}">
                     {% else %}
                     <div class="collapse collapse{{profile.name}}">
-                    {% endif %}                    
+                    {% endif %}
                     <div class="google-sdtt-button">
                         <span class="tooltiptext">Visualise on GTest tool</span>
                         <a href="https://search.google.com/structured-data/testing-tool#url={{live.example_URL}}" class="btn btn-bioschema btn-block" target="_blank">visualise</a>
@@ -92,9 +97,25 @@ description: |-
             </tr>
             {% endfor %}
             {% endfor %}
-            </tbody>            
+            </tbody>
         </table>
     </section>
+  </div>
+
+  <div class="col-md-4 right-column">
+
+      <section class="upcoming-events">
+          <h3>Deployment Stories</h3>
+          <div class="event">
+              <strong><a href="https://www.dtls.nl/2018/07/19/toxicology-data-management-tutorials-automatically-collected-by-european-training-portal-tess/">Toxicology data management tutorials automatically collected by European training portal TeSS</a></strong>
+              <p> <strong>19/7/2018</strong> <p/>
+              <p>
+                BioSchemas used to create a system that automatically pulls toxicology-related training materials from the eNanoMapper project into the European training portal TeSS.
+              </p>
+          </div class="event">
+        </section>
+    </div>
+  </div>
     <blockquote>
         <h6>Note:</h6>
         As we do not maintain the websites listed above we can not guarantee the list is up to date, the sites are live and feature appropriate content or the links work.

--- a/liveDeploys/index.html
+++ b/liveDeploys/index.html
@@ -105,14 +105,22 @@ description: |-
   <div class="col-md-4 right-column">
 
       <section class="upcoming-events">
-          <h3>Deployment Stories</h3>
+        <h3>Deployment Stories</h3>
+          {% assign sorted_stories = (site.stories | sort: 'date-added') %}
+          {% for story in sorted_stories %}
           <div class="event">
-              <strong><a href="https://www.dtls.nl/2018/07/19/toxicology-data-management-tutorials-automatically-collected-by-european-training-portal-tess/">Toxicology data management tutorials automatically collected by European training portal TeSS</a></strong>
-              <p> <strong>19/7/2018</strong> <p/>
+              <strong><a href="{{ story.external-url }}">{{ story.name }}</a></strong>
+              <p> <strong>{{ story.date-added }}</strong> </p>
+              <ul>
+                {% for spec in story.specs %}
+                  <li>{{ spec }}</li>
+                {% endfor %}
+              </ul>
               <p>
-                BioSchemas used to create a system that automatically pulls toxicology-related training materials from the eNanoMapper project into the European training portal TeSS.
+                {{ story.description }}
               </p>
           </div class="event">
+          {% endfor %}
         </section>
     </div>
   </div>

--- a/liveDeploys/index.html
+++ b/liveDeploys/index.html
@@ -106,7 +106,7 @@ description: |-
 
       <section class="upcoming-events">
         <h3>Deployment Stories</h3>
-          {% assign sorted_stories = (site.stories | sort: 'date-added') %}
+          {% assign sorted_stories = (site.stories | sort: 'date-added' | reverse ) %}
           {% for story in sorted_stories %}
           <div class="event">
               <strong><a href="{{ story.external-url }}">{{ story.name }}</a></strong>


### PR DESCRIPTION
I've added a way to list success stories of Bioschemas to the live deploy page. These show as a column to the right of the table of live deploys and link to external pages that give more details of the deployment story (see screenshot).

What do you think of the way I have done this? What could be improved?

![screen shot 2018-08-10 at 16 04 37](https://user-images.githubusercontent.com/1141265/43965439-24790010-9cb7-11e8-82fe-771f408e2b9a.png)
