### PR TITLE
Added link to protein structure live deploy

### DIFF
--- a/_specifications/ProteinStructure.html
+++ b/_specifications/ProteinStructure.html
@@ -9,7 +9,7 @@ group: proteins
 use_cases_url: /useCases/Proteins/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1VaqJUGPUtGvUZgzXskI2VQTfhX23uQJ83GOybjIg6xw
 gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20ProteinStructure
-live_deploy: ''
+live_deploy: /liveDeploys/
 
 parent_type: BioChemEntity
 hierarchy:
@@ -154,8 +154,8 @@ mapping:
   expected_types:
   - Place
   - PostalAddress
-  - PropertyValue 
-  - Text 
+  - PropertyValue
+  - Text
   - URL
   description: The location of for example where the event is happening, an organization
     is located, or where an action takes place.
@@ -250,7 +250,7 @@ mapping:
   example: ""
 - property: SIO:010081
   expected_types:
-  - BioChemEntity 
+  - BioChemEntity
   - URL
   description: ""
   type: external
@@ -274,7 +274,7 @@ mapping:
   cardinality: ONE
   controlled_vocab: ""
   example: ""
-  
+
 ---
 
 <!DOCTYPE HTML>


### PR DESCRIPTION
ProteinStructure has two live deploys on the live deploy page but these were not being shown from the table of profiles on the [specifications](https://bioschemas.org/specifications/) page. This is due to the live deploys link being missed from the metadata in the ProteinStructure profile.  

This pull request adds the relevant metadata link and allows the hyperlink from the row in the profiles table on the specification page to the live deploys page.