### PR TITLE
Update draft types inline with proposals made to community

### DIFF
--- a/_devTypes/BioChemEntity.html
+++ b/_devTypes/BioChemEntity.html
@@ -141,11 +141,10 @@ external: #454547;
                          <a href="http://schema.org/URL">URL</a>
                        </td>
                        <td>
-                         <strong>Schema</strong>: An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax.
+                         An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax.
                          This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax -
                          the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those
-                         defined externally. <br />
-                         <strong>Bioschemas</strong>:  Whenever a suitable profile exists, the profile type should be used in addition to the BioChemEntity type. Other additional types are always possible via the additionalType property. For instance, http://purl.obolibrary.org/obo/PR_000000001 is the type used for the Protein profile but http://semanticscience.org/resource/SIO_010043 or https://www.wikidata.org/wiki/Q8054 can be used as an additionalType if that is useful to the data providers.
+                         defined externally.
                        </td>
                      </tr>
                      <tr>
@@ -154,7 +153,7 @@ external: #454547;
                          <a href="http://schema.org/Text">Text</a>
                        </td>
                        <td>
-                         <strong>Schema</strong>: An alias for the item.
+                         An alias for the item.
                        </td>
                      </tr>
                      <tr>
@@ -163,7 +162,7 @@ external: #454547;
                          <a href="http://schema.org/Text">Text</a>
                        </td>
                        <td>
-                         <strong>Schema</strong>: A descripton of the item.
+                         A descripton of the item.
                        </td>
                      </tr>
                      <tr>
@@ -172,40 +171,42 @@ external: #454547;
                          <a href="http://schema.org/Text">Text</a>
                        </td>
                        <td>
-                         <strong>Schema</strong>: A sub property of description. A short description of the item used to disambiguate from other, similar items.
-                         Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.
+                         A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.
                        </td>
                      </tr>
                      <tr>
                        <th><a href="http://schema.org/identifier">identifier</a></th>
                        <td>
-                         <a href="http://schema.org/PropertyValue">PropertyValue</a><br /><a href="http://schema.org/Text">Text</a><br /><a href="http://schema.org/URL">URL</a>
+                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
+                         <a href="http://schema.org/Text">Text</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
                        </td>
                        <td>
-                         <strong>Schema</strong>: The identifier property represents any kind of identifier for any kind of <a href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc.
+                         The identifier property represents any kind of identifier for any kind of <a href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc.
                          Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links.
-                         See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details. <br/>
-                         <strong>Bioschemas</strong>: We recommend you use either an authoritative source or identifiers.org whenever possible.
+                         See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.
                        </td>
                      </tr>
                      <tr>
                        <th><a href="http://schema.org/image">image</a></th>
                        <td>
-                         <a href="http://schema.org/ImageObject">ImageObject</a><br /><a href="http://schema.org/URL">URL</a>
+                         <a href="http://schema.org/ImageObject">ImageObject</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
                        </td>
                        <td>
-                         <strong>Schema</strong>: An image of the item. This can be a <a href="http://schema.org/URL">URL</a> or a fully described <a href="http://schema.org/ImageObject">ImageObject</a>.
+                         An image of the item. This can be a <a href="http://schema.org/URL">URL</a> or a fully described <a href="http://schema.org/ImageObject">ImageObject</a>.
                        </td>
                      </tr>
                      <tr>
                        <th><a href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></th>
                        <td>
-                         <a href="http://schema.org/CreativeWork">CreativeWork</a><br /><a href="http://schema.org/URL">URL</a>
+                         <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
                        </td>
                        <td>
-                         <strong>Schema</strong>: Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See
-                         <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br />
-                         <strong>Bioschemas</strong>: Link via DataRecord or <a href="http://schema.org/URL">URL</a> to the main DataRecord representing this entity in a dataset.<br />
+                         Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See
+                         <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/>
+                         Inverse property: <a href="http://schema.org/mainEntity">mainEntity</a>
                        </td>
                      </tr>
                      <tr>
@@ -214,7 +215,7 @@ external: #454547;
                          <a href="http://schema.org/Text">Text</a>
                        </td>
                        <td>
-                         <strong>Schema</strong>: The name of the item.
+                         The name of the item.
                        </td>
                      </tr>
                      <tr>
@@ -223,7 +224,7 @@ external: #454547;
                          <a href="http://schema.org/Action">Action</a>
                        </td>
                        <td>
-                         <strong>Schema</strong>: Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.
+                         Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.
                        </td>
                      </tr>
                      <tr>
@@ -232,16 +233,18 @@ external: #454547;
                          <a href="http://schema.org/URL">URL</a>
                        </td>
                        <td>
-                         <strong>Schema</strong>: URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.
+                         URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.
                        </td>
                      </tr>
                      <tr>
                        <th><a style="color: #0000CC;" href="http://pending.schema.org/subjectOf">subjectOf</a></th>
                        <td>
-                         <a href="http://schema.org/CreativeWork">CreativeWork</a><br /><a href="http://schema.org/Event">Event</a>
+                         <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
+                         <a href="http://schema.org/Event">Event</a>
                        </td>
                        <td>
-                         <strong>Schema</strong>: A CreativeWork or Event about this Thing. <em>Inverse property: about.</em>
+                         A CreativeWork or Event about this Thing..<br/>
+                         Inverse property: <a href="http://schema.org/about">about</a>.
                        </td>
                      </tr>
                      <tr>
@@ -250,8 +253,7 @@ external: #454547;
                          <a href="http://schema.org/URL">URL</a>
                        </td>
                        <td>
-                         <strong>Schema</strong>: URL of the item.<br />
-                         <strong>Bioschemas</strong>: Link to the official webpage associated to this entity.
+                         URL of the item.
                        </td>
                      </tr>
                    </tbody>

--- a/_devTypes/BioChemEntity.html
+++ b/_devTypes/BioChemEntity.html
@@ -45,7 +45,7 @@ external: #454547;
                    <tbody>
                      <tr class="new_props_sdo">
                         <td colspan="3">
-                           Properties from <a style="color: #0B794B;" href="#">{{page.name}}</a> (pending schema.org integration).
+                           Properties from <a style="color: #0B794B;" href="/{{page.name}}">{{page.name}}</a> (pending schema.org integration).
                         </td>
                      </tr>
                      <tr id="additionalProperty">

--- a/_devTypes/BioChemEntity.html
+++ b/_devTypes/BioChemEntity.html
@@ -1,23 +1,18 @@
 ---
 redirect_from: "devTypes/BioChemEntity/specification"
 redirect_from: "devTypes/BioChemEntity/specification/"
-dateModified: 2018-03-01
-description: A BioChemEntity is any object that exists in the physical world representing biological, chemical and biochemical entities, and cannot be better represented with any other existing type in schema.org (for instance there is a full extension for the Medical field).
-  <br />
-  <br />
-  <em>Bioschemas usage</em>
-  <br />
-  As BioChemEntity is a generic, flexible and extensible wrapper for entitties in Life Sciences. Specialized types (a.k.a. profiles in Bioschemas) should customize BioChemEntity by modifying the marginality, cardinality and specify what ontologies and terms should be used per property (if applicable). Profiles should be as specific as possible. For instance, a protein profile would recommend pointing to an organism as part of the minimum information, but not necessarily to a sample or disease. Representations of physical entities in Life Sciences are usually recorded in datasets; the link to a dataset should be done via properties, i.e., mainEntityOfPage. Whenever a suitable profile exists, the profile type should be used in addition to the BioChemEntity type. For instance, both BioChemEntity and Protein would be the types assigned to a protein. Other additional types are always possible via the additionalType property. For instance, <a href="http://purl.obolibrary.org/obo/PR_000000001">http://purl.obolibrary.org/obo/PR_000000001</a> is the official type used for the Protein profile but <a href="http://semanticscience.org/resource/SIO_010043">http://semanticscience.org/resource/SIO_010043</a> or <a href="https://www.wikidata.org/wiki/Q8054">https://www.wikidata.org/wiki/Q8054</a> can be used as an additionaType if that results useful somehow to the data providers.
+dateModified: 2018-11-06
+description: "Any biological, chemical, or biochemical thing. For example: a protein; a gene; a chemical; a synthetic chemical."
 hierarchy:
 - Thing
+- Intangible
 gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20BioChemEntity
 group: biologicalentities
 name: BioChemEntity
-parent_type: Thing
+parent_type: Intangible
 spec_type: Type
 status: revision
-subtitle: Bioschemas specification describing a biological, chemical or biochemical entity that exists in the physical world
-version: '0.5'
+version: '0.6-DRAFT'
 
 bsc: #0B794B;
 pending: #0000CC;
@@ -50,80 +45,93 @@ external: #454547;
                    <tbody>
                      <tr class="new_props_sdo">
                         <td colspan="3">
-                           New properties for <a style="color: #0B794B;" href="#">{{page.name}}</a> (pending schema.org integration).
+                           Properties from <a style="color: #0B794B;" href="#">{{page.name}}</a> (pending schema.org integration).
                         </td>
                      </tr>
-                     <tr>
+                     <tr id="additionalProperty">
                        <th><a href="http://schema.org/additionalProperty">additionalProperty</th>
                        <td>
                          <a href="http://schema.org/PropertyValue">PropertyValue</a>
                        </td>
