### PR TITLE
Fix redirects for types

### DIFF
--- a/_types/BioChemEntity.html
+++ b/_types/BioChemEntity.html
@@ -1,8 +1,9 @@
 ---
-redirect_from: "BioChemEntity"
-redirect_from: "BioChemEntity/"
-redirect_from: "types/BioChemEntity/specification"
-redirect_from: "types/BioChemEntity/specification/"
+redirect_from: 
+  - "BioChemEntity"
+  - "BioChemEntity/"
+  - "types/BioChemEntity/specification"
+  - "types/BioChemEntity/specification/"
 dateModified: 2018-11-10
 description: "Any biological, chemical, or biochemical thing. For example: a protein; a gene; a chemical; a synthetic chemical."
 hierarchy:

--- a/_types/BioChemEntity.html
+++ b/_types/BioChemEntity.html
@@ -1,9 +1,9 @@
 ---
 redirect_from: 
-  - "BioChemEntity"
-  - "BioChemEntity/"
-  - "types/BioChemEntity/specification"
-  - "types/BioChemEntity/specification/"
+ - "BioChemEntity"
+ - "BioChemEntity/"
+ - "types/BioChemEntity/specification"
+ - "types/BioChemEntity/specification/"
 dateModified: 2018-11-10
 description: "Any biological, chemical, or biochemical thing. For example: a protein; a gene; a chemical; a synthetic chemical."
 hierarchy:

--- a/_types/DataRecord.html
+++ b/_types/DataRecord.html
@@ -1,8 +1,9 @@
 ---
-redirect_from: "DataRecord"
-redirect_from: "DataRecord/"
-redirect_from: "types/DataRecord/specification"
-redirect_from: "types/DataRecord/specification/"
+redirect_from:
+ - "DataRecord"
+ - "DataRecord/"
+ - "types/DataRecord/specification"
+ - "types/DataRecord/specification/"
 cross_walk_url: ''
 dateModified: 2018-02-25
 description: "A Record acts itself as a dataset although it refers to what could be

--- a/_types/Gene.html
+++ b/_types/Gene.html
@@ -1,6 +1,7 @@
 ---
-redirect_from: "Gene"
-redirect_from: "Gene/"
+redirect_from:
+ - "Gene"
+ - "Gene/"
 dateModified: 2018-11-10
 description: "A gene."
 hierarchy:

--- a/_types/LabProtocol.html
+++ b/_types/LabProtocol.html
@@ -1,8 +1,9 @@
 ---
-redirect_from: "LabProtocol"
-redirect_from: "LabProtocol/"
-redirect_from: "types/LabProtocol/specification"
-redirect_from: "types/LabProtocol/specification/"
+redirect_from:
+ - "LabProtocol"
+ - "LabProtocol/"
+ - "types/LabProtocol/specification"
+ - "types/LabProtocol/specification/"
 cross_walk_url: https://docs.google.com/spreadsheets/d/1RWYIphvcBMHl8SLJl5-xRMZI0YaYrtJtClBSoOPL4xQ
 dateModified: 2018-03-09
 description: 'An experimental protocol is a sequence of tasks and operations executed to perform experimental research in biological and biomedical areas.

--- a/_types/Protein.html
+++ b/_types/Protein.html
@@ -1,6 +1,7 @@
 ---
-redirect_from: "Protein"
-redirect_from: "Protein/"
+redirect_from:
+ - "Protein"
+ - "Protein/"
 dateModified: 2018-11-10
 description: "A protein or a computationally generated protein annotation."
 hierarchy:

--- a/_types/Sample.html
+++ b/_types/Sample.html
@@ -1,6 +1,7 @@
 ---
-redirect_from: "Sample"
-redirect_from: "Sample/"
+redirect_from:
+ - "Sample"
+ - "Sample/"
 dateModified: 2018-11-09
 description: "A material entity that is a portion of a whole. <p>Comments: Typically samples are intended to be representative of the whole or aspects thereof. Examples of samples include biomedical samples (blood, urine) and commercial samples (carpet, metal).</p>"
 hierarchy:

--- a/_types/Taxon.html
+++ b/_types/Taxon.html
@@ -1,6 +1,7 @@
 ---
-redirect_from: "Taxon"
-redirect_from: "Taxon/"
+redirect_from:
+ - "Taxon"
+ - "Taxon/"
 dateModified: 2018-11-09
 description: "A set of organisms asserted to represent a natural cohesive biological unit."
 hierarchy:


### PR DESCRIPTION
Previously it was specifying `redirect_from` multiple times, presumably overwriting each time, so only the last redirect was being honoured. e.g. for `BioChemEntity`, only the `types/BioChemEntity/specification/` redirect would work.