### PR TITLE
Removing isa-explore from live deploys

### DIFF
--- a/_liveDeploys/liveDeploy.md
+++ b/_liveDeploys/liveDeploy.md
@@ -52,15 +52,6 @@ list:
     bsc_ver: 0.1
     comments:
 -
-    name: Isaexplorer
-    highlight:
-    example_URL: http://scientificdata.isa-explorer.org/
-    resource_URL: http://scientificdata.isa-explorer.org/
-    schema_org: DataCatalog
-    bsc_profile: DataCatalog
-    bsc_ver: 0.1
-    comments:
--
     name: IUPHAR/BPS
     highlight:
     example_URL: http://www.guidetopharmacology.org/


### PR DESCRIPTION
http://scientificdata.isa-explorer.org/ is no longer online, ie, URL doesn't resolve