-                       <td><strong>Schema</strong>: A property-value pair representing an additional characteristics of the entitity, e.g. a product feature or another characteristic for which there is no matching property in schema.org.
-Note: Publishers should be aware that applications designed to use specific schema.org properties (e.g. http://schema.org/width, http://schema.org/color, http://schema.org/gtin13, ...) will typically expect such data to be provided using those properties, rather than using the generic property/value mechanism.<br />
-                        Note: Publishers should be aware that applications designed to use specific schema.org properties (e.g. http://schema.org/width, http://schema.org/color, http://schema.org/gtin13, ...) will typically expect such data to be provided using those properties, rather than using the generic property/value mechanism.<br/>
-                        <strong>Bioschemas</strong>: Whenever possible, please use a property coined in a third-party well-known vocabulary. For instance, you can directly use http://purl.obolibrary.org/obo/RO_0002327 as a property to express how a protein or gene enables some GO molecular function.
-                        If you still want or need to use additionalProperty, please use (i) property name to specify the name of the property, (ii) additionalType (if possible) to better specify the nature of the property, and (iii) value to link to the object/range of this property.
+                       <td>A property-value pair representing an additional characteristics of the entitity, e.g. a product feature or another characteristic for which there is no matching property in schema.org. <br/>
+                         Note: Publishers should be aware that applications designed to use specific schema.org properties (e.g. http://schema.org/width, http://schema.org/color, http://schema.org/gtin13, ...) will typically expect such data to be provided using those properties, rather than using the generic property/value mechanism.<br />
                       </td>
                      </tr>
-                     <tr id="hasCategoryCode">
-                       <th style="color: #0B794B;">hasCategoryCode</th>
+                     <tr id="associatedDisease">
+                       <th style="color: #0B794B;">associatedDisease</th>
                        <td>
-                         <a style="color: #0000CC;" href="http://pending.schema.org/CategoryCode">CategoryCode</a>
+                         <a href="http://schema.org/MedicalCondition">MedicalCondition</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
                        </td>
-                       <td><strong>Bioschemas</strong>: A controlled vocabulary term equivalent to this entity. For instance, an organism coined in NCBI taxonomy can be represented as a BioChemEntity. As it also exists as a term in an ontology, it would be nice to capture that information via categoryCode.
+                       <td>
+                         Disease associated to this BioChemEntity.
                        </td>
                      </tr>
                      <tr id="contains">
                        <th style="color: #0B794B;">contains</th>
                        <td>
-                         <a style="color: #0B794B;" href="#">BioChemEntity</a><br><a href="http://schema.org/URL">URL</a>
+                         <a style="color: #0B794B;" href="/BioChemEntity">BioChemEntity</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
                        </td>
-                       <td><strong>Bioschemas</strong>: Indicates a BioChemEntity that is (in some sense) a part of this BioChemEntity. <em>Inverse property: isContainedIn.</em>
-                          <a style="color: #0B794B;" href="#">contains</a> is equivalent to <a href="http://schema.org/isPartOf">isPartOf</a> but with BioChemEntuty as both the domain and range.
+                       <td>
+                         Indicates a BioChemEntity that is (in some sense) a part of this BioChemEntity. <br/>
+                         Inverse property: isContainedIn
                        </td>
                      </tr>
                      <tr id="hasRepresentation">
                        <th style="color: #0B794B;">hasRepresentation</th>
                        <td>
-                         <a href="http://schema.org/PropertyValue">PropertyValue</a><br><a href="http://schema.org/Text">Text</a><br /><a href="http://schema.org/URL">URL</a>
+                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
+                         <a href="http://schema.org/Text">Text</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
                        </td>
-                       <td><strong>Bioschemas</strong>: A representation for this entity other than, for instance, an image (use image property for that) or the main web page/record
-                         (use mainEntityOfPage for that), and see <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a>, for sameAs and url).
-                         <strong>Bioschemas usage</strong>: This property could be used, for instance, to register a sequence protein as it is a representation of the protein. If you want to better define the nature of the representation, use a PropertyValue as described in additionalProperty.
+                       <td>
+                         A common representation such as a protein sequence or chemical structure for this entity. For images use schema.org/image.
                        </td>
                      </tr>
                      <tr id="isContainedIn">
                        <th style="color: #0B794B;">isContainedIn</th>
                        <td>
-                         <a style="color: #0B794B;" href="#">BioChemEntity</a><br><a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         <strong>Bioschemas</strong>: Indicates a BioChemEntity that is (in some sense) a part of this BioChemEntity. <em>Inverse property: containedIn.</em> <a style="color: #0B794B;" href="#">isContainedIn<a/> is equivalent to <a href="http://schemma.org/isPartOf">isPartOf</a> but with BioChemEntity as domain and range.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a style="color: #0B794B;" href="http://schema.org/location">location</a></th>
-                       <td>
-                         <a href="http://schema.org/Place">Place</a><br /><a href="http://schema.org/PostalAddress">PostalAddress</a><br />
-                         <a href="http://schema.org/PropertyValue">PropertyValue</a><br /><a href="http://schema.org/Text">Text</a><br />
+                         <a style="color: #0B794B;" href="/BioChemEntity">BioChemEntity</a> or<br/>
                          <a href="http://schema.org/URL">URL</a>
                        </td>
                        <td>
-                         <strong>Schema</strong>: The location of for example where the event is happening, an organization is located, or where an action takes place.<br/>
-                         <strong>Bioschemas</strong>: The location can refer to a position in the chromosome or sequence or to a physical place where, for instance, a
-                         sample is stored. Using additionalType is advised to make the distinction. For instance, <a href="https://github.com/OBF/FALDO">FALDO</a> or <a href="http://schema.org/PropertyValue">PropertyValue</a> (with properties value, minValue and maxValue) can be used for sequence coordinates.<br />
-                         <u><strong>Note</strong></u>: The list of Expected Types has been extended as <a href="http://schema.org/location">schema.org/location</a> only has Place, PostalAddress and Text.
+                         Indicates a BioChemEntity that (in some sense) has this BioChemEntity as a part.<br/>
+                         Inverse property: contains
                        </td>
                      </tr>
-                     <!-- <tr id="preferredLabel">
-                       <th style="color: #0B794B;">preferredLabel</th>
+                     <tr>
+                       <th><a href="http://schema.org/location">location</a></th>
                        <td>
-                         <a href="http://schema.org/Text">Text</a>
+                         <a href="http://schema.org/Place">Place</a> or<br/><a href="http://schema.org/PostalAddress">PostalAddress</a> or<br/>
+                         <a href="http://schema.org/Text">Text</a><br/>
                        </td>
                        <td>
-                         <strong>Bioschemas</strong>:  Indicates the preferred label to refer to a specific (sub)type of BioChemEntity.
+                         The location of for example where the event is happening, an organization is located, or where an action takes place.
                        </td>
-                     </tr> -->
+                     </tr>
+                     <tr id="taxonomicRange">
+                       <th style="color: #0B794B;">taxonomicRange</th>
+                       <td>
+                         <a style="color: #0B794B;" href="/Taxon">Taxon</a> or<br/>
+                         <a href="http://schema.org/Text">Text</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         The taxonomic grouping of the organism that expresses, encodes, or in someway related to the BioChemEntity.
+                       </td>
+                     </tr>
+                     <tr id="position">
+                       <th style="color: #0B794B;">position</th>
+                       <td>
+                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
+                         <a href="http://schema.org/Text">Text</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         Refers to a position in the chromosome or sequence. For instance, FALDO can be used for sequence coordinates.
+                       </td>
+                     </tr>
                      <tr class="reu_props_sdo">
                         <td colspan="3">Properties from <a href="http://schema.org/Thing">Thing</a></td>
                      </tr>

--- a/_devTypes/BioChemEntity.html
+++ b/_devTypes/BioChemEntity.html
@@ -110,17 +110,6 @@ external: #454547;
                          The location of for example where the event is happening, an organization is located, or where an action takes place.
                        </td>
                      </tr>
-                     <tr id="taxonomicRange">
-                       <th style="color: #0B794B;">taxonomicRange</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/Taxon">Taxon</a> or<br/>
-                         <a href="http://schema.org/Text">Text</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         The taxonomic grouping of the organism that expresses, encodes, or in someway related to the BioChemEntity.
-                       </td>
-                     </tr>
                      <tr id="position">
                        <th style="color: #0B794B;">position</th>
                        <td>
@@ -130,6 +119,17 @@ external: #454547;
                        </td>
                        <td>
                          Refers to a position in the chromosome or sequence. For instance, FALDO can be used for sequence coordinates.
+                       </td>
+                     </tr>
+                     <tr id="taxonomicRange">
+                       <th style="color: #0B794B;">taxonomicRange</th>
+                       <td>
+                         <a style="color: #0B794B;" href="/Taxon">Taxon</a> or<br/>
+                         <a href="http://schema.org/Text">Text</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         The taxonomic grouping of the organism that expresses, encodes, or in someway related to the BioChemEntity.
                        </td>
                      </tr>
                      <tr class="reu_props_sdo">

--- a/_devTypes/BioChemEntity.html
+++ b/_devTypes/BioChemEntity.html
@@ -110,8 +110,8 @@ external: #454547;
                          The location of for example where the event is happening, an organization is located, or where an action takes place.
                        </td>
                      </tr>
-                     <tr id="position">
-                       <th style="color: #0B794B;">position</th>
+                     <tr id="positionInRepresentation">
+                       <th style="color: #0B794B;">positionInRepresentation</th>
                        <td>
                          <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
                          <a href="http://schema.org/Text">Text</a> or<br/>

--- a/_devTypes/DataRecord.html
+++ b/_devTypes/DataRecord.html
@@ -146,12 +146,13 @@ external: #454547;
                        <td colspan="3">Properties from <a href="http://schema.org/CreativeWork">CreativeWork</a></td>
                      </tr>
                      <tr>
-                        <th><a style="color: #0000CC;" href="http://pending.schema.org/about">about</a></th>
+                        <th><a href="http://schema.org/about">about</a></th>
                         <td>
                            <a href="http://schema.org/Thing">Thing</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: The subject matter of the content. <em>Inverse property: subjectOf.</em>
+                          The subject matter of the content. <br/>
+                          Inverse property: subjectOf.
                         </td>
                      </tr>
                      <tr>
@@ -160,7 +161,7 @@ external: #454547;
                            <a href="http://schema.org/Text">Text</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: The human sensory perceptual system or cognitive faculty through which a person may process or perceive information. Expected values include: auditory, tactile, textual, visual, colorDependent, chartOnVisual, chemOnVisual, diagramOnVisual, mathOnVisual, musicOnVisual, textOnVisual.
+                          The human sensory perceptual system or cognitive faculty through which a person may process or perceive information. Expected values include: auditory, tactile, textual, visual, colorDependent, chartOnVisual, chemOnVisual, diagramOnVisual, mathOnVisual, musicOnVisual, textOnVisual.
                         </td>
                      </tr>
                      <tr>
@@ -169,7 +170,7 @@ external: #454547;
                            <a href="http://schema.org/Text">Text</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: A list of single or combined accessModes that are sufficient to understand all the intellectual content of a resource. Expected values include: auditory, tactile, textual, visual.
+                          A list of single or combined accessModes that are sufficient to understand all the intellectual content of a resource. Expected values include: auditory, tactile, textual, visual.
                         </td>
                      </tr>
                      <tr>
@@ -178,7 +179,7 @@ external: #454547;
                            <a href="http://schema.org/Text">Text</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: Indicates that the resource is compatible with the referenced accessibility API (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).
+                          Indicates that the resource is compatible with the referenced accessibility API (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).
                         </td>
                      </tr>
                      <tr>
@@ -187,7 +188,7 @@ external: #454547;
                            <a href="http://schema.org/Text">Text</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: Identifies input methods that are sufficient to fully control the described resource (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).
+                          Identifies input methods that are sufficient to fully control the described resource (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).
                         </td>
                      </tr>
                      <tr>
@@ -196,7 +197,7 @@ external: #454547;
                            <a href="http://schema.org/Text">Text</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: Content features of the resource, such as accessible media, alternatives and supported enhancements for accessibility (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).
+                          Content features of the resource, such as accessible media, alternatives and supported enhancements for accessibility (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).
                         </td>
                      </tr>
                      <tr>
@@ -205,7 +206,7 @@ external: #454547;
                            <a href="http://schema.org/Text">Text</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: A characteristic of the described resource that is physiologically dangerous to some users. Related to WCAG 2.0 guideline 2.3 (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).
+                          A characteristic of the described resource that is physiologically dangerous to some users. Related to WCAG 2.0 guideline 2.3 (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).
                         </td>
                      </tr>
                      <tr>
@@ -214,7 +215,7 @@ external: #454547;
                            <a href="http://schema.org/Text">Text</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: A human-readable summary of specific accessibility features or deficiencies, consistent with the other accessibility metadata but expressing subtleties such as "short descriptions are present but long descriptions will be needed for non-visual users" or "short descriptions are present and no long descriptions are needed."
+                          A human-readable summary of specific accessibility features or deficiencies, consistent with the other accessibility metadata but expressing subtleties such as "short descriptions are present but long descriptions will be needed for non-visual users" or "short descriptions are present and no long descriptions are needed."
                         </td>
                      </tr>
                      <tr>
@@ -223,7 +224,7 @@ external: #454547;
                            <a href="http://schema.org/Person">Person</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: Specifies the Person that is legally accountable for the CreativeWork.
+                          Specifies the Person that is legally accountable for the CreativeWork.
                         </td>
                      </tr>
                      <tr>
@@ -232,7 +233,7 @@ external: #454547;
                            <a href="http://schema.org/AggregateRating">AggregateRating</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: The overall rating, based on a collection of reviews or ratings, of the item.
+                          The overall rating, based on a collection of reviews or ratings, of the item.
                         </td>
                      </tr>
                      <tr>
@@ -241,7 +242,7 @@ external: #454547;
                            <a href="http://schema.org/Text">Text</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: A secondary title of the CreativeWork.
+                          A secondary title of the CreativeWork.
                         </td>
                      </tr>
                      <tr>
@@ -250,7 +251,7 @@ external: #454547;
                            <a href="http://schema.org/MediaObject">MediaObject</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: A media object that encodes this CreativeWork. This property is a synonym for encoding.
+                          A media object that encodes this CreativeWork. This property is a synonym for encoding.
                         </td>
                      </tr>
                      <tr>
@@ -259,7 +260,7 @@ external: #454547;
                            <a href="http://schema.org/Audience">Audience</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: An intended audience, i.e. a group for whom something was created. Supersedes serviceAudience.
+                          An intended audience, i.e. a group for whom something was created. Supersedes <a href="https://schema.org/serviceAudience">serviceAudience</a>.
                         </td>
                      </tr>
                      <tr>
@@ -268,17 +269,17 @@ external: #454547;
                            <a href="http://schema.org/AudioObject">AudioObject</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: An embedded audio object.
+                          An embedded audio object.
                         </td>
                      </tr>
                      <tr>
                         <th><a href="http://schema.org/author">author</a></th>
                         <td>
-                           <a href="http://schema.org/Organization">Organization</a><br />
+                           <a href="http://schema.org/Organization">Organization</a> or<br/>
                            <a href="http://schema.org/Person">Person</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.
+                          The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.
                         </td>
                      </tr>
                      <tr>
@@ -287,7 +288,7 @@ external: #454547;
                            <a href="http://schema.org/Text">Text</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: An award won by or for this item. Supersedes awards.
+                          An award won by or for this item. Supersedes <a href="https://schema.org/awards">awards</a>.
                         </td>
                      </tr>
                      <tr>
@@ -296,17 +297,17 @@ external: #454547;
                            <a href="http://schema.org/Person">Person</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: Fictional person connected with a creative work.
+                          Fictional person connected with a creative work.
                         </td>
                      </tr>
                      <tr>
                         <th><a href="http://schema.org/citation">citation</a></th>
                         <td>
-                           <a href="http://schema.org/CreativeWork">CreativeWork</a><br />
+                           <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
                            <a href="http://schema.org/Text">Text</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: A citation or reference to another creative work, such as another publication, web page, scholarly article, etc.
+                          A citation or reference to another creative work, such as another publication, web page, scholarly article, etc.
                         </td>
                      </tr>
                      <tr>
@@ -315,7 +316,7 @@ external: #454547;
                            <a href="http://schema.org/Comment">Comment</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: Comments, typically from users.
+                          Comments, typically from users.
                         </td>
                      </tr>
                      <tr>
@@ -324,7 +325,7 @@ external: #454547;
                            <a href="http://schema.org/Integer">Integer</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: The number of comments this CreativeWork (e.g. Article, Question or Answer) has received. This is most applicable to works published in Web sites with commenting system; additional comments may exist elsewhere.
+                          The number of comments this CreativeWork (e.g. Article, Question or Answer) has received. This is most applicable to works published in Web sites with commenting system; additional comments may exist elsewhere.
                         </td>
                      </tr>
                      <tr>
@@ -333,7 +334,7 @@ external: #454547;
                            <a href="http://schema.org/Place">Place</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: The location depicted or described in the content. For example, the location in a photograph or painting.
+                          The location depicted or described in the content. For example, the location in a photograph or painting.
                         </td>
                      </tr>
                      <tr>
@@ -342,7 +343,7 @@ external: #454547;
                            <a href="http://schema.org/Text">Text</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: Official rating of a piece of content—for example,'MPAA PG-13'.
+                          Official rating of a piece of content—for example,'MPAA PG-13'.
                         </td>
                      </tr>
                      <tr>
@@ -351,25 +352,25 @@ external: #454547;
                            <a href="http://schema.org/DateTime">DateTime</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: The specific time described by a creative work, for works (e.g. articles, video objects etc.) that emphasise a particular moment within an Event.
+                          The specific time described by a creative work, for works (e.g. articles, video objects etc.) that emphasise a particular moment within an Event.
                         </td>
                      </tr>
                      <tr>
                         <th><a href="http://schema.org/contributor">contributor</a></th>
                         <td>
-                           <a href="http://schema.org/Organization">Organization</a><br /><a href="http://schema.org/Person">Person</a>
+                           <a href="http://schema.org/Organization">Organization</a> or<br/><a href="http://schema.org/Person">Person</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: A secondary contributor to the CreativeWork or Event.
+                          A secondary contributor to the CreativeWork or Event.
                         </td>
                      </tr>
                      <tr>
                         <th><a href="http://schema.org/copyrightHolder">copyrightHolder</a></th>
                         <td>
-                           <a href="http://schema.org/Organization">Organization</a><br /><a href="http://schema.org/Person">Person</a>
+                           <a href="http://schema.org/Organization">Organization</a> or<br/><a href="http://schema.org/Person">Person</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: The party holding the legal copyright to the CreativeWork.
+                          The party holding the legal copyright to the CreativeWork.
                         </td>
                      </tr>
                      <tr>
@@ -378,40 +379,53 @@ external: #454547;
                            <a href="http://schema.org/Number">Number</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: The year during which the claimed copyright for the CreativeWork was first asserted.
+                          The year during which the claimed copyright for the CreativeWork was first asserted.
+                        </td>
+                     </tr>
+                     <tr>
+                        <th>
+                          <a style="color: #0000CC;" href="http://pending.schema.org/correction">correction</a>
+                        </th>
+                        <td>
+                           <a href="http://pending.schema.org/CorrectionComment">CorrectionComment</a> or<br/>
+                           <a href="http://schema.org/Text">Text</a> or<br/>
+                           <a href="http://schema.org/URL">URL</a>
+                        </td>
+                        <td>
+                          Indicates a correction to a <a href="https://schema.org/CreativeWork">CreativeWork</a>, either via a <a href="https://schema.org/CorrectionComment">CorrectionComment</a>, textually or in another document.
                         </td>
                      </tr>
                      <tr>
                         <th><a href="http://schema.org/creator">creator</a></th>
                         <td>
-                           <a href="http://schema.org/Number">Organization</a><br /><a href="http://schema.org/Person">Person</a>
+                           <a href="http://schema.org/Number">Organization</a> or<br/><a href="http://schema.org/Person">Person</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: The creator/author of this CreativeWork. This is the same as the Author property for CreativeWork.
+                          The creator/author of this CreativeWork. This is the same as the Author property for CreativeWork.
                         </td>
                      </tr>
                      <tr>
                         <th><a href="http://schema.org/dateCreated">dateCreated</a></th>
                         <td>
-                           <a href="http://schema.org/Date">Date</a><br />
+                           <a href="http://schema.org/Date">Date</a> or<br/>
                            <a href="http://schema.org/DateTime">DateTime</a>
                         </td>
-                        <td><strong>Schema</strong>: The date on which the CreativeWork was created or the item was added to a DataFeed.</td>
+                        <td>The date on which the CreativeWork was created or the item was added to a DataFeed.</td>
                      </tr>
                      <tr>
                         <th><a href="http://schema.org/dateModified">dateModified</a></th>
                         <td>
-                           <a href="http://schema.org/Date">Date</a><br />
+                           <a href="http://schema.org/Date">Date</a> or<br/>
                            <a href="http://schema.org/DateTime">DateTime</a>
                         </td>
-                        <td><strong>Schema</strong>: The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.</td>
+                        <td>The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.</td>
                      </tr>
                      <tr>
                         <th><a href="http://schema.org/datePublished">datePublished</a></th>
                         <td>
                            <a href="http://schema.org/Date">Date</a>
                         </td>
-                        <td><strong>Schema</strong>: Date of first broadcast/publication.</td>
+                        <td>Date of first broadcast/publication.</td>
                      </tr>
                      <tr>
                         <th><a href="http://schema.org/discussionUrl">discussionUrl</a></th>
@@ -419,7 +433,7 @@ external: #454547;
                            <a href="http://schema.org/URL">URL</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: A link to the page containing the comments of the CreativeWork.
+                          A link to the page containing the comments of the CreativeWork.
                         </td>
                      </tr>
                      <tr>
@@ -428,7 +442,7 @@ external: #454547;
                            <a href="http://schema.org/Person">Person</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: Specifies the Person who edited the CreativeWork.
+                          Specifies the Person who edited the CreativeWork.
                         </td>
                      </tr>
                      <tr>
@@ -437,7 +451,7 @@ external: #454547;
                            <a href="http://schema.org/AlignmentObject">AlignmentObject</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: An alignment to an established educational framework.
+                          An alignment to an established educational framework.
                         </td>
                      </tr>
                      <tr>
@@ -446,7 +460,7 @@ external: #454547;
                            <a href="http://schema.org/Text">Text</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: The purpose of a work in the context of education; for example, 'assignment', 'group work'.
+                          The purpose of a work in the context of education; for example, 'assignment', 'group work'.
                         </td>
                      </tr>
                      <tr>
@@ -455,7 +469,21 @@ external: #454547;
                            <a href="http://schema.org/MediaObject">MediaObject</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: A media object that encodes this CreativeWork. This property is a synonym for associatedMedia. Supersedes encodings.
+                          A media object that encodes this CreativeWork. This property is a synonym for associatedMedia. Supersedes <a href="https://schema.org/encodings">encodings</a>.
+                        </td>
+                     </tr>
+                     <tr>
+                        <th><a href="http://schema.org/encodingFormat">encodingFormat</a></th>
+                        <td>
+                           <a href="http://schema.org/Text">Text</a> or<br/>
+                           <a href="http://schema.org/URL">URL</a>
+                        </td>
+                        <td>
+                          Media type typically expressed using a MIME format (see <a href="http://www.iana.org/assignments/media-types/media-types.xhtml">IANA</a> site and <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MDN reference</a>) e.g. application/zip for a SoftwareApplication binary, audio/mpeg for .mp3 etc.).
+                          <br/>
+                          In cases where a <a href="https://schema.org/CreativeWork">CreativeWork</a> has several media type representations, <a href="https://schema.org/encoding">encoding</a> can be used to indicate each <a href="https://schema.org/MediaObject">MediaObject</a> alongside particular <a href="https://schema.org/encodingFormat">encodingFormat</a> information.
+                          <br/>
+                          Unregistered or niche encoding and file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia/Wikidata entry. Supersedes <a href="https://schema.org/fileFormat">fileFormat</a>.
                         </td>
                      </tr>
                      <tr>
@@ -464,7 +492,8 @@ external: #454547;
                            <a href="http://schema.org/CreativeWork">CreativeWork</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: A creative work that this work is an example/instance/realization/derivation of. <em>Inverse property: <a href="http://schema.org/workExample">workExample</a>.</em>
+                          A creative work that this work is an example/instance/realization/derivation of.<br/>
+                          Inverse property: <a href="http://schema.org/workExample">workExample</a>.
                         </td>
                      </tr>
                      <tr>
@@ -473,43 +502,38 @@ external: #454547;
                            <a href="http://schema.org/Date">Date</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: Date the content expires and is no longer useful or available. For example a <a href="http://schema.org/VideoObject">VideoObject</a> or <a href="http://schema.org/NewsArticle">NewsArticle</a> whose availability or relevance is time-limited, or a <a href="http://schema.org/ClaimReview">ClaimReview</a> fact check whose publisher wants to indicate that it may no longer be relevant (or helpful to highlight) after some date.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/fileFormat">fileFormat</a></th>
-                        <td>
-                           <a href="http://schema.org/Text">Text</a><br /><a href="http://schema.org/URL">URL</a>
-                        </td>
-                        <td>
-                          <strong>Schema</strong>: Media type, typically MIME format (see <a href="http://www.iana.org/assignments/media-types/media-types.xhtml">IANA site</a>) of the content e.g. application/zip of a SoftwareApplication binary. In cases where a CreativeWork has several media type representations, 'encoding' can be used to indicate each MediaObject alongside particular fileFormat information. Unregistered or niche file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia entry.
+                          Date the content expires and is no longer useful or available. For example a <a href="http://schema.org/VideoObject">VideoObject</a> or <a href="http://schema.org/NewsArticle">NewsArticle</a> whose availability or relevance is time-limited, or a <a href="http://schema.org/ClaimReview">ClaimReview</a> fact check whose publisher wants to indicate that it may no longer be relevant (or helpful to highlight) after some date.
                         </td>
                      </tr>
                      <tr>
                         <th><a href="http://schema.org/funder">funder</a></th>
                         <td>
-                           <a href="http://schema.org/Organization">Organization</a><br /><a href="http://schema.org/Person">Person</a>
+                           <a href="http://schema.org/Organization">Organization</a> or<br/>
+                           <a href="http://schema.org/Person">Person</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: A person or organization that supports (sponsors) something through some kind of financial contribution.
+                          A person or organization that supports (sponsors) something through some kind of financial contribution.
                         </td>
                      </tr>
                      <tr>
                         <th><a href="http://schema.org/genre">genre</a></th>
                         <td>
-                           <a href="http://schema.org/Text">Text</a><br /><a href="http://schema.org/URL">URL</a>
+                           <a href="http://schema.org/Text">Text</a> or<br/>
+                           <a href="http://schema.org/URL">URL</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: Genre of the creative work, broadcast channel or group.
+                          Genre of the creative work, broadcast channel or group.
                         </td>
                      </tr>
                      <tr>
                         <th><a href="http://schema.org/hasPart">hasPart</a></th>
                         <td>
-                           <a href="http://schema.org/CreativeWork">CreativeWork</a>
+                           <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
+                           <a href="http://schema.org/Trip">Trip</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: Indicates a CreativeWork that is (in some sense) a part of this CreativeWork. <em>Inverse property: <a href="http://schema.org/isPartOf">isPartOf</a>.</em>
+                          Indicates a CreativeWork that is (in some sense) a part of this CreativeWork.<br/>
+                          Inverse property: <a href="http://schema.org/isPartOf">isPartOf</a>.
                         </td>
                      </tr>
                      <tr>
@@ -518,16 +542,17 @@ external: #454547;
                            <a href="http://schema.org/Text">Text</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: Headline of the article.
+                          Headline of the article.
                         </td>
                      </tr>
                      <tr>
                         <th><a href="http://schema.org/inLanguage">inLanguage</a></th>
                         <td>
-                           <a href="http://schema.org/Language">Language</a><br /><a href="http://schema.org/Text">Text</a>
+                           <a href="http://schema.org/Language">Language</a> or<br/>
+                           <a href="http://schema.org/Text">Text</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: The language of the content or performance or used in an action. Please use one of the language codes from the <a href="http://tools.ietf.org/html/bcp47">IETF BCP 47 standard</a>. See also <a href="http://schema.org/availableLanguage">availableLanguage</a>. Supersedes language.
+                          The language of the content or performance or used in an action. Please use one of the language codes from the <a href="http://tools.ietf.org/html/bcp47">IETF BCP 47 standard</a>. See also <a href="http://schema.org/availableLanguage">availableLanguage</a>. Supersedes <a href="https://schema.org/language">language</a>.
                         </td>
                      </tr>
                      <tr>
@@ -536,7 +561,7 @@ external: #454547;
                            <a href="http://schema.org/InteractionCounter">InteractionCounter</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used. Supersedes interactionCount.
+                          The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used. Supersedes <a href="https://schema.org/interactionCount">interactionCount</a>.
                         </td>
                      </tr>
                      <tr>
@@ -545,7 +570,7 @@ external: #454547;
                            <a href="http://schema.org/Text">Text</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: The predominant mode of learning supported by the learning resource. Acceptable values are 'active', 'expositive', or 'mixed'.
+                          The predominant mode of learning supported by the learning resource. Acceptable values are 'active', 'expositive', or 'mixed'.
                         </td>
                      </tr>
                      <tr>
@@ -554,17 +579,18 @@ external: #454547;
                            <a href="http://schema.org/Boolean">Boolean</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: A flag to signal that the item, event, or place is accessible for free. Supersedes free.
+                          A flag to signal that the item, event, or place is accessible for free. Supersedes <a href="https://schema.org/free">free</a>.
                         </td>
                      </tr>
                      <tr>
                         <th><a href="http://schema.org/isBasedOn">isBasedOn</a></th>
                         <td>
-                           <a href="http://schema.org/CreativeWork">CreativeWork</a><br /><a href="http://schema.org/Product">Product</a><br /><a href="http://schema.org/URL">URL</a>
+                           <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
+                           <a href="http://schema.org/Product">Product</a> or<br/>
+                           <a href="http://schema.org/URL">URL</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: A resource that was used in the creation of this resource. This term can be repeated for multiple sources. For example, http://example.com/great-multiplication-intro.html. <em>Supersedes isBasedOnUrl</em>.<br />
-                          <strong>Bioschemas</strong>: Whenever possible use <a href="http://www.ebi.ac.uk/ols/ontologies/eco">Evidence Codes (ECO)</a>.</td>
+                          A resource that was used in the creation of this resource. This term can be repeated for multiple sources. For example, http://example.com/great-multiplication-intro.html. Supersedes <a href="https://schema.org/isBasedOnUrl">isBasedOnUrl</a>.
                         </td>
                      </tr>
                      <tr>
@@ -573,16 +599,18 @@ external: #454547;
                            <a href="http://schema.org/Boolean">Boolean</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: Indicates whether this content is family friendly.
+                          Indicates whether this content is family friendly.
                         </td>
                      </tr>
                      <tr>
                         <th><a href="http://schema.org/isPartOf">isPartOf</a></th>
                         <td>
-                           <a href="http://schema.org/CreativeWork">CreativeWork</a>
+                           <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
+                           <a href="http://schema.org/Trip">Trip</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: Indicates a CreativeWork that this CreativeWork is (in some sense) part of. <em>Inverse property: <a href="http://schema.org/hasPart">hasPart</a>.</em>
+                          Indicates an item or CreativeWork that this item, or CreativeWork (in some sense), is part of.<br/>
+                          Inverse property: <a href="http://schema.org/hasPart">hasPart</a>.
                         </td>
                      </tr>
                      <tr>
@@ -590,7 +618,7 @@ external: #454547;
                         <td>
                            <a href="http://schema.org/Text">Text</a>
                         </td>
-                        <td><strong>Schema</strong>: Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.</td>
+                        <td>Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.</td>
                       </tr>
                       <tr>
                          <th><a href="http://schema.org/learningResourceType">learningResourceType</a></th>
@@ -598,16 +626,17 @@ external: #454547;
                             <a href="http://schema.org/Text">Text</a>
                          </td>
                          <td>
-                           <strong>Schema</strong>: The predominant type or kind characterizing the learning resource. For example, 'presentation', 'handout'.
+                           The predominant type or kind characterizing the learning resource. For example, 'presentation', 'handout'.
                          </td>
                       </tr>
                       <tr>
                          <th><a href="http://schema.org/license">license</a></th>
                          <td>
-                            <a href="http://schema.org/CreativeWork">CreativeWork</a><br /><a href="http://schema.org/URL">URL</a>
+                            <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
+                            <a href="http://schema.org/URL">URL</a>
                          </td>
                          <td>
-                           <strong>Schema</strong>: A license document that applies to this content, typically indicated by URL.
+                           A license document that applies to this content, typically indicated by URL.
                          </td>
                       </tr>
                       <tr>
@@ -616,7 +645,7 @@ external: #454547;
                             <a href="http://schema.org/Place">Place</a>
                          </td>
                          <td>
-                           <strong>Schema</strong>: The location where the CreativeWork was created, which may not be the same as the location depicted in the CreativeWork.
+                           The location where the CreativeWork was created, which may not be the same as the location depicted in the CreativeWork.
                          </td>
                       </tr>
                       <tr>
@@ -625,17 +654,19 @@ external: #454547;
                            <a href="http://schema.org/Thing">Thing</a>
                          </td>
                          <td>
-                           <strong>Schema</strong>: Indicates the primary entity described in some page or other CreativeWork. <em>Inverse-property: <a href="http:schema.org/mainEntityOfPage">mainEntityOfPage</a>.</em><br />
-                           <strong>Bioschemas</strong>: Bioschemas usage.  Link to the BioChemEntity represented by this record.
+                           Indicates the primary entity described in some page or other CreativeWork. <br/>
+                           Inverse-property: <a href="http:schema.org/mainEntityOfPage">mainEntityOfPage</a>.
                          </td>
                        </tr>
                        <tr>
                           <th><a href="http://schema.org/material">material</a></th>
                           <td>
-                             <a href="http://schema.org/Product">Product</a><br /><a href="http://schema.org/Text">Text</a><br /><a href="http://schema.org/URL">URL</a>
+                             <a href="http://schema.org/Product">Product</a> or<br/>
+                             <a href="http://schema.org/Text">Text</a> or<br/>
+                             <a href="http://schema.org/URL">URL</a>
                           </td>
                           <td>
-                            <strong>Schema</strong>: A material that something is made from, e.g. leather, wool, cotton, paper.
+                            A material that something is made from, e.g. leather, wool, cotton, paper.
                           </td>
                        </tr>
                        <tr>
@@ -644,7 +675,7 @@ external: #454547;
                              <a href="http://schema.org/Thing">Thing</a>
                           </td>
                           <td>
-                            <strong>Schema</strong>: Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept.
+                            Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept.
                           </td>
                        </tr>
                        <tr>
@@ -653,34 +684,37 @@ external: #454547;
                              <a href="http://schema.org/Offer">Offer</a>
                           </td>
                           <td>
-                            <strong>Schema</strong>: An offer to provide this item—for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
+                            An offer to provide this item—for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
                           </td>
                        </tr>
                        <tr>
                           <th><a href="http://schema.org/position">position</a></th>
                           <td>
-                             <a href="http://schema.org/Integer">Integer</a><br /><a href="http://schema.org/Text">Text</a>
+                             <a href="http://schema.org/Integer">Integer</a> or<br/>
+                             <a href="http://schema.org/Text">Text</a>
                           </td>
                           <td>
-                            <strong>Schema</strong>: The position of an item in a series or sequence of items.
+                            The position of an item in a series or sequence of items.
                           </td>
                        </tr>
                        <tr>
                           <th><a href="http://schema.org/producer">producer</a></th>
                           <td>
-                             <a href="http://schema.org/Organization">Organization</a><br /><a href="http://schema.org/Person">Person</a>
+                             <a href="http://schema.org/Organization">Organization</a> or<br/>
+                             <a href="http://schema.org/Person">Person</a>
                           </td>
                           <td>
-                            <strong>Schema</strong>: The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.).
+                            The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.).
                           </td>
                        </tr>
                        <tr>
                           <th><a href="http://schema.org/provider">provider</a></th>
                           <td>
