### PR TITLE
Adding ChemicalSubstance type and profile

### DIFF
--- a/_devSpecs/ChemicalSubstance.html
+++ b/_devSpecs/ChemicalSubstance.html
@@ -28,7 +28,7 @@ spec_info:
   version: 0.1-draft
   version_date: 20181207T110158
   official_type: ""
-  full_example: https://github.com/BioSchemas/specifications/tree/master/ChemicalSubstance/examples
+  full_example: https://github.com/BioSchemas/specifications/tree/master/ChemicalSubstance/examples/0.1-DRAFT/
 mapping:
 - property: alternateName
   expected_types:

--- a/_devSpecs/ChemicalSubstance.html
+++ b/_devSpecs/ChemicalSubstance.html
@@ -1,0 +1,272 @@
+---
+redirect_from: "devSpecs/ChemicalSubstance/specification"
+redirect_from: "devSpecs/ChemicalSubstance/specification/"
+name: ChemicalSubstance
+
+status: revision
+spec_type: Profile
+group: chemicals
+use_cases_url: '/useCases/ChemicalSubstance/'
+cross_walk_url: 'https://docs.google.com/spreadsheets/d/1ZuJHrUwpkWACAt0De6OXhlWZ9pSRTJ1m9H954i8-FvQ/edit?ts=5bebfe78&pli=1#gid=1261485211'
+gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Chemistry
+live_deploy: ''
+
+parent_type: Thing
+hierarchy:
+- Thing
+- BioChemEntity
+- ChemicalSubstance
+
+spec_mapping_url: https://docs.google.com/spreadsheets/d/1ZuJHrUwpkWACAt0De6OXhlWZ9pSRTJ1m9H954i8-FvQ/edit?ts=5bebfe78&pli=1#gid=1261485211
+
+spec_info:
+  title: ChemicalSubstance
+  subtitle: Bioschemas profile describing a ChemicalEntity
+  description: 'This specification describes a ChemicalSubstance which is ''a portion
+    of matter of constant composition, composed of molecular entities of the same
+    type or of different types'' (source: ChEBI).'
+  version: 0.1-draft
+  version_date: 20181207T110158
+  official_type: ""
+  full_example: https://github.com/BioSchemas/specifications/tree/master/ChemicalSubstance/examples
+mapping:
+- property: alternateName
+  expected_types:
+  - Text
+  description: An alias for the item.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: MANY
+  controlled_vocab: ""
+  example: |-
+    "alternateName": [
+        "SiO2"
+    ]
+- property: biochemicalInteraction
+  expected_types:
+  - BioChemEntity
+  description: ""
+  type: bioschemas
+  type_url: ""
+  bsc_description: Interaction of the molecular entity with other BioChemical entities.
+  marginality: Optional
+  cardinality: MANY
+  controlled_vocab: ""
+  example: ""
+- property: 'biochemicalSimilarity '
+  expected_types:
+  - BioChemEntity
+  description: ""
+  type: bioschemas
+  type_url: ""
+  bsc_description: A similar molecular entity, e.g., obtained by fingerprint similarity
+    algorithms.
+  marginality: Optional
+  cardinality: MANY
+  controlled_vocab: ""
+  example: ""
+- property: biologicalRole
+  expected_types:
+  - DefinedTerm
+  description: ""
+  type: bioschemas
+  type_url: ""
+  bsc_description: A role played by the molecular entity within a biological context.
+  marginality: Optional
+  cardinality: MANY
+  controlled_vocab: Any suitable ontology such as [ChEBI biological role](https://www.ebi.ac.uk/ols/ontologies/chebi/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FCHEBI_24432)
+  example: ""
+- property: chemicalRole
+  expected_types:
+  - DefinedTerm
+  description: ""
+  type: bioschemas
+  type_url: ""
+  bsc_description: A role played by the molecular entity within a chemical context.
+  marginality: Optional
+  cardinality: MANY
+  controlled_vocab: Any suitable ontology such as [ChEBI Chemical Role](https://www.ebi.ac.uk/ols/ontologies/chebi/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FCHEBI_51086)
+  example: |-
+    "chemicalRole": [{
+        "@type": "DefinedTerm",
+        "@id": "http://purl.bioontology.org/ontology/npo#NPO_1909",
+        "inDefinedTermSet": {
+            "@type": "DefinedTermSet",
+            "@id": "https://github.com/enanomapper/ontologies/blob/master/enanomapper.owl",
+            "name": "eNanoMapper ontology"
+        },
+        "termCode": "NPO_1909",
+        "name": "engineered nanomaterial",
+        "url": "http://bioportal.bioontology.org/ontologies/ENM/?p=classes&conceptid=http%3A%2F%2Fpurl.bioontology.org%2Fontology%2Fnpo%23NPO_1909"
+    }]
+- property: description
+  expected_types:
+  - Text
+  description: A description of the item.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: ONE
+  controlled_vocab: ""
+  example: ""
+- property: disambiguatingDescription
+  expected_types:
+  - Text
+  description: A sub property of description. A short description of the item used
+    to disambiguate from other, similar items. Information from other properties (in
+    particular, name) may be necessary for the description to be useful for disambiguation.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: ONE
+  controlled_vocab: ""
+  example: ""
+- property: hasBioChemEntityPart
+  expected_types:
+  - BioChemEntity
+  - URL
+  description: Indicates a BioChemEntity that (in some sense) has this BioChemEntity
+    as a part.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Recommended
+  cardinality: MANY
+  controlled_vocab: ""
+  example: |-
+    "hasBioChemEntityPart": [{
+        "@type": "BioChemEntity",
+        "identifier": "CHEBI:30563",
+        "name": "silicon dioxide",
+        "url": "https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:30563"
+    }]
+- property: identifier
+  expected_types:
+  - PropertyValue
+  - Text
+  - URL
+  description: The identifier property represents any kind of identifier for any kind
+    of Thing, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated
+    properties for representing many of these, either as textual strings or as URL
+    (URI) links. See [background notes](http://schema.org/docs/datamodel.html#identifierBg)
+    for more details.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Minimum
+  cardinality: ONE
+  controlled_vocab: ""
+  example: '"identifier": "https://data.enanomapper.net/substance/NWKI-e624f68e-2e00-30e4-b4bb-9e34383580cb/study"'
+- property: image
+  expected_types:
+  - ImageObject
+  - URL
+  description: An image of the item. This can be a URL or a fully described ImageObject.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: MANY
+  controlled_vocab: ""
+  example: ""
+- property: molecularFormula
+  expected_types:
+  - Text
+  description: 'Inverse property: isPartOfBioChemEntity'
+  type: bioschemas
+  type_url: ""
+  bsc_description: The empirical formula is the simplest whole number ratio of all
+    the atoms in a molecule. Because for substances this often cannot accurately be
+    determined, an approximation is acceptable.
+  marginality: Recommended
+  cardinality: ONE
+  controlled_vocab: ""
+  example: '"molecularFormula": "SiO2"'
+- property: name
+  expected_types:
+  - Text
+  description: The name of the item.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Minimum
+  cardinality: ONE
+  controlled_vocab: ""
+  example: '"name": "JRCNM10404",'
+- property: potentialUse
+  expected_types:
+  - DefinedTerm
+  description: ""
+  type: bioschemas
+  type_url: ""
+  bsc_description: Intended use of the molecular entity by humans.
+  marginality: Optional
+  cardinality: MANY
+  controlled_vocab: Any suitable ontology such as  [ChEBI Application](https://www.ebi.ac.uk/ols/ontologies/chebi/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FCHEBI_33232)
+  example: |-
+    "potentialUse": [{
+            "@type": "DefinedTerm",
+            "@id": "http://purl.obolibrary.org/obo/CHEBI_23888",
+            "inDefinedTermSet": "ftp://ftp.ebi.ac.uk/pub/databases/chebi/ontology/chebi.owl",
+            "termCode": "CHEBI:23888",
+            "name": "drug",
+            "url": "https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:23888"
+        },
+        {
+            "@type": "DefinedTerm",
+            "@id": "http://purl.enanomapper.org/onto/ENM_8000194",
+            "inDefinedTermSet": "http://purl.enanomapper.net/onto/enanomapper.owl",
+            "termCode": "ENM_8000194",
+            "name": "food flavouring and nutrient",
+            "url": "https://www.ebi.ac.uk/ols/ontologies/enm/terms?iri=http%3A%2F%2Fpurl.enanomapper.org%2Fonto%2FENM_8000194"
+        }
+    ]
+- property: sameAs
+  expected_types:
+  - URL
+  description: URL of a reference Web page that unambiguously indicates the item's
+    identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official
+    website.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: MANY
+  controlled_vocab: ""
+  example: '"sameAs": "https://www.wikidata.org/wiki/Q58630711"'
+- property: url
+  expected_types:
+  - URL
+  description: URL of the item.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Minimum
+  cardinality: MANY
+  controlled_vocab: ""
+  example: '"url": "https://data.enanomapper.net/substance/NWKI-e624f68e-2e00-30e4-b4bb-9e34383580cb/study'
+
+---
+<!DOCTYPE HTML>
+<html>
+   {% include head.html %}
+   <body>
+      {% include header.html %}
+      {% include navbar.html %}
+      <div class="page-content">
+         <div class="wrapper">
+            <div id="main-content-wrapper" class="outer">
+               <section id="main_content" class="inner">
+                  {% include profile_start.html %}
+                  {% include specification_table.html %}
+               </section>
+            </div>
+         </div>
+      </div>
+      {% include footer.html %}
+   </body>
+</html>

--- a/_devTypes/ChemicalSubstance.html
+++ b/_devTypes/ChemicalSubstance.html
@@ -1,0 +1,316 @@
+---
+dateModified: 2018-11-14
+description: "A chemical substance."
+hierarchy:
+- Thing
+- BioChemEntity
+gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Chemicals
+group: chemicals
+name: ChemicalSubstance
+parent_type: BioChemEntity
+spec_type: Type
+status: revision
+version: '0.1-DRAFT'
+
+bsc: #0B794B;
+pending: #0000CC;
+external: #454547;
+
+---
+
+
+<!DOCTYPE HTML>
+<html>
+   {% include head.html %}
+
+   <body>
+      {% include header.html %}
+      {% include navbar.html %}
+      <div class="page-content">
+        <div class="wrapper">
+           <div id="main-content-wrapper" class="outer">
+              <section id="main_content" class="inner">
+                {% include type_start.html %}
+
+                <table class="bioschemas_properties bsc_type">
+                   <thead>
+                      <tr>
+                         <th>Property</th>
+                         <th>Expected Type</th>
+                         <th>Description</th>
+                      </tr>
+                   </thead>
+                   <tbody>
+                     <tr class="new_props_sdo">
+                        <td colspan="3">
+                           Properties from <a style="color: #0B794B;" href="/{{page.name}}">{{page.name}}</a> (pending schema.org integration).
+                        </td>
+                     </tr>
+                     <!-- ChemicalSubstance properties begin here -->
+                    <tr id="molecularFormula">
+                      <th style="color: #0B794B;">molecularFormula</th>
+                      <td>
+                        <a href="http://schema.org/URL">Text</a>
+                      </td>
+                      <td>
+                        The empirical formula is the simplest whole number ratio of all the atoms in a molecule.
+                      </td>
+                    </tr>
+                    <tr id="biochemicalInteraction">
+                      <th style="color: #0B794B;">biochemicalInteraction</th>
+                      <td>
+                          <a style="color: #0B794B;" href="/BioChemEntity">BioChemEntity</a>
+                      </td>
+                      <td>
+                          A BioChemEntity that is known to interact with the item.
+                      </td>
+                    </tr>
+                    <tr id="biochemicalSimilarity">
+                      <th style="color: #0B794B;">biochemicalSimilarity</th>
+                      <td>
+                        <a style="color: #0B794B;" href="/BioChemEntity">BioChemEntity</a>
+                      </td>
+                      <td>
+                          A similar molecular substance or molecular entity, e.g., obtained by fingerprint similarity algorithms.
+                      </td>
+                    </tr>
+                    <tr id="biologicalRole">
+                      <th style="color: #0B794B;">biologicalRole</th>
+                      <td>
+                        <a href="http://schema.org/DefinedTerm">DefinedTerm</a>
+                      </td>
+                      <td>
+                          A role played by the molecular entity within a biological context.
+                      </td>
+                    </tr>
+                    <tr id="chemicalRole">
+                      <th style="color: #0B794B;">chemicalRole</th>
+                      <td>
+                          <a href="http://schema.org/DefinedTerm">DefinedTerm</a>
+                      </td>
+                      <td>
+                          A role played by the molecular entity within a chemical context.
+                      </td>
+                    </tr>
+                    <tr id="potentialUse">
+                      <th style="color: #0B794B;">potentialUse</th>
+                      <td>
+                          <a href="http://schema.org/DefinedTerm">DefinedTerm</a>
+                      </td>
+                      <td>
+                          Intended use of the molecular entity by humans.
+                      </td>
+                    </tr>                    
+
+                    <!-- MolecularEntity properties ENDS here -->
+                     <tr class="reu_props_sdo">
+                        <td colspan="3">Properties from <a style="color: #0B794B;" href="/BioChemEntity">BioChemEntity</a></td>
+                     </tr>
+                     <tr id="additionalProperty">
+                       <th><a href="http://schema.org/additionalProperty">additionalProperty</th>
+                       <td>
+                         <a href="http://schema.org/PropertyValue">PropertyValue</a>
+                       </td>
+                       <td>A property-value pair representing an additional characteristics of the entitity, e.g. a product feature or another characteristic for which there is no matching property in schema.org. <br/>
+                         Note: Publishers should be aware that applications designed to use specific schema.org properties (e.g. http://schema.org/width, http://schema.org/color, http://schema.org/gtin13, ...) will typically expect such data to be provided using those properties, rather than using the generic property/value mechanism.<br />
+                      </td>
+                     </tr>
+                     <tr id="associatedDisease">
+                       <th style="color: #0B794B;">associatedDisease</th>
+                       <td>
+                         <a href="http://schema.org/MedicalCondition">MedicalCondition</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         Disease associated to this BioChemEntity.
+                       </td>
+                     </tr>
+                     <tr id="hasBioChemEntityPart">
+                       <th style="color: #0B794B;">hasBioChemEntityPart</th>
+                       <td>
+                         <a style="color: #0B794B;" href="/BioChemEntity">BioChemEntity</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         Indicates a BioChemEntity that (in some sense) has this BioChemEntity as a part.<br/>
+                         Inverse property: isPartOfBioChemEntity
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a style="color: #0000CC;" href="http://pending.schema.org/hasCategoryCode">hasCategoryCode</a></th>
+                       <td>
+                         <a style="color: #0000CC;" href="http://pending.schema.org/CategoryCode">CategoryCode</a>
+                       </td>
+                       <td>
+                         A Category code contained in this code set.
+                       </td>
+                     </tr>
+                     <tr id="hasRepresentation">
+                       <th style="color: #0B794B;">hasRepresentation</th>
+                       <td>
+                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
+                         <a href="http://schema.org/Text">Text</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         A common representation such as a protein sequence or chemical structure for this entity. For images use schema.org/image.
+                       </td>
+                     </tr>
+                     <tr id="isPartOfBioChemEntity">
+                       <th style="color: #0B794B;">isPartOfBioChemEntity</th>
+                       <td>
+                         <a style="color: #0B794B;" href="/BioChemEntity">BioChemEntity</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         Indicates a BioChemEntity that is (in some sense) a part of this BioChemEntity. <br/>
+                         Inverse property: hasBioChemEntityPart
+                       </td>
+                     </tr>
+                     <tr id="taxonomicRange">
+                       <th style="color: #0B794B;">taxonomicRange</th>
+                       <td>
+                         <a style="color: #0B794B;" href="/Taxon">Taxon</a> or<br/>
+                         <a href="http://schema.org/Text">Text</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         The taxonomic grouping of the organism that expresses, encodes, or in someway related to the BioChemEntity.
+                       </td>
+                     </tr>
+                     <tr class="reu_props_sdo">
+                        <td colspan="3">Properties from <a href="http://schema.org/Thing">Thing</a></td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/additionalType">additionalType</a></th>
+                       <td>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax.
+                         This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax -
+                         the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those
+                         defined externally.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/alternateName">alternateName</a></th>
+                       <td>
+                         <a href="http://schema.org/Text">Text</a>
+                       </td>
+                       <td>
+                         An alias for the item.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/description">description</a></th>
+                       <td>
+                         <a href="http://schema.org/Text">Text</a>
+                       </td>
+                       <td>
+                         A descripton of the item.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></th>
+                       <td>
+                         <a href="http://schema.org/Text">Text</a>
+                       </td>
+                       <td>
+                         A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/identifier">identifier</a></th>
+                       <td>
+                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
+                         <a href="http://schema.org/Text">Text</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         The identifier property represents any kind of identifier for any kind of <a href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc.
+                         Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links.
+                         See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/image">image</a></th>
+                       <td>
+                         <a href="http://schema.org/ImageObject">ImageObject</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         An image of the item. This can be a <a href="http://schema.org/URL">URL</a> or a fully described <a href="http://schema.org/ImageObject">ImageObject</a>.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></th>
+                       <td>
+                         <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See
+                         <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/>
+                         Inverse property: <a href="http://schema.org/mainEntity">mainEntity</a>
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/name">name</a></th>
+                       <td>
+                         <a href="http://schema.org/Text">Text</a>
+                       </td>
+                       <td>
+                         The name of the item.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/potentialAction">potentialAction</a></th>
+                       <td>
+                         <a href="http://schema.org/Action">Action</a>
+                       </td>
+                       <td>
+                         Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/sameAs">sameAs</a></th>
+                       <td>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a style="color: #0000CC;" href="http://pending.schema.org/subjectOf">subjectOf</a></th>
+                       <td>
+                         <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
+                         <a href="http://schema.org/Event">Event</a>
+                       </td>
+                       <td>
+                         A CreativeWork or Event about this Thing..<br/>
+                         Inverse property: <a href="http://schema.org/about">about</a>.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/url">url</a></th>
+                       <td>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         URL of the item.
+                       </td>
+                     </tr>
+                   </tbody>
+                 </table>
+               </section>
+             </div>
+           </div>
+      </div>
+      {% include footer.html %}
+
+
+
+   </body>
+</html>

--- a/_useCases/ChemicalSubstance.html
+++ b/_useCases/ChemicalSubstance.html
@@ -1,0 +1,31 @@
+---
+name: ChemicalSubstance
+group: chemicals
+collection: useCases
+active: true
+---
+
+<!DOCTYPE HTML>
+<html>
+   {% include head.html %}
+   <body>
+      {% include header.html %}
+      {% include navbar.html %}
+      <div class="page-content">
+         <div class="wrapper">
+            <div id="main-content-wrapper" class="outer">
+               <section id="main_content" class="inner">
+                  <h1>Use Cases for {{page.name}}</h1>
+                  {% assign group = site.groups | where:"identifier", page.group %}
+                  {% for g in group %}
+                  <p>The following use cases were developed by the <a href="{{g.url}}">{{ g.name }}</a> group.
+                     {% endfor %}
+                
+
+               </section>
+            </div>
+         </div>
+      </div>
+      {% include footer.html %}
+   </body>
+</html>


### PR DESCRIPTION
Based on the cosswalk mapping for [ChemicalSubstance](https://docs.google.com/spreadsheets/d/1ZuJHrUwpkWACAt0De6OXhlWZ9pSRTJ1m9H954i8-FvQ/edit?ts=5bebfe78&pli=1#gid=1261485211) I have created the first draft 0.1-draft on Bioschemas website:

- [x] ChemicalSubstance draft Profile page.
- [x] ChemicalSubstance draft Type page.
- [x] ChemicalSubstance empty Use Case page.

ToDo:

- [ ] Fill ChemicalSubstance Use Case page.
