### PR TITLE
Remove travel fund banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,10 +14,6 @@ layout: default
 
 
     <div class="container-flow">
-        <div class="alert alert-success" role="alert">
-            <i class="fas fa-exclamation-circle"></i>   Welcoming applications for the <a href="https://www.elixir-europe.org/platforms/interoperability/rfp-bioschemas" class="alert-link">ELIXIR Bioschemas Travel Grants and Staff Exchange Programme</a>.<br/>
-            <em>Travel grant applications for the Face-to-Face meeting are being accepted until 24 April 2019.</em>
-        </div>
         <div class="row">
             <div class="col-md-8">
                 <h1>What is Bioschemas?</h1>


### PR DESCRIPTION
Remove the banner from the home page about the travel fund. The fund is no longer accepting applications.