-                             <a href="http://schema.org/Organization">Organization</a><br /><a href="http://schema.org/Person">Person</a>
+                             <a href="http://schema.org/Organization">Organization</a> or<br/>
+                             <a href="http://schema.org/Person">Person</a>
                           </td>
                           <td>
-                            <strong>Schema</strong>: The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller. Supersedes carrier.
+                            The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller. Supersedes <a href="https://schema.org/carrier">carrier</a>.
                           </td>
                        </tr>
                        <tr>
@@ -689,34 +723,37 @@ external: #454547;
                              <a href="http://schema.org/PublicationEvent">PublicationEvent</a>
                           </td>
                           <td>
-                            <strong>Schema</strong>: A publication event associated with the item.
+                            A publication event associated with the item.
                           </td>
                        </tr>
                        <tr>
                           <th><a href="http://schema.org/publication">publisher</a></th>
                           <td>
-                             <a href="http://schema.org/Organization">Organization</a><br /><a href="http://schema.org/Person">Person</a>
+                             <a href="http://schema.org/Organization">Organization</a> or<br/>
+                             <a href="http://schema.org/Person">Person</a>
                           </td>
                           <td>
-                            <strong>Schema</strong>: The publisher of the creative work.
+                            The publisher of the creative work.
                           </td>
                        </tr>
                        <tr>
