### PR TITLE
Update Taxon profile to v0.4

### DIFF
--- a/_devSpecs/Taxon.html
+++ b/_devSpecs/Taxon.html
@@ -79,7 +79,7 @@ mapping:
   description: |-
     Closest child taxa of the taxon in question.
     Inverse property: parentTaxon
-  type: schema.org
+  type: ""
   type_url: ""
   bsc_description: Direct, most proximate lower-rank child taxa
   marginality: Optional
@@ -123,7 +123,7 @@ mapping:
   description: |-
     Closest parent taxon of the taxon in question.
     Inverse property: childTaxon
-  type: schema.org
+  type: ""
   type_url: ""
   bsc_description: Direct, most proximate higher-rank parent taxon
   marginality: Recommended
@@ -159,7 +159,7 @@ mapping:
   description: The taxonomic rank of this taxon given preferably as a URI from a controlled
     vocabulary (e.g. the ranks from TDWG TaxonRank ontology or equivalent Wikidata
     URIs)
-  type: schema.org
+  type: ""
   type_url: ""
   bsc_description: ""
   marginality: Minimum

--- a/_devSpecs/Taxon.html
+++ b/_devSpecs/Taxon.html
@@ -6,7 +6,7 @@ redirect_from:
 name: Taxon
 url: Taxon
 
-status: release # Change to revision if you are working on an update
+status: revision # Change to revision if you are working on an update
 spec_type: Profile
 group: biodiversity
 use_cases_url: /useCases/Taxon/
@@ -26,10 +26,11 @@ spec_info:
   subtitle: Bioschemas profile for describing a biological taxon
   description: 'This profile aims to denote a taxon by common properties such as its
     scientific name, taxonomic rank and vernacular names. It is also a means to link
-    to existing taxonomic registers where each taxon has a URI.Changes in 0.4: parentTaxon,
-    childTaxon and taxonRank are moved to namespace schema.org.'
-  version: "0.4"
-  version_date: 20190617T154222
+    to existing taxonomic registers where each taxon has a URI. <br/>Changes in 0.4:
+    <ul><li>taxonRank promoted to minimal marginality</li><li>parentTaxon, childTaxon
+    and taxonRank are moved to namespace schema.org.</li><li>scientificName and scientificNameAuthorship removed</li></ul>'
+  version: 0.4-DRAFT
+  version_date: 20190619T133527
   official_type: http://schema.org/Taxon
   full_example: https://github.com/BioSchemas/specifications/tree/master/Taxon/examples/
 mapping:

--- a/_devSpecs/Taxon.html
+++ b/_devSpecs/Taxon.html
@@ -24,12 +24,13 @@ hierarchy:
 spec_info:
   title: Taxon
   subtitle: Bioschemas profile for describing a biological taxon
-  description: This profile aims to denote a taxon by common properties such as its
-    scientific name, authority, taxonomic rank and vernacular names. It is also a
-    means to link to existing taxonomic registers where each taxon has a URI.
-  version: 0.3
-  version_date: 20181110T112249
-  official_type: http://bioschemas.org/Taxon
+  description: 'This profile aims to denote a taxon by common properties such as its
+    scientific name, taxonomic rank and vernacular names. It is also a means to link
+    to existing taxonomic registers where each taxon has a URI.Changes in 0.4: parentTaxon,
+    childTaxon and taxonRank are moved to namespace schema.org.'
+  version: "0.4"
+  version_date: 20190617T154222
+  official_type: http://schema.org/Taxon
   full_example: https://github.com/BioSchemas/specifications/tree/master/Taxon/examples/
 mapping:
 - property: additionalType
@@ -48,22 +49,21 @@ mapping:
   marginality: Optional
   cardinality: MANY
   controlled_vocab: ""
-  example: |-
-    { "@context": [
-            "http://schema.org",
-            { "dwc": "http://rs.tdwg.org/dwc/terms/" }
-        ],
-        "@type" : "Taxon",
-        "additionalType": "dwc:Taxon"
-    }
+  example: |
+    "@context": [
+          "http://schema.org",
+          { "dwc": "http://rs.tdwg.org/dwc/terms/" }
+      ],
+    "@type" : "Taxon",
+    "additionalType": "dwc:Taxon"
 - property: alternateName
   expected_types:
   - Text
   description: An alias for the item.
   type: ""
   type_url: ""
-  bsc_description: Scientific name, possibly including authorship and date information,
-    of a synonym of the currently valid (zoological) or accepted (botanical) taxon.
+  bsc_description: Scientific name, with authorship and date information if known,
+    of a synonym of the currently valid (zoological) or accepted (botanical) name.
   marginality: Optional
   cardinality: MANY
   controlled_vocab: ""
@@ -79,16 +79,16 @@ mapping:
   description: |-
     Closest child taxa of the taxon in question.
     Inverse property: parentTaxon
-  type: bioschemas
-  type_url: http://bioschemas.org/childTaxon
+  type: schema.org
+  type_url: ""
   bsc_description: Direct, most proximate lower-rank child taxa
   marginality: Optional
   cardinality: MANY
   controlled_vocab: ""
