### PR TITLE
Fixed draft tools profile link to crosswalk

### DIFF
--- a/_devSpecs/Tool.html
+++ b/_devSpecs/Tool.html
@@ -7,7 +7,7 @@ status: revision
 spec_type: Profile
 group: tools
 use_cases_url: ''
-cross_walk_url: https://docs.google.com/spreadsheets/d/1s342mMwfXAGl5uwgTCcwsVLQztxRIDwTi92zEouP33o/edit#gid=1063339077
+cross_walk_url: https://docs.google.com/spreadsheets/d/1kogQ4tLMbhnM-B8IKtFNmMenRgqopi76wGKCCyAqUXM/edit#gid=1483018794
 gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Tool
 live_deploy: /liveDeploys/
 
@@ -17,7 +17,7 @@ hierarchy:
 - CreativeWork
 - SoftwareApplication
 
-spec_mapping_url: https://docs.google.com/spreadsheets/d/1s342mMwfXAGl5uwgTCcwsVLQztxRIDwTi92zEouP33o/edit#gid=1063339077
+spec_mapping_url: https://docs.google.com/spreadsheets/d/1kogQ4tLMbhnM-B8IKtFNmMenRgqopi76wGKCCyAqUXM/edit#gid=1483018794
 
 spec_info:
   title: Tool


### PR DESCRIPTION
The link to the crosswalk document in the 0.3 draft tools profile was pointing to an old crosswalk document. This PR fixes the link.