-                          <th><a class="pending" href="http://schema.org/publisherImprint">publisherImprint</a></th>
+                          <th><a class="pending" href="http://pending.schema.org/publisherImprint">publisherImprint</a></th>
                           <td>
                              <a href="http://schema.org/Organization">Organization</a>
                           </td>
                           <td>
-                            <strong>Schema</strong>: The publishing division which published the comic.
+                            The publishing division which published the comic.
                           </td>
                        </tr>
                        <tr>
                           <th><a href="http://schema.org/publishingPrinciples">publishingPrinciples</a></th>
                           <td>
-                             <a href="http://schema.org/CreativeWork">CreativeWork</a><br /><a href="http://schema.org/URL">URL</a>
+                             <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
+                             <a href="http://schema.org/URL">URL</a>
                           </td>
                           <td>
-                            <strong>Schema</strong>: The publishingPrinciples property indicates (typically via URL) a document describing the editorial principles of an <a href="http://schema.org/Organization">Organization</a> (or individual e.g. a <a href="http://schema.org/Person">Person</a> writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a <a href="http://schema.org/CreativeWork">CreativeWork</a> (e.g. <a href="http://schema.org/NewsArticle">NewsArticle</a>) the principles are those of the party primarily responsible for the creation of the <a href="http://schema.org/CreativeWork">CreativeWork</a>. <br />While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a <a href="http://schema.org/funder">funder</a>) can be expressed using schema.org terminology.
+                            The publishingPrinciples property indicates (typically via <a href="https://schema.org/URL">URL</a>) a document describing the editorial principles of an <a href="http://schema.org/Organization">Organization</a> (or individual e.g. a <a href="http://schema.org/Person">Person</a> writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a <a href="http://schema.org/CreativeWork">CreativeWork</a> (e.g. <a href="http://schema.org/NewsArticle">NewsArticle</a>) the principles are those of the party primarily responsible for the creation of the <a href="http://schema.org/CreativeWork">CreativeWork</a>. <br />
+                            While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a <a href="http://schema.org/funder">funder</a>) can be expressed using schema.org terminology.
                           </td>
                        </tr>
                        <tr>
@@ -725,7 +762,8 @@ external: #454547;
                              <a href="http://schema.org/Event">Event</a>
                           </td>
                           <td>
-                            <strong>Schema</strong>: The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event. <em>Inverse property: <a href="http://schema.org/recordedIn">recordedIn</a>.</em>
+                            The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event. <br/>
+                            Inverse property: <a href="http://schema.org/recordedIn">recordedIn</a>.
                           </td>
                        </tr>
                        <tr>
@@ -734,7 +772,7 @@ external: #454547;
                              <a href="http://schema.org/PublicationEvent">PublicationEvent</a>
                           </td>
                           <td>
-                            <strong>Schema</strong>: The place and time the release was issued, expressed as a PublicationEvent.
+                            The place and time the release was issued, expressed as a PublicationEvent.
                           </td>
                        </tr>
                        <tr>
@@ -743,16 +781,46 @@ external: #454547;
                              <a href="http://schema.org/Review">Review</a>
                           </td>
                           <td>
-                            <strong>Schema</strong>: A review of the item. Supersedes reviews.
+                            A review of the item. Supersedes <a href="https://schema.org/reviews">reviews</a>.
                           </td>
                        </tr>
                        <tr>
                           <th><a href="http://schema.org/schemaVersion">schemaVersion</a></th>
                           <td>
-                             <a href="http://schema.org/Text">Text</a><br /><a href="http://schema.org/URL">URL</a>
+                             <a href="http://schema.org/Text">Text</a> or<br/>
+                             <a href="http://schema.org/URL">URL</a>
                           </td>
                           <td>
-                            <strong>Schema</strong>: Indicates (by URL or string) a particular version of a schema used in some CreativeWork. For example, a document could declare a schemaVersion using an URL such as http://schema.org/version/2.0/ if precise indication of schema version was required by some application.
+                            Indicates (by URL or string) a particular version of a schema used in some CreativeWork. For example, a document could declare a schemaVersion using an URL such as http://schema.org/version/2.0/ if precise indication of schema version was required by some application.
+                          </td>
+                       </tr>
+                       <tr>
+                          <th><a class="pending" href="http://pending.schema.org/sdDatePublished">sdDatePublished</a></th>
+                          <td>
+                             <a href="http://schema.org/Date">Date</a>
+                          </td>
+                          <td>
+                            Indicates the date on which the current structured data was generated / published. Typically used alongside <a href="https://schema.org/sdPublisher">sdPublisher</a>
+                          </td>
+                       </tr>
+                       <tr>
+                          <th><a class="pending" href="http://pending.schema.org/sdLicense">sdLicense</a></th>
+                          <td>
+                             <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
+                             <a href="http://schema.org/URL">URL</a>
+                          </td>
+                          <td>
+                            A license document that applies to this structured data, typically indicated by URL.
+                          </td>
+                       </tr>
+                       <tr>
+                          <th><a class="pending" href="http://pending.schema.org/sdPublisher">sdPublisher</a></th>
+                          <td>
+                             <a href="http://schema.org/Organization">Organization</a> or<br/>
+                             <a href="http://schema.org/Person">Person</a>
+                          </td>
+                          <td>
+                            Indicates the party responsible for generating and publishing the current structured data markup, typically in cases where the structured data is derived automatically from existing published content but published on a different site. For example, student projects and open data initiatives often re-publish existing content with more explicitly structured metadata. The <a href="https://schema.org/sdPublisher">sdPublisher</a> property helps make such practices more explicit.
                           </td>
                        </tr>
                        <tr>
@@ -761,7 +829,7 @@ external: #454547;
                              <a href="http://schema.org/Organization">Organization</a>
                           </td>
                           <td>
-                            <strong>Schema</strong>: The Organization on whose behalf the creator was working.
+                            The Organization on whose behalf the creator was working.
                           </td>
                        </tr>
                        <tr>
@@ -770,25 +838,30 @@ external: #454547;
                              <a href="http://schema.org/Place">Place</a>
                           </td>
                           <td>
-                            <strong>Schema</strong>: The spatialCoverage of a CreativeWork indicates the place(s) which are the focus of the content. It is a subproperty of contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York. Supersedes spatial.
+                            The spatialCoverage of a CreativeWork indicates the place(s) which are the focus of the content. It is a subproperty of contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York. Supersedes <a href="https://schema.org/spatial">spatial</a>.
                           </td>
                        </tr>
                        <tr>
                           <th><a href="http://schema.org/sponsor">sponsor</a></th>
                           <td>
-                             <a href="http://schema.org/Organization">Organization</a><br /><a href="http://schema.org/Person">Person</a>
+                             <a href="http://schema.org/Organization">Organization</a> or<br/>
+                             <a href="http://schema.org/Person">Person</a>
                           </td>
                           <td>
-                            <strong>Schema</strong>: A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
+                            A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
                           </td>
                        </tr>
                        <tr>
                           <th><a href="http://schema.org/temporalCoverage">temporalCoverage</a></th>
                           <td>
-                             <a href="http://schema.org/DateTime">DateTime</a><br /><a href="http://schema.org/Text">Text</a><br /><a href="http://schema.org/URL">URL</a>
+                             <a href="http://schema.org/DateTime">DateTime</a> or<br/>
+                             <a href="http://schema.org/Text">Text</a> or<br/>
+                             <a href="http://schema.org/URL">URL</a>
                           </td>
                           <td>
-                            <strong>Schema</strong>: The temporalCoverage of a CreativeWork indicates the period that the content applies to, i.e. that it describes, either as a DateTime or as a textual string indicating a time period in <a href="https://en.wikipedia.org/wiki/ISO_8601#Time_intervals">ISO 8601 time interval format</a>. In the case of a Dataset it will typically indicate the relevant time period in a precise notation (e.g. for a 2011 census dataset, the year 2011 would be written "2011/2012"). Other forms of content e.g. ScholarlyArticle, Book, TVSeries or TVEpisode may indicate their temporalCoverage in broader terms - textually or via well-known URL. Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945". Supersedes datasetTimeInterval, temporal.
+                            The temporalCoverage of a CreativeWork indicates the period that the content applies to, i.e. that it describes, either as a DateTime or as a textual string indicating a time period in <a href="https://en.wikipedia.org/wiki/ISO_8601#Time_intervals">ISO 8601 time interval format</a>. In the case of a Dataset it will typically indicate the relevant time period in a precise notation (e.g. for a 2011 census dataset, the year 2011 would be written "2011/2012"). Other forms of content e.g. ScholarlyArticle, Book, TVSeries or TVEpisode may indicate their temporalCoverage in broader terms - textually or via well-known URL. Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945".
+                            <br/>
+                            Open-ended date ranges can be written with ".." in place of the end date. For example, "2015-11/.." indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated. Supersedes <a href="https://schema.org/datasetTimeInterval">datasetTimeInterval</a>, <a href="https://schema.org/temporal">temporal</a>.
                           </td>
                        </tr>
                        <tr>