-  example: "{   \"@type\" : \"Taxon\",\n    \"name\": \"Delphinapterus\",\n    \"taxonRank\"
-    : [ \"WD:Q34740\",  \"genus\" ],\n    \"childTaxon\": { \n        \"@type\": \"Taxon\",\n
-    \       \"name\": \"Delphinapterus leucas\",\n        \"taxonRank\" : [ \"WD:Q7432\",
-    \ \"species\" ]\n    }\n}"
+  example: "\"@type\" : \"Taxon\",\n\"name\": \"Delphinapterus\",\n\"taxonRank\" :
+    [ \"WD:Q34740\",  \"genus\" ],\n\"childTaxon\": { \n    \"@type\": \"Taxon\",\n
+    \   \"name\": \"Delphinapterus leucas\",\n    \"taxonRank\" : [ \"WD:Q7432\",
+    \ \"species\" ]\n}"
 - property: hasCategoryCode
   expected_types:
   - CategoryCode
@@ -106,14 +106,14 @@ mapping:
   description: The name of the item.
   type: ""
   type_url: ""
-  bsc_description: Taxon name without authorship nor date information of the currently
-    valid (zoological) or accepted (botanical) taxon.
+  bsc_description: Currently valid (zoological) or accepted (botanical) name for that
+    taxon, with authorship and date information if known.
   marginality: Minimum
   cardinality: ONE
   controlled_vocab: ""
   example: |-
     {
-        "name": "Delphinapterus leucas"
+        "name": "Delphinapterus leucas (Pallas, 1776)"
     }
 - property: parentTaxon
   expected_types:
@@ -123,8 +123,8 @@ mapping:
   description: |-
     Closest parent taxon of the taxon in question.
     Inverse property: childTaxon
-  type: bioschemas
-  type_url: http://bioschemas.org/parentTaxon
+  type: schema.org
+  type_url: ""
   bsc_description: Direct, most proximate higher-rank parent taxon
   marginality: Recommended
   cardinality: ONE
@@ -145,67 +145,32 @@ mapping:
   cardinality: MANY
   controlled_vocab: ""
   example: |-
-    {
-        "sameAs": [
-            "http://eol.org/pages/328541",
-            "http://en.wikipedia.org/w/index.php?title=Beluga_whale",
-            "http://www.catalogueoflife.org/annual-checklist/details/species/id/6850357",
-            "http://www.iucnredlist.org/details/6335"
-        ]
-    }
-- property: scientificName
-  expected_types:
-  - Text
-  description: ""
-  type: external
-  type_url: http://rs.tdwg.org/dwc/terms/scientificName
-  bsc_description: Full scientific name, with authorship and date information if know,
-    of the currently valid (zoological) or accepted (botanical) taxon.
-  marginality: Optional
-  cardinality: ONE
-  controlled_vocab: ""
-  example: |-
-    {
-        "dwc:scientificName": "Delphinapterus leucas (Pallas, 1776)"
-    }
-- property: scientificNameAuthorship
-  expected_types:
-  - Text
-  description: ""
-  type: external
-  type_url: http://rs.tdwg.org/dwc/terms/scientificNameAuthorship
-  bsc_description: 'Authorship information for the scientificName formatted according
-    to the conventions of the applicable nomenclatural Code. Example: "(Torr.) J.T.
-    Howell", "(Martinovský) Tzvelev", "(Györfi, 1952)"'
-  marginality: Optional
-  cardinality: ONE
-  controlled_vocab: ""
-  example: |-
-    {
-        "dwc:scientificNameAuthorship": "(Pallas, 1776)"
-    }
+    "sameAs": [
+        "http://eol.org/pages/328541",
+        "http://en.wikipedia.org/w/index.php?title=Beluga_whale",
+        "http://www.catalogueoflife.org/annual-checklist/details/species/id/6850357",
+        "http://www.iucnredlist.org/details/6335"
+    ]
 - property: taxonRank
   expected_types:
   - PropertyValue
   - Text
   - URL
   description: The taxonomic rank of this taxon given preferably as a URI from a controlled
-    vocabulary (typically the ranks from TDWG TaxonRank ontology or equivalent Wikidata
+    vocabulary (e.g. the ranks from TDWG TaxonRank ontology or equivalent Wikidata
     URIs)
-  type: bioschemas
-  type_url: http://bioschemas.org/taxonRank
+  type: schema.org
+  type_url: ""
   bsc_description: ""
-  marginality: Recommended
+  marginality: Minimum
   cardinality: MANY
   controlled_vocab: ""
-  example: |-
-    {
-        "taxonRank": [
-          "http://rs.tdwg.org/ontology/voc/TaxonRank#Species",
-          "http://www.wikidata.org/entity/Q7432",
-          "species"
-        ]
-    }
+  example: |
+    "taxonRank": [
+      "http://rs.tdwg.org/ontology/voc/TaxonRank#Species",
+      "http://www.wikidata.org/entity/Q7432",
+      "species"
+    ]
 - property: url
   expected_types:
   - URL
@@ -228,12 +193,10 @@ mapping:
   cardinality: MANY
   controlled_vocab: ""
   example: |-
-    {
-        "dwc:vernacularName": [
-            { "@language": "en", "@value": "Beluga Whale" },
-            { "@language": "fr", "@value": "Bélouga" }
-        ]
-    }
+    "dwc:vernacularName": [
+        { "@language": "en", "@value": "Beluga Whale" },
+        { "@language": "fr", "@value": "Bélouga" }
+    ]
 
 ---
 


### PR DESCRIPTION
Hey guys, I updated the Taxon profile wrt. to the last discussions we had. 

This profile is consistent with Taxon type v0.3-draft that we intend to submit to schema.org. 
Most important changes are wrt. to 
- the use of parentTaxon/childTaxon properties
- name and alternateName Bioschemas descriptions

The example is also up to date.

Franck.
