### PR TITLE
Corrected liquid syntax for sorting

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@ layout: default
 
                 <section class="upcoming-events">
                     <h3>Upcoming events</h3>
-                    {% assign sorted_meetings = (site.meetings | sort: 'start_date') %}
+                    {% assign sorted_meetings = site.meetings | sort: 'start_date' %}
                     {% assign count = 0 %}
                     {% for meeting in sorted_meetings %}
                     {% assign currentDate = site.time | date: '%F' %}

--- a/liveDeploys/index.html
+++ b/liveDeploys/index.html
@@ -106,7 +106,7 @@ description: |-
 
       <section>
         <h3>Deployment Stories</h3>
-          {% assign sorted_stories = (site.stories | sort: 'date-added' | reverse ) %}
+          {% assign sorted_stories = site.stories | sort: 'date-added' | reverse  %}
           {% for story in sorted_stories %}
           <div class="deployment-story">
               <strong><a href="{{ story.external-url }}">{{ story.name }}</a></strong>

--- a/meetings/index.html
+++ b/meetings/index.html
@@ -8,7 +8,7 @@ title: Meetings
 <p>Here you can find all the meetings involving Bioschemas community. If you wish to be involved, please have a look at the <a href="/howtojoin/">Joining Bioschemas</a> page.</p>
 <h2>Upcoming Meetings</h2>
 <ul>
-  {% assign sorted_meetings = (site.meetings | sort: 'start_date') %}
+  {% assign sorted_meetings = site.meetings | sort: 'start_date' %}
   {% for meeting in sorted_meetings %}
     {% assign currentDate = site.time | date: '%F' %}
     {% assign meetingDate = meeting.start_date | date: '%F' %}


### PR DESCRIPTION
This branch removes the warnings that were displaying in the Jekyll logs. The sorting had been done with an older version of liquid. This now has the same effect but does not generate the warnings.