@@ -797,7 +870,7 @@ external: #454547;
                              <a href="http://schema.org/Text">Text</a>
                           </td>
                           <td>
-                            <strong>Schema</strong>: The textual content of this CreativeWork.
+                            The textual content of this CreativeWork.
                           </td>
                        </tr>
                        <tr>
@@ -806,7 +879,7 @@ external: #454547;
                              <a href="http://schema.org/URL">URL</a>
                           </td>
                           <td>
-                            <strong>Schema</strong>: A thumbnail image relevant to the Thing.
+                            A thumbnail image relevant to the Thing.
                           </td>
                        </tr>
                        <tr>
@@ -815,7 +888,7 @@ external: #454547;
                              <a href="http://schema.org/Duration">Duration</a>
                           </td>
                           <td>
-                            <strong>Schema</strong>: Approximate or typical time it takes to work with or through this learning resource for the typical intended target audience, e.g. 'P30M', 'P1H25M'.
+                            Approximate or typical time it takes to work with or through this learning resource for the typical intended target audience, e.g. 'P30M', 'P1H25M'.
                           </td>
                        </tr>
                        <tr>
@@ -824,16 +897,18 @@ external: #454547;
                              <a href="http://schema.org/CreativeWork">CreativeWork</a>
                           </td>
                           <td>
-                            <strong>Schema</strong>: The work that this work has been translated from. e.g. 物种起源 is a translationOf “On the Origin of Species”. <em>Inverse property: <a style="color: #0000CC;"  href="http://pending.schema.org/workTranslation">workTranslation</a>.</em>
+                            The work that this work has been translated from. e.g. 物种起源 is a translationOf “On the Origin of Species”. <br/>
+                            Inverse property: <a style="color: #0000CC;"  href="http://pending.schema.org/workTranslation">workTranslation</a>.
                           </td>
                        </tr>
                        <tr>
                           <th><a href="http://schema.org/translator">translator</a></th>
                           <td>
-                             <a href="http://schema.org/Organization">Organization</a><br /><a href="http://schema.org/Person">Person</a>
+                             <a href="http://schema.org/Organization">Organization</a> or<br/>
+                             <a href="http://schema.org/Person">Person</a>
                           </td>
                           <td>
-                            <strong>Schema</strong>: Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.
+                            Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.
                           </td>
                        </tr>
                        <tr>
@@ -842,16 +917,17 @@ external: #454547;
                              <a href="http://schema.org/Text">Text</a>
                           </td>
                           <td>
-                            <strong>Schema</strong>: The typical expected age range, e.g. '7-9', '11-'.
+                            The typical expected age range, e.g. '7-9', '11-'.
                           </td>
                        </tr>
                        <tr>
                           <th><a href="http://schema.org/version">version</a></th>
                           <td>
-                             <a href="http://schema.org/Number">Number</a><br /><a href="http://schema.org/Text">Text</a>
+                             <a href="http://schema.org/Number">Number</a> or<br/>
+                             <a href="http://schema.org/Text">Text</a>
                           </td>
                           <td>
-                            <strong>Schema</strong>: The version of the CreativeWork embodied by a specified resource.
+                            The version of the CreativeWork embodied by a specified resource.
                           </td>
                        </tr>
                        <tr>
@@ -860,7 +936,7 @@ external: #454547;
                              <a href="http://schema.org/VideoObject">VideoObject</a>
                           </td>
                           <td>
-                            <strong>Schema</strong>: An embedded video object.
+                            An embedded video object.
                           </td>
                        </tr>
                        <tr>
@@ -869,7 +945,8 @@ external: #454547;
                              <a href="http://schema.org/CreativeWork">CreativeWork</a>
                           </td>
                           <td>
-                            <strong>Schema</strong>: Example/instance/realization/derivation of the concept of this creative work. eg. The paperback edition, first edition, or eBook. <em>Inverse property: <a href="http://schema.org/exampleOfWork">exampleOfWork</a>.</em>
+                            Example/instance/realization/derivation of the concept of this creative work. eg. The paperback edition, first edition, or eBook. <br/>
+                            Inverse property: <a href="http://schema.org/exampleOfWork">exampleOfWork</a>.
                           </td>
                        </tr>
                        <tr>
@@ -878,11 +955,11 @@ external: #454547;
                              <a href="http://schema.org/CreativeWork">CreativeWork</a>
                           </td>
                           <td>
-                            <strong>Schema</strong>: A work that is a translation of the content of this work. e.g. 西遊記 has an English workTranslation “Journey to the West”,a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese translation Tây du ký bình khảo.
-                            <em>Inverse property: <a style="color: #0000CC;"  href="http://pending.schema.org/translationOfWork">translationOfWork</a>.</em>
+                            A work that is a translation of the content of this work. e.g. 西遊記 has an English workTranslation “Journey to the West”,a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese translation Tây du ký bình khảo. <br/>
+                            Inverse property: <a style="color: #0000CC;"  href="http://pending.schema.org/translationOfWork">translationOfWork</a>.
                           </td>
                        </tr>
-<!-- Thing -->                
+<!-- Thing -->
                        <tr class="reu_props_sdo">
                           <td colspan="3">Properties from <a href="http://schema.org/Thing">Thing</a></td>
                        </tr>

--- a/_devTypes/DataRecord.html
+++ b/_devTypes/DataRecord.html
@@ -2,9 +2,7 @@
 redirect_from: "devTypes/DataRecord/specification"
 redirect_from: "devTypes/DataRecord/specification/"
 dateModified: 2018-11-06
-description: "A Record acts itself as a dataset although it refers to what could be
-  seen as the minimum compact, complete and auto-descriptive unit in a dataset, i.e.,
-  a record.\n\nBioschemas usage\n\nIn Life Sciences, records will represent a BioChemEntity."
+description: "A DataRecord acts itself as a dataset although it refers to what could be seen as the minimum compact, complete and auto-descriptive unit in a dataset."
 gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20DataRecord
 group: data
 hierarchy:
@@ -48,45 +46,40 @@ external: #454547;
                       </tr>
                    </thead>
                    <tbody>
-<!-- New -->
                      <tr class="new_props_sdo">
                         <td colspan="3">
-                           New properties for <a style="color: #0B794B;" href="#">{{page.name}}</a> (pending schema.org integration).
+                           Properties from <a style="color: #0B794B;" href="/{{page.name}}">{{page.name}}</a> (pending schema.org integration).
                         </td>
                      </tr>
-                     <tr>
-                        <th><a href="http://schema.org/additionalProperty">additionalProperty</a></th>
-                        <td>
-                           <a href="http://schema.org/PropertyValue">PropertyValue</a><br>
-                        </td>
-                        <td>
-                          <strong>Schema</strong>: A property-value pair representing an additional characteristics of the entitity, e.g. a product feature or another characteristic for which there is no matching property in schema.org.  Note: Publishers should be aware that applications designed to use specific schema.org properties (e.g. http://schema.org/width, http://schema.org/color, http://schema.org/gtin13, ...) will typically expect such data to be provided using those properties, rather than using the generic property/value mechanism.<br/ >
-                          <strong>Bioschemas</strong>: Additional to the use of <a href="http://schema.org/name">name</a> and <a href="http://schema.org/description">description</a> to describe this property in a human-readable way,
-                          <a href="http://schema.org/additionalType">additionalType</a> should be used to specify the nature of the property/relation. For instance, if the property refers to a gene/protein disease association,
-                          you could use <a class="externalProp" href="http://semanticscience.org/resource/SIO_000983">SIO:000983 (gene-disease association)</a> as the <a href="http://schema.org/additionalType">additionalType</a> for the additionalProperty.
-                        </td>
-                      </tr>
+                     <tr id="additionalProperty">
+                       <th><a href="http://schema.org/additionalProperty">additionalProperty</th>
+                       <td>
+                         <a href="http://schema.org/PropertyValue">PropertyValue</a>
+                       </td>
+                       <td>A property-value pair representing an additional characteristics of the entitity, e.g. a product feature or another characteristic for which there is no matching property in schema.org. <br/>
+                         Note: Publishers should be aware that applications designed to use specific schema.org properties (e.g. http://schema.org/width, http://schema.org/color, http://schema.org/gtin13, ...) will typically expect such data to be provided using those properties, rather than using the generic property/value mechanism.<br />
+                      </td>
+                     </tr>
                      <tr id="isBasisFor">
-                        <th><a style="color: #0B794B;" href="#">isBasisFor</a></th>
+                        <th style="color: #0B794B;">isBasisFor</th>
                         <td>
-                           <a href="http://schema.org/CreativeWork">CreativeWork</a><br>
-                           <a href="http://schema.org/Product">Product</a><br>
-                           <a href="http://schema.org/URL">URL</a><br>
-                        </td>
-                        <td>
-                          <strong>Bioschemas</strong>: A resource for which this resource is basis for. Inverse property: <a href="http://schema.org/isBasedOn">isBasedOn</a>.<br />
-                          <strong>Bioschemas DataRecord</strong>: Whenever possible use Evidence Codes (<a href="http://www.ebi.ac.uk/ols/ontologies/eco">ECO</a>).
-                        </td>
-                     </tr>
-                     <tr id="seeAlso">
-                        <th><a style="color: #0B794B;"  href="#">seeAlso</a></th>
-                        <td>
-                           <a href="http://schema.org/Thing">Thing</a><br />
+                           <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
+                           <a href="http://schema.org/Product">Product</a> or<br/>
                            <a href="http://schema.org/URL">URL</a>
                         </td>
                         <td>
-                          <strong>Bioschemas</strong>: A pointer to any (somehow related) Thing. To be used whenever you are not so sure about the nature of the relation.
-                          Otherwise, use more precise terms from pre-existing Controlled Vocabularies.
+                          A resource for which this resource is the basis for.<br/>
+                          Inverse property: isBasedOn
+                        </td>
+                     </tr>
+                     <tr id="seeAlso">
+                        <th style="color: #0B794B;">seeAlso</th>
+                        <td>
+                           <a href="http://schema.org/Thing">Thing</a> or<br/>
+                           <a href="http://schema.org/URL">URL</a>
+                        </td>
+                        <td>
+                          A pointer to any (somehow related) Thing. To be used whenever you are not so sure about the nature of the relation. Otherwise, use more precise terms from pre-existing Controlled Vocabularies.
                         </td>
                      </tr>
 <!-- Dataset -->

--- a/_devTypes/DataRecord.html
+++ b/_devTypes/DataRecord.html
@@ -1,26 +1,21 @@
 ---
 redirect_from: "devTypes/DataRecord/specification"
 redirect_from: "devTypes/DataRecord/specification/"
-cross_walk_url: ''
-dateModified: 2018-02-25
+dateModified: 2018-11-06
 description: "A Record acts itself as a dataset although it refers to what could be
   seen as the minimum compact, complete and auto-descriptive unit in a dataset, i.e.,
   a record.\n\nBioschemas usage\n\nIn Life Sciences, records will represent a BioChemEntity."
-gh_examples: ''
 gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20DataRecord
 group: data
 hierarchy:
 - Thing
 - CreativeWork
 - Dataset
-live_deploy: ''
 name: DataRecord
 parent_type: Dataset
 spec_type: Type
 status: revision
-subtitle: Bioschemas specification describing a record in a dataset.
-use_cases_url: ''
-version: '0.1'
+version: '0.2-DRAFT'
 
 bsc: #0B794B;
 pending: #0000CC;
@@ -70,7 +65,7 @@ external: #454547;
                           <a href="http://schema.org/additionalType">additionalType</a> should be used to specify the nature of the property/relation. For instance, if the property refers to a gene/protein disease association,
                           you could use <a class="externalProp" href="http://semanticscience.org/resource/SIO_000983">SIO:000983 (gene-disease association)</a> as the <a href="http://schema.org/additionalType">additionalType</a> for the additionalProperty.
                         </td>
-                      </tr>                     
+                      </tr>
                      <tr id="isBasisFor">
                         <th><a style="color: #0B794B;" href="#">isBasisFor</a></th>
                         <td>
@@ -1014,8 +1009,8 @@ external: #454547;
            </div>
       </div>
       {% include footer.html %}
-      
-      
-      
+
+
+
    </body>
 </html>

--- a/_devTypes/DataRecord.html
+++ b/_devTypes/DataRecord.html
@@ -91,15 +91,18 @@ external: #454547;
                         <td>
                            <a href="http://schema.org/DataDownload">DataDownload</a>
                         </td>
-                        <td><strong>Schema</strong>: A downloadable form of this dataset, at a specific location, in a specific format.</td>
+                        <td>
+                          A downloadable form of this dataset, at a specific location, in a specific format.
+                        </td>
                      </tr>
                      <tr>
-                        <th><a href="http://schema.org/includedInDataCatalog">includedInDataCatalog</a></th>
+                        <th>
+                          <a href="http://schema.org/includedInDataCatalog">includedInDataCatalog</a></th>
                         <td>
                            <a href="http://schema.org/DataCatalog">DataCatalog</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: A data catalog which contains this dataset. Supersedes catalog, includedDataCatalog. <em>Inverse property: <a href="http://schema.org/dataset">dataset</a>.</em>
+                          A data catalog which contains this dataset. Supersedes <a href="https://schema.org/catalog">catalog</a>, <a href="https://schema.org/includedDataCatalog">includedDataCatalog</a>.<br/> Inverse property: <a href="http://schema.org/dataset">dataset</a>.
                         </td>
                      </tr>
                      <tr>
@@ -108,30 +111,34 @@ external: #454547;
                            <a href="http://schema.org/Text">Text</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: The International Standard Serial Number (ISSN) that identifies this serial publication. You can repeat this property to identify different formats of, or the linking ISSN (ISSN-L) for, this serial publication.
+                          The International Standard Serial Number (ISSN) that identifies this serial publication. You can repeat this property to identify different formats of, or the linking ISSN (ISSN-L) for, this serial publication.
                         </td>
                      </tr>
                      <tr>
-                        <th><a style="color: #0000CC;" href="http://pending.schema.org/measurementTechnique">measurementTechnique</a></th>
+                        <th>
+                          <a style="color: #0000CC;" href="http://pending.schema.org/measurementTechnique">measurementTechnique</a>
+                        </th>
                         <td>
-                           <a href="http://schema.org/Text">Text</a><br /><a href="http://schema.org/URL">URL</a>
+                           <a href="http://schema.org/Text">Text</a> or<br/>
+                           <a href="http://schema.org/URL">URL</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: 	A technique or technology used in a Dataset (or DataDownload, DataCatalog), corresponding to the method used for measuring the corresponding variable(s) (described using <a style="color: #0000CC;" href="http://pending.schema.org/variableMeasured">variableMeasured</a>).
-                          This is oriented towards scientific and scholarly dataset publication but may have broader applicability; it is not intended as a full representation of measurement, but rather as a high level summary for dataset discovery.
-                          For example, if <a style="color: #0000CC;" href="http://pending.schema.org/variableMeasured">variableMeasured</a> is: molecule concentration, <a style="color: #0000CC;" href="http://pending.schema.org/measurementTechnique">measurementTechnique</a> could be: "mass spectrometry" or "nmr spectroscopy" or "colorimetry" or "immunofluorescence".<br />
-                          If the <a style="color: #0000CC;" href="http://pending.schema.org/variableMeasured">variableMeasured</a> is "depression rating", the <a style="color: #0000CC;" href="http://pending.schema.org/measurementTechnique">measurementTechnique</a> could be "Zung Scale" or "HAM-D" or "Beck Depression Inventory".<br />
-                          If there are several <a style="color: #0000CC;" href="http://pending.schema.org/variableMeasured">variableMeasured</a> properties recorded for some given data object, use a <a href="http://schema.org/PropertyValue">PropertyValue</a> for each <a style="color: #0000CC;" href="http://pending.schema.org/variableMeasured">variableMeasured</a>
-                          and attach the corresponding <a style="color: #0000CC;" href="http://pending.schema.org/measurementTechnique">measurementTechnique</a>.
+                          	A technique or technology used in a <a href="https://schema.org/Dataset">Dataset</a> (or <a href="https://schema.org/DataDownload">DataDownload</a>, <a href="https://schema.org/DataCatalog">DataCatalog</a>), corresponding to the method used for measuring the corresponding variable(s) (described using <a style="color: #0000CC;" href="http://pending.schema.org/variableMeasured">variableMeasured</a>). This is oriented towards scientific and scholarly dataset publication but may have broader applicability; it is not intended as a full representation of measurement, but rather as a high level summary for dataset discovery.<br/>
+                            For example, if <a style="color: #0000CC;" href="http://pending.schema.org/variableMeasured">variableMeasured</a> is: molecule concentration, <a style="color: #0000CC;" href="http://pending.schema.org/measurementTechnique">measurementTechnique</a> could be: "mass spectrometry" or "nmr spectroscopy" or "colorimetry" or "immunofluorescence".<br/>
+                            If the <a style="color: #0000CC;" href="http://pending.schema.org/variableMeasured">variableMeasured</a> is "depression rating", the <a style="color: #0000CC;" href="http://pending.schema.org/measurementTechnique">measurementTechnique</a> could be "Zung Scale" or "HAM-D" or "Beck Depression Inventory".<br/>
+                            If there are several <a style="color: #0000CC;" href="http://pending.schema.org/variableMeasured">variableMeasured</a> properties recorded for some given data object, use a <a href="http://schema.org/PropertyValue">PropertyValue</a> for each <a style="color: #0000CC;" href="http://pending.schema.org/variableMeasured">variableMeasured</a> and attach the corresponding <a style="color: #0000CC;" href="http://pending.schema.org/measurementTechnique">measurementTechnique</a>.
                         </td>
                      </tr>
                      <tr>
-                        <th><a style="color: #0000CC;" href="http://pending.schema.org/variableMeasured">variableMeasured</a></th>
+                        <th>
+                          <a style="color: #0000CC;" href="http://pending.schema.org/variableMeasured">variableMeasured</a>
+                        </th>
                         <td>
-                           <a href="http://schema.org/PropertyValue">PropertyValue</a><br /><a href="http://schema.org/Text">Text</a>
+                           <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
+                           <a href="http://schema.org/Text">Text</a>
                         </td>
                         <td>
-                          <strong>Schema</strong>: 	The variableMeasured property can indicate (repeated as necessary) the variables that are measured in some dataset, either described as text or as pairs of identifier and description using <a href="http://schema.org/PropertyValue">PropertyValue</a>.
+                          	The variableMeasured property can indicate (repeated as necessary) the variables that are measured in some dataset, either described as text or as pairs of identifier and description using <a href="http://schema.org/PropertyValue">PropertyValue</a>.
                         </td>
                      </tr>
 <!-- CREATIVEWORK -->

--- a/_devTypes/DataRecord.html
+++ b/_devTypes/DataRecord.html
@@ -875,126 +875,131 @@ external: #454547;
                             <em>Inverse property: <a style="color: #0000CC;"  href="http://pending.schema.org/translationOfWork">translationOfWork</a>.</em>
                           </td>
                        </tr>
-<!-- Thing -->
-                     <tr class="reu_props_sdo">
-                        <td colspan="3">Properties from <a href="http://schema.org/Thing">Thing</a></td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/additionalType">additionalType</a></th>
-                        <td>
+<!-- Thing -->                
+                       <tr class="reu_props_sdo">
+                          <td colspan="3">Properties from <a href="http://schema.org/Thing">Thing</a></td>
+                       </tr>
+                       <tr>
+                         <th><a href="http://schema.org/additionalType">additionalType</a></th>
+                         <td>
                            <a href="http://schema.org/URL">URL</a>
-                        </td>
-                        <td>
-                          <strong>Schema</strong>: An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between
-                          something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax - the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker
-                          understanding of extra types, in particular those defined externally.<br />
-                          <strong>Bioschemas</strong>: Although not required, additionalType can be used to specify the nature of the record. For instance, a UniProt protein record would
-                          have <a style="color: #454547;" href="http://purl.uniprot.org/core/Protein">UP:Protein</a> as type.
-                        </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/alternateName">alternateName</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         <strong>Schema</strong>: An alias for the item.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/description">description</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         <strong>Schema</strong>: A descripton of the item.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         <strong>Schema</strong>: A sub property of description. A short description of the item used to disambiguate from other, similar items.
-                         Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/identifier">identifier</a></th>
-                       <td>
-                         <a href="http://schema.org/PropertyValue">PropertyValue</a><br /><a href="http://schema.org/Text">Text</a><br /><a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         <strong>Schema</strong>: The identifier property represents any kind of identifier for any kind of <a href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc.
-                         Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links.
-                         See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/image">image</a></th>
-                       <td>
-                         <a href="http://schema.org/ImageObject">ImageObject</a><br /><a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         <strong>Schema</strong>: An image of the item. This can be a <a href="http://schema.org/URL">URL</a> or a fully described <a href="http://schema.org/ImageObject">ImageObject</a>.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></th>
-                       <td>
-                         <a href="http://schema.org/CreativeWork">CreativeWork</a><br /><a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         <strong>Schema</strong>: Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See
-                         <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br />
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/name">name</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         <strong>Schema</strong>: The name of the item.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/potentialAction">potentialAction</a></th>
-                       <td>
-                         <a href="http://schema.org/Action">Action</a>
-                       </td>
-                       <td>
-                         <strong>Schema</strong>: Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/sameAs">sameAs</a></th>
-                       <td>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         <strong>Schema</strong>: URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a style="color: #0000CC;" href="http://pending.schema.org/subjectOf">subjectOf</a></th>
-                       <td>
-                         <a href="http://schema.org/CreativeWork">CreativeWork</a><br /><a href="http://schema.org/Event">Event</a>
-                       </td>
-                       <td>
-                         <strong>Schema</strong>: A CreativeWork or Event about this Thing. <em>Inverse property: <a href="http://schema.org/about">about</a>.</em>
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/url">url</a></th>
-                       <td>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         <strong>Schema</strong>: URL of the item.
-                       </td>
-                     </tr>
+                         </td>
+                         <td>
+                           An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax.
+                           This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax -
+                           the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those
+                           defined externally.
+                         </td>
+                       </tr>
+                       <tr>
+                         <th><a href="http://schema.org/alternateName">alternateName</a></th>
+                         <td>
+                           <a href="http://schema.org/Text">Text</a>
+                         </td>
+                         <td>
+                           An alias for the item.
+                         </td>
+                       </tr>
+                       <tr>
+                         <th><a href="http://schema.org/description">description</a></th>
+                         <td>
+                           <a href="http://schema.org/Text">Text</a>
+                         </td>
+                         <td>
+                           A descripton of the item.
+                         </td>
+                       </tr>
+                       <tr>
+                         <th><a href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></th>
+                         <td>
+                           <a href="http://schema.org/Text">Text</a>
+                         </td>
+                         <td>
+                           A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.
+                         </td>
+                       </tr>
+                       <tr>
+                         <th><a href="http://schema.org/identifier">identifier</a></th>
+                         <td>
+                           <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
+                           <a href="http://schema.org/Text">Text</a> or<br/>
+                           <a href="http://schema.org/URL">URL</a>
+                         </td>
+                         <td>
+                           The identifier property represents any kind of identifier for any kind of <a href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc.
+                           Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links.
+                           See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.
+                         </td>
+                       </tr>
+                       <tr>
+                         <th><a href="http://schema.org/image">image</a></th>
+                         <td>
+                           <a href="http://schema.org/ImageObject">ImageObject</a> or<br/>
+                           <a href="http://schema.org/URL">URL</a>
+                         </td>
+                         <td>
+                           An image of the item. This can be a <a href="http://schema.org/URL">URL</a> or a fully described <a href="http://schema.org/ImageObject">ImageObject</a>.
+                         </td>
+                       </tr>
+                       <tr>
+                         <th><a href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></th>
+                         <td>
+                           <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
+                           <a href="http://schema.org/URL">URL</a>
+                         </td>
+                         <td>
+                           Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See
+                           <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/>
+                           Inverse property: <a href="http://schema.org/mainEntity">mainEntity</a>
+                         </td>
+                       </tr>
+                       <tr>
+                         <th><a href="http://schema.org/name">name</a></th>
+                         <td>
+                           <a href="http://schema.org/Text">Text</a>
+                         </td>
+                         <td>
+                           The name of the item.
+                         </td>
+                       </tr>
+                       <tr>
+                         <th><a href="http://schema.org/potentialAction">potentialAction</a></th>
+                         <td>
+                           <a href="http://schema.org/Action">Action</a>
+                         </td>
+                         <td>
+                           Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.
+                         </td>
+                       </tr>
+                       <tr>
+                         <th><a href="http://schema.org/sameAs">sameAs</a></th>
+                         <td>
+                           <a href="http://schema.org/URL">URL</a>
+                         </td>
+                         <td>
+                           URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.
+                         </td>
+                       </tr>
+                       <tr>
+                         <th><a style="color: #0000CC;" href="http://pending.schema.org/subjectOf">subjectOf</a></th>
+                         <td>
+                           <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
+                           <a href="http://schema.org/Event">Event</a>
+                         </td>
+                         <td>
+                           A CreativeWork or Event about this Thing..<br/>
+                           Inverse property: <a href="http://schema.org/about">about</a>.
+                         </td>
+                       </tr>
+                       <tr>
+                         <th><a href="http://schema.org/url">url</a></th>
+                         <td>
+                           <a href="http://schema.org/URL">URL</a>
+                         </td>
+                         <td>
+                           URL of the item.
+                         </td>
+                       </tr>
                    </tbody>
                  </table>
                </section>

--- a/_devTypes/Gene.html
+++ b/_devTypes/Gene.html
@@ -123,8 +123,8 @@ external: #454547;
                          The location of for example where the event is happening, an organization is located, or where an action takes place.
                        </td>
                      </tr>
-                     <tr id="position">
-                       <th style="color: #0B794B;">position</th>
+                     <tr id="positionInRepresentation">
+                       <th style="color: #0B794B;">positionInRepresentation</th>
                        <td>
                          <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
                          <a href="http://schema.org/Text">Text</a> or<br/>

--- a/_devTypes/Gene.html
+++ b/_devTypes/Gene.html
@@ -6,7 +6,7 @@ hierarchy:
 - Intangible
 - BioChemEntity
 gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Gene
-group: gene
+group: genes
 name: Gene
 parent_type: BioChemEntity
 spec_type: Type

--- a/_devTypes/Gene.html
+++ b/_devTypes/Gene.html
@@ -51,7 +51,7 @@ external: #454547;
                        <th style="color: #0B794B;">encodes</th>
                        <td>
                          <a style="color: #0B794B;" href="/BioChemEntity">BioChemEntity</a> or<br/>
-                         <a style="color: #0B794B;" href="/BioChemEntity">Protein</a> or<br/>
+                         <a style="color: #0B794B;" href="/Protein">Protein</a> or<br/>
                          <a href="http://schema.org/URL">URL</a>
                        </td>
                        <td>

--- a/_devTypes/Gene.html
+++ b/_devTypes/Gene.html
@@ -44,7 +44,7 @@ external: #454547;
                    <tbody>
                      <tr class="new_props_sdo">
                         <td colspan="3">
-                           Properties from <a style="color: #0B794B;" href="#">{{page.name}}</a> (pending schema.org integration).
+                           Properties from <a style="color: #0B794B;" href="/{{page.name}}">{{page.name}}</a> (pending schema.org integration).
                         </td>
                      </tr>
                      <tr id="encodes">

--- a/_devTypes/Gene.html
+++ b/_devTypes/Gene.html
@@ -1,0 +1,283 @@
+---
+dateModified: 2018-11-06
+description: "A gene."
+hierarchy:
+- Thing
+- Intangible
+- BioChemEntity
+gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Gene
+group: gene
+name: Gene
+parent_type: BioChemEntity
+spec_type: Type
+status: revision
+version: '0.1-DRAFT'
+
+bsc: #0B794B;
+pending: #0000CC;
+external: #454547;
+
+---
+
+
+<!DOCTYPE HTML>
+<html>
+   {% include head.html %}
+
+   <body>
+      {% include header.html %}
+      {% include navbar.html %}
+      <div class="page-content">
+        <div class="wrapper">
+           <div id="main-content-wrapper" class="outer">
+              <section id="main_content" class="inner">
+                {% include type_start.html %}
+
+                <table class="bioschemas_properties bsc_type">
+                   <thead>
+                      <tr>
+                         <th>Property</th>
+                         <th>Expected Type</th>
+                         <th>Description</th>
+                      </tr>
+                   </thead>
+                   <tbody>
+                     <tr class="new_props_sdo">
+                        <td colspan="3">
+                           Properties from <a style="color: #0B794B;" href="#">{{page.name}}</a> (pending schema.org integration).
+                        </td>
+                     </tr>
+                     <tr id="encodes">
+                       <th style="color: #0B794B;">encodes</th>
+                       <td>
+                         <a style="color: #0B794B;" href="/BioChemEntity">BioChemEntity</a> or<br/>
+                         <a style="color: #0B794B;" href="/BioChemEntity">Protein</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         This property is used to link to gene products encoded (even indirectly) from this gene such as RNA or proteins.
+                       </td>
+                     </tr>
+                     <tr class="reu_props_sdo">
+                        <td colspan="3">Properties from <a style="color: #0B794B;" href="/BioChemEntity">BioChemEntity</a></td>
+                     </tr>
+                     <tr id="additionalProperty">
+                       <th><a href="http://schema.org/additionalProperty">additionalProperty</th>
+                       <td>
+                         <a href="http://schema.org/PropertyValue">PropertyValue</a>
+                       </td>
+                       <td>A property-value pair representing an additional characteristics of the entitity, e.g. a product feature or another characteristic for which there is no matching property in schema.org. <br/>
+                         Note: Publishers should be aware that applications designed to use specific schema.org properties (e.g. http://schema.org/width, http://schema.org/color, http://schema.org/gtin13, ...) will typically expect such data to be provided using those properties, rather than using the generic property/value mechanism.<br />
+                      </td>
+                     </tr>
+                     <tr id="associatedDisease">
+                       <th style="color: #0B794B;">associatedDisease</th>
+                       <td>
+                         <a href="http://schema.org/MedicalCondition">MedicalCondition</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         Disease associated to this BioChemEntity.
+                       </td>
+                     </tr>
+                     <tr id="contains">
+                       <th style="color: #0B794B;">contains</th>
+                       <td>
+                         <a style="color: #0B794B;" href="/BioChemEntity">BioChemEntity</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         Indicates a BioChemEntity that is (in some sense) a part of this BioChemEntity. <br/>
+                         Inverse property: isContainedIn
+                       </td>
+                     </tr>
+                     <tr id="hasRepresentation">
+                       <th style="color: #0B794B;">hasRepresentation</th>
+                       <td>
+                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
+                         <a href="http://schema.org/Text">Text</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         A common representation such as a protein sequence or chemical structure for this entity. For images use schema.org/image.
+                       </td>
+                     </tr>
+                     <tr id="isContainedIn">
+                       <th style="color: #0B794B;">isContainedIn</th>
+                       <td>
+                         <a style="color: #0B794B;" href="/BioChemEntity">BioChemEntity</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         Indicates a BioChemEntity that (in some sense) has this BioChemEntity as a part.<br/>
+                         Inverse property: contains
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/location">location</a></th>
+                       <td>
+                         <a href="http://schema.org/Place">Place</a> or<br/><a href="http://schema.org/PostalAddress">PostalAddress</a> or<br/>
+                         <a href="http://schema.org/Text">Text</a><br/>
+                       </td>
+                       <td>
+                         The location of for example where the event is happening, an organization is located, or where an action takes place.
+                       </td>
+                     </tr>
+                     <tr id="position">
+                       <th style="color: #0B794B;">position</th>
+                       <td>
+                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
+                         <a href="http://schema.org/Text">Text</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         Refers to a position in the chromosome or sequence. For instance, FALDO can be used for sequence coordinates.
+                       </td>
+                     </tr>
+                     <tr id="taxonomicRange">
+                       <th style="color: #0B794B;">taxonomicRange</th>
+                       <td>
+                         <a style="color: #0B794B;" href="/Taxon">Taxon</a> or<br/>
+                         <a href="http://schema.org/Text">Text</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         The taxonomic grouping of the organism that expresses, encodes, or in someway related to the BioChemEntity.
+                       </td>
+                     </tr>
+                     <tr class="reu_props_sdo">
+                        <td colspan="3">Properties from <a href="http://schema.org/Thing">Thing</a></td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/additionalType">additionalType</a></th>
+                       <td>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax.
+                         This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax -
+                         the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those
+                         defined externally.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/alternateName">alternateName</a></th>
+                       <td>
+                         <a href="http://schema.org/Text">Text</a>
+                       </td>
+                       <td>
+                         An alias for the item.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/description">description</a></th>
+                       <td>
+                         <a href="http://schema.org/Text">Text</a>
+                       </td>
+                       <td>
+                         A descripton of the item.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></th>
+                       <td>
+                         <a href="http://schema.org/Text">Text</a>
+                       </td>
+                       <td>
+                         A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/identifier">identifier</a></th>
+                       <td>
+                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
+                         <a href="http://schema.org/Text">Text</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         The identifier property represents any kind of identifier for any kind of <a href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc.
+                         Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links.
+                         See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/image">image</a></th>
+                       <td>
+                         <a href="http://schema.org/ImageObject">ImageObject</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         An image of the item. This can be a <a href="http://schema.org/URL">URL</a> or a fully described <a href="http://schema.org/ImageObject">ImageObject</a>.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></th>
+                       <td>
+                         <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See
+                         <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/>
+                         Inverse property: <a href="http://schema.org/mainEntity">mainEntity</a>
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/name">name</a></th>
+                       <td>
+                         <a href="http://schema.org/Text">Text</a>
+                       </td>
+                       <td>
+                         The name of the item.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/potentialAction">potentialAction</a></th>
+                       <td>
+                         <a href="http://schema.org/Action">Action</a>
+                       </td>
+                       <td>
+                         Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/sameAs">sameAs</a></th>
+                       <td>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a style="color: #0000CC;" href="http://pending.schema.org/subjectOf">subjectOf</a></th>
+                       <td>
+                         <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
+                         <a href="http://schema.org/Event">Event</a>
+                       </td>
+                       <td>
+                         A CreativeWork or Event about this Thing..<br/>
+                         Inverse property: <a href="http://schema.org/about">about</a>.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/url">url</a></th>
+                       <td>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         URL of the item.
+                       </td>
+                     </tr>
+                   </tbody>
+                 </table>
+               </section>
+             </div>
+           </div>
+      </div>
+      {% include footer.html %}
+
+
+
+   </body>
+</html>

--- a/_devTypes/Protein.html
+++ b/_devTypes/Protein.html
@@ -123,8 +123,8 @@ external: #454547;
                          The location of for example where the event is happening, an organization is located, or where an action takes place.
                        </td>
                      </tr>
-                     <tr id="position">
-                       <th style="color: #0B794B;">position</th>
+                     <tr id="positionInRepresentation">
+                       <th style="color: #0B794B;">positionInRepresentation</th>
                        <td>
                          <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
                          <a href="http://schema.org/Text">Text</a> or<br/>

--- a/_devTypes/Protein.html
+++ b/_devTypes/Protein.html
@@ -44,7 +44,7 @@ external: #454547;
                    <tbody>
                      <tr class="new_props_sdo">
                         <td colspan="3">
-                           Properties from <a style="color: #0B794B;" href="#">{{page.name}}</a> (pending schema.org integration).
+                           Properties from <a style="color: #0B794B;" href="/{{page.name}}">{{page.name}}</a> (pending schema.org integration).
                         </td>
                      </tr>
                      <tr id="isEncodedBy">

--- a/_devTypes/Protein.html
+++ b/_devTypes/Protein.html
@@ -1,0 +1,283 @@
+---
+dateModified: 2018-11-06
+description: "A protein or a computationally generated protein annotation."
+hierarchy:
+- Thing
+- Intangible
+- BioChemEntity
+gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Protein
+group: proteins
+name: Protein
+parent_type: BioChemEntity
+spec_type: Type
+status: revision
+version: '0.1-DRAFT'
+
+bsc: #0B794B;
+pending: #0000CC;
+external: #454547;
+
+---
+
+
+<!DOCTYPE HTML>
+<html>
+   {% include head.html %}
+
+   <body>
+      {% include header.html %}
+      {% include navbar.html %}
+      <div class="page-content">
+        <div class="wrapper">
+           <div id="main-content-wrapper" class="outer">
+              <section id="main_content" class="inner">
+                {% include type_start.html %}
+
+                <table class="bioschemas_properties bsc_type">
+                   <thead>
+                      <tr>
+                         <th>Property</th>
+                         <th>Expected Type</th>
+                         <th>Description</th>
+                      </tr>
+                   </thead>
+                   <tbody>
+                     <tr class="new_props_sdo">
+                        <td colspan="3">
+                           Properties from <a style="color: #0B794B;" href="#">{{page.name}}</a> (pending schema.org integration).
+                        </td>
+                     </tr>
+                     <tr id="isEncodedBy">
+                       <th style="color: #0B794B;">isEncodedBy</th>
+                       <td>
+                         <a style="color: #0B794B;" href="/BioChemEntity">BioChemEntity</a> or<br/>
+                         <a style="color: #0B794B;" href="/Gene">Gene</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         BioChemEntity  from which this protein was encoded from.
+                       </td>
+                     </tr>
+                     <tr class="reu_props_sdo">
+                        <td colspan="3">Properties from <a style="color: #0B794B;" href="/BioChemEntity">BioChemEntity</a></td>
+                     </tr>
+                     <tr id="additionalProperty">
+                       <th><a href="http://schema.org/additionalProperty">additionalProperty</th>
+                       <td>
+                         <a href="http://schema.org/PropertyValue">PropertyValue</a>
+                       </td>
+                       <td>A property-value pair representing an additional characteristics of the entitity, e.g. a product feature or another characteristic for which there is no matching property in schema.org. <br/>
+                         Note: Publishers should be aware that applications designed to use specific schema.org properties (e.g. http://schema.org/width, http://schema.org/color, http://schema.org/gtin13, ...) will typically expect such data to be provided using those properties, rather than using the generic property/value mechanism.<br />
+                      </td>
+                     </tr>
+                     <tr id="associatedDisease">
+                       <th style="color: #0B794B;">associatedDisease</th>
+                       <td>
+                         <a href="http://schema.org/MedicalCondition">MedicalCondition</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         Disease associated to this BioChemEntity.
+                       </td>
+                     </tr>
+                     <tr id="contains">
+                       <th style="color: #0B794B;">contains</th>
+                       <td>
+                         <a style="color: #0B794B;" href="/BioChemEntity">BioChemEntity</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         Indicates a BioChemEntity that is (in some sense) a part of this BioChemEntity. <br/>
+                         Inverse property: isContainedIn
+                       </td>
+                     </tr>
+                     <tr id="hasRepresentation">
+                       <th style="color: #0B794B;">hasRepresentation</th>
+                       <td>
+                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
+                         <a href="http://schema.org/Text">Text</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         A common representation such as a protein sequence or chemical structure for this entity. For images use schema.org/image.
+                       </td>
+                     </tr>
+                     <tr id="isContainedIn">
+                       <th style="color: #0B794B;">isContainedIn</th>
+                       <td>
+                         <a style="color: #0B794B;" href="/BioChemEntity">BioChemEntity</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         Indicates a BioChemEntity that (in some sense) has this BioChemEntity as a part.<br/>
+                         Inverse property: contains
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/location">location</a></th>
+                       <td>
+                         <a href="http://schema.org/Place">Place</a> or<br/><a href="http://schema.org/PostalAddress">PostalAddress</a> or<br/>
+                         <a href="http://schema.org/Text">Text</a><br/>
+                       </td>
+                       <td>
+                         The location of for example where the event is happening, an organization is located, or where an action takes place.
+                       </td>
+                     </tr>
+                     <tr id="position">
+                       <th style="color: #0B794B;">position</th>
+                       <td>
+                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
+                         <a href="http://schema.org/Text">Text</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         Refers to a position in the chromosome or sequence. For instance, FALDO can be used for sequence coordinates.
+                       </td>
+                     </tr>
+                     <tr id="taxonomicRange">
+                       <th style="color: #0B794B;">taxonomicRange</th>
+                       <td>
+                         <a style="color: #0B794B;" href="/Taxon">Taxon</a> or<br/>
+                         <a href="http://schema.org/Text">Text</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         The taxonomic grouping of the organism that expresses, encodes, or in someway related to the BioChemEntity.
+                       </td>
+                     </tr>
+                     <tr class="reu_props_sdo">
+                        <td colspan="3">Properties from <a href="http://schema.org/Thing">Thing</a></td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/additionalType">additionalType</a></th>
+                       <td>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax.
+                         This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax -
+                         the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those
+                         defined externally.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/alternateName">alternateName</a></th>
+                       <td>
+                         <a href="http://schema.org/Text">Text</a>
+                       </td>
+                       <td>
+                         An alias for the item.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/description">description</a></th>
+                       <td>
+                         <a href="http://schema.org/Text">Text</a>
+                       </td>
+                       <td>
+                         A descripton of the item.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></th>
+                       <td>
+                         <a href="http://schema.org/Text">Text</a>
+                       </td>
+                       <td>
+                         A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/identifier">identifier</a></th>
+                       <td>
+                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
+                         <a href="http://schema.org/Text">Text</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         The identifier property represents any kind of identifier for any kind of <a href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc.
+                         Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links.
+                         See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/image">image</a></th>
+                       <td>
+                         <a href="http://schema.org/ImageObject">ImageObject</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         An image of the item. This can be a <a href="http://schema.org/URL">URL</a> or a fully described <a href="http://schema.org/ImageObject">ImageObject</a>.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></th>
+                       <td>
+                         <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See
+                         <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/>
+                         Inverse property: <a href="http://schema.org/mainEntity">mainEntity</a>
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/name">name</a></th>
+                       <td>
+                         <a href="http://schema.org/Text">Text</a>
+                       </td>
+                       <td>
+                         The name of the item.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/potentialAction">potentialAction</a></th>
+                       <td>
+                         <a href="http://schema.org/Action">Action</a>
+                       </td>
+                       <td>
+                         Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/sameAs">sameAs</a></th>
+                       <td>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a style="color: #0000CC;" href="http://pending.schema.org/subjectOf">subjectOf</a></th>
+                       <td>
+                         <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
+                         <a href="http://schema.org/Event">Event</a>
+                       </td>
+                       <td>
+                         A CreativeWork or Event about this Thing..<br/>
+                         Inverse property: <a href="http://schema.org/about">about</a>.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/url">url</a></th>
+                       <td>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         URL of the item.
+                       </td>
+                     </tr>
+                   </tbody>
+                 </table>
+               </section>
+             </div>
+           </div>
+      </div>
+      {% include footer.html %}
+
+
+
+   </body>
+</html>

--- a/_devTypes/Sample.html
+++ b/_devTypes/Sample.html
@@ -1,6 +1,6 @@
 ---
 dateModified: 2018-11-06
-description: " A material entity that is a portion of a whole, and intended to be representative of the whole. Examples of samples include biomedical samples (blood, urine), commercial samples (carpet, metal)."
+description: "A material entity that is a portion of a whole. <p>Comments: Typically samples are intended to be representative of the whole or aspects thereof. Examples of samples include biomedical samples (blood, urine) and commercial samples (carpet, metal).</p>"
 hierarchy:
 - Thing
 gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Sample

--- a/_devTypes/Sample.html
+++ b/_devTypes/Sample.html
@@ -1,0 +1,192 @@
+---
+dateModified: 2018-11-06
+description: " A material entity that is a portion of a whole, and intended to be representative of the whole. Examples of samples include biomedical samples (blood, urine), commercial samples (carpet, metal)."
+hierarchy:
+- Thing
+gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Sample
+group: samples
+name: Sample
+parent_type: Thing
+spec_type: Type
+status: revision
+version: '0.1-DRAFT'
+
+bsc: #0B794B;
+pending: #0000CC;
+external: #454547;
+
+---
+
+
+<!DOCTYPE HTML>
+<html>
+   {% include head.html %}
+
+   <body>
+      {% include header.html %}
+      {% include navbar.html %}
+      <div class="page-content">
+        <div class="wrapper">
+           <div id="main-content-wrapper" class="outer">
+              <section id="main_content" class="inner">
+                {% include type_start.html %}
+
+                <table class="bioschemas_properties bsc_type">
+                   <thead>
+                      <tr>
+                         <th>Property</th>
+                         <th>Expected Type</th>
+                         <th>Description</th>
+                      </tr>
+                   </thead>
+                   <tbody>
+                     <tr class="new_props_sdo">
+                        <td colspan="3">
+                           Properties from <a style="color: #0B794B;" href="/{{page.name}}">{{page.name}}</a> (pending schema.org integration).
+                        </td>
+                     </tr>
+                     <tr id="additionalProperty">
+                       <th><a href="http://schema.org/additionalProperty">additionalProperty</th>
+                       <td>
+                         <a href="http://schema.org/PropertyValue">PropertyValue</a>
+                       </td>
+                       <td>A property-value pair representing an additional characteristics of the entitity, e.g. a product feature or another characteristic for which there is no matching property in schema.org. <br/>
+                         Note: Publishers should be aware that applications designed to use specific schema.org properties (e.g. http://schema.org/width, http://schema.org/color, http://schema.org/gtin13, ...) will typically expect such data to be provided using those properties, rather than using the generic property/value mechanism.<br />
+                      </td>
+                     </tr>
+                     <tr class="reu_props_sdo">
+                        <td colspan="3">Properties from <a href="http://schema.org/Thing">Thing</a></td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/additionalType">additionalType</a></th>
+                       <td>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax.
+                         This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax -
+                         the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those
+                         defined externally.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/alternateName">alternateName</a></th>
+                       <td>
+                         <a href="http://schema.org/Text">Text</a>
+                       </td>
+                       <td>
+                         An alias for the item.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/description">description</a></th>
+                       <td>
+                         <a href="http://schema.org/Text">Text</a>
+                       </td>
+                       <td>
+                         A descripton of the item.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></th>
+                       <td>
+                         <a href="http://schema.org/Text">Text</a>
+                       </td>
+                       <td>
+                         A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/identifier">identifier</a></th>
+                       <td>
+                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
+                         <a href="http://schema.org/Text">Text</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         The identifier property represents any kind of identifier for any kind of <a href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc.
+                         Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links.
+                         See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/image">image</a></th>
+                       <td>
+                         <a href="http://schema.org/ImageObject">ImageObject</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         An image of the item. This can be a <a href="http://schema.org/URL">URL</a> or a fully described <a href="http://schema.org/ImageObject">ImageObject</a>.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></th>
+                       <td>
+                         <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See
+                         <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/>
+                         Inverse property: <a href="http://schema.org/mainEntity">mainEntity</a>
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/name">name</a></th>
+                       <td>
+                         <a href="http://schema.org/Text">Text</a>
+                       </td>
+                       <td>
+                         The name of the item.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/potentialAction">potentialAction</a></th>
+                       <td>
+                         <a href="http://schema.org/Action">Action</a>
+                       </td>
+                       <td>
+                         Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/sameAs">sameAs</a></th>
+                       <td>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a style="color: #0000CC;" href="http://pending.schema.org/subjectOf">subjectOf</a></th>
+                       <td>
+                         <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
+                         <a href="http://schema.org/Event">Event</a>
+                       </td>
+                       <td>
+                         A CreativeWork or Event about this Thing..<br/>
+                         Inverse property: <a href="http://schema.org/about">about</a>.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/url">url</a></th>
+                       <td>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         URL of the item.
+                       </td>
+                     </tr>
+                   </tbody>
+                 </table>
+               </section>
+             </div>
+           </div>
+      </div>
+      {% include footer.html %}
+
+
+
+   </body>
+</html>

--- a/_devTypes/Taxon.html
+++ b/_devTypes/Taxon.html
@@ -1,6 +1,7 @@
 ---
-dateModified: 2018-11-06
-description: "A taxonomic group of any rank, such as a species, family, or class."
+dateModified: 2018-11-09
+description: "A set of organisms asserted to represent a natural cohesive biological unit.
+<p>Note: The set of organisms is inclusive of individuals living, recently dead, and yet to be born.</p>"
 hierarchy:
 - Thing
 gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Taxon
@@ -54,7 +55,7 @@ external: #454547;
                          <a href="http://schema.org/URL">URL</a>
                        </td>
                        <td>
-                         Closest child taxon of the taxon in question. <br/>
+                         Closest child taxa of the taxon in question. <br/>
                          Inverse property: parentTaxon
                        </td>
                      </tr>
@@ -78,7 +79,7 @@ external: #454547;
                          <a href="http://schema.org/URL">URL</a>
                        </td>
                        <td>
-                         The taxonomic rank of this name given as a URI from a controlled vocabulary, typically the ranks from TDWG TaxonRank ontology or equivalent Wikidata URIs.
+                         The taxonomic rank of this taxon given preferably as a URI from a controlled vocabulary – (typically the ranks from TDWG TaxonRank ontology or equivalent Wikidata URIs).
                        </td>
                      </tr>
                      <tr class="reu_props_sdo">

--- a/_devTypes/Taxon.html
+++ b/_devTypes/Taxon.html
@@ -1,0 +1,219 @@
+---
+dateModified: 2018-11-06
+description: "A taxonomic group of any rank, such as a species, family, or class."
+hierarchy:
+- Thing
+gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Taxon
+group: biodiversity
+name: Taxon
+parent_type: Thing
+spec_type: Type
+status: revision
+version: '0.1-DRAFT'
+
+bsc: #0B794B;
+pending: #0000CC;
+external: #454547;
+
+---
+
+
+<!DOCTYPE HTML>
+<html>
+   {% include head.html %}
+
+   <body>
+      {% include header.html %}
+      {% include navbar.html %}
+      <div class="page-content">
+        <div class="wrapper">
+           <div id="main-content-wrapper" class="outer">
+              <section id="main_content" class="inner">
+                {% include type_start.html %}
+
+                <table class="bioschemas_properties bsc_type">
+                   <thead>
+                      <tr>
+                         <th>Property</th>
+                         <th>Expected Type</th>
+                         <th>Description</th>
+                      </tr>
+                   </thead>
+                   <tbody>
+                     <tr class="new_props_sdo">
+                        <td colspan="3">
+                           Properties from <a style="color: #0B794B;" href="/{{page.name}}">{{page.name}}</a> (pending schema.org integration).
+                        </td>
+                     </tr>
+                     </tr>
+                     <tr id="childTaxon">
+                       <th style="color: #0B794B;">childTaxon</th>
+                       <td>
+                         <a style="color: #0B794B;" href="/Taxon">Taxon</a> or<br/>
+                         <a href="http://schema.org/Text">Text</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         Closest child taxon of the taxon in question. <br/>
+                         Inverse property: parentTaxon
+                       </td>
+                     </tr>
+                     <tr id="parentTaxon">
+                       <th style="color: #0B794B;">parentTaxon</th>
+                       <td>
+                         <a style="color: #0B794B;" href="/Taxon">Taxon</a> or<br/>
+                         <a href="http://schema.org/Text">Text</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         Closest parent taxon of the taxon in question. <br/>
+                         Inverse property: childTaxon
+                       </td>
+                     </tr>
+                     <tr id="taxonRank">
+                       <th style="color: #0B794B;">taxonRank</th>
+                       <td>
+                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
+                         <a href="http://schema.org/Text">Text</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         The taxonomic rank of this name given as a URI from a controlled vocabulary, typically the ranks from TDWG TaxonRank ontology or equivalent Wikidata URIs.
+                       </td>
+                     </tr>
+                     <tr class="reu_props_sdo">
+                        <td colspan="3">Properties from <a href="http://schema.org/Thing">Thing</a></td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/additionalType">additionalType</a></th>
+                       <td>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax.
+                         This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax -
+                         the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those
+                         defined externally.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/alternateName">alternateName</a></th>
+                       <td>
+                         <a href="http://schema.org/Text">Text</a>
+                       </td>
+                       <td>
+                         An alias for the item.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/description">description</a></th>
+                       <td>
+                         <a href="http://schema.org/Text">Text</a>
+                       </td>
+                       <td>
+                         A descripton of the item.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></th>
+                       <td>
+                         <a href="http://schema.org/Text">Text</a>
+                       </td>
+                       <td>
+                         A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/identifier">identifier</a></th>
+                       <td>
+                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
+                         <a href="http://schema.org/Text">Text</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         The identifier property represents any kind of identifier for any kind of <a href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc.
+                         Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links.
+                         See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/image">image</a></th>
+                       <td>
+                         <a href="http://schema.org/ImageObject">ImageObject</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         An image of the item. This can be a <a href="http://schema.org/URL">URL</a> or a fully described <a href="http://schema.org/ImageObject">ImageObject</a>.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></th>
+                       <td>
+                         <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See
+                         <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/>
+                         Inverse property: <a href="http://schema.org/mainEntity">mainEntity</a>
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/name">name</a></th>
+                       <td>
+                         <a href="http://schema.org/Text">Text</a>
+                       </td>
+                       <td>
+                         The name of the item.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/potentialAction">potentialAction</a></th>
+                       <td>
+                         <a href="http://schema.org/Action">Action</a>
+                       </td>
+                       <td>
+                         Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/sameAs">sameAs</a></th>
+                       <td>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a style="color: #0000CC;" href="http://pending.schema.org/subjectOf">subjectOf</a></th>
+                       <td>
+                         <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
+                         <a href="http://schema.org/Event">Event</a>
+                       </td>
+                       <td>
+                         A CreativeWork or Event about this Thing..<br/>
+                         Inverse property: <a href="http://schema.org/about">about</a>.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/url">url</a></th>
+                       <td>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         URL of the item.
+                       </td>
+                     </tr>
+                   </tbody>
+                 </table>
+               </section>
+             </div>
+           </div>
+      </div>
+      {% include footer.html %}
+
+
+
+   </body>
+</html>

--- a/_includes/profile_start.html
+++ b/_includes/profile_start.html
@@ -84,7 +84,7 @@
    <br />
    <br />
    {%for branch_name in page.hierarchy %}
-   {% if branch_name == "BioChemEntity" or branch_name == "DataRecord" or branch_name == "LabProtocol"  %}
+   {% if branch_name == "BioChemEntity" or branch_name == "DataRecord" or branch_name == "LabProtocol" or branch_name == "Gene" or branch_name == "Protein" or branch_name == "Sample" or branch_name == "Taxon"  %}
    <a href="/devTypes/{{branch_name}}/">{{branch_name}}</a>
    {% else %}
    <a href="http://schema.org/{{branch_name}}">{{branch_name}}</a>


### PR DESCRIPTION
Brings the types in the drafts section of the website inline with the [proposal](https://docs.google.com/document/d/1FCLcjlsC_xfUCwKy-HnwockRexVcMUHAAGohfTryh08/edit#) made to the community.

Here is the [proposal](https://docs.google.com/document/d/1ds_HK5PtRc3OlpR2OEi9D1kwhTuKDT_jyuKx2Ucl-oI/edit#) from the Samples group.

This pull request only affects the drafts, not the current types.