### PR TITLE
Add draft types

### DIFF
--- a/_devTypes/BioChemStructure.html
+++ b/_devTypes/BioChemStructure.html
@@ -32,7 +32,7 @@ external: #454547;
            <div id="main-content-wrapper" class="outer">
               <section id="main_content" class="inner">
                 {% include type_start.html %}
-                <table class="definition-table">
+                <table class="definition-table bsc_type">
                         <thead>
                   <tr><th>Property</th><th>Expected Type</th><th>Description</th>
                   </tr>

--- a/_devTypes/BioChemStructure.html
+++ b/_devTypes/BioChemStructure.html
@@ -1,0 +1,288 @@
+---
+redirect_from:
+- "/BioChemStructure"
+dateModified: 2019-06-20
+description: WwPDB and related data including modelled and hypothetical data. As well as 3D data for chemicals, e.g. stereo chemistry images in an analyzable format (not pure images).
+hierarchy:
+- Thing
+- BioChemEntity
+gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Enzyme
+group: chemicals
+name: BioChemStructure
+parent_type: BioChemEntity
+spec_type: Type
+status: revision #Revert to revision when working on the next version
+version: '0.1-DRAFT'
+
+bsc: #0B794B;
+pending : #0000CC;
+external: #454547;
+
+---
+
+
+<!DOCTYPE HTML>
+<html>
+   {% include head.html %}
+   <body>
+      {% include header.html %}
+      {% include navbar.html %}
+      <div class="page-content">
+        <div class="wrapper">
+           <div id="main-content-wrapper" class="outer">
+              <section id="main_content" class="inner">
+                {% include type_start.html %}
+                <table class="definition-table">
+                        <thead>
+                  <tr><th>Property</th><th>Expected Type</th><th>Description</th>
+                  </tr>
+                  </thead>
+
+                <tr class="supertype">
+                     <th class="supertype-name" colspan="3">Properties from <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemStructure">BioChemStructure</a></th>
+
+                </tr>
+
+                <tbody class="supertype">
+                  <tr typeof="rdfs:Property" resource="http://schema.org/boundMolecule">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#boundMolecule">boundMolecule</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp; or <br/> <link  property="rangeIncludes" href="/ChemicalSubstance" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/ChemicalSubstance">ChemicalSubstance</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/MolecularEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/MolecularEntity">MolecularEntity</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemStructure"></td><td class="prop-desc" property="rdfs:comment">Molecule, e.g., ligand, bound to this BioChem structure</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/creationMethod">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#creationMethod">creationMethod</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemStructure"><link property="domainIncludes" href="http://schema.org/SequenceAnnotation"></td><td class="prop-desc" property="rdfs:comment">Method used to create or obtain this annotation or BioChemEntity; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasAssociatedBioChemEntity">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasAssociatedBioChemEntity">hasAssociatedBioChemEntity</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Protein" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/Protein">Protein</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/RNA" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/RNA">RNA</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemStructure"><link property="domainIncludes" href="http://schema.org/Enzyme"></td><td class="prop-desc" property="rdfs:comment">Used to define the actual protein or RNA.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/massResolution">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#massResolution">massResolution</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Quantity" /><a   href="http://schema.org/Quantity">Quantity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemStructure"></td><td class="prop-desc" property="rdfs:comment">Mass spectometry resolution in the form '&lt;Number&gt; &lt;Unit of measure&gt;', for example '2.85 Å'</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sequenceLocation">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#sequenceLocation">sequenceLocation</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/SequenceRange" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/SequenceRange">SequenceRange</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemStructure"><link property="domainIncludes" href="http://schema.org/SequenceAnnotation"></td><td class="prop-desc" property="rdfs:comment">A range/position location where this annotation or BioChemEntity is located reagrding another BioChemEntity, for instance a BioChemStructure in a Protein.</td></tr><tr class="supertype">
+                     <th class="supertype-name" colspan="3">Properties from <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a></th>
+
+                </tr>
+
+                <tbody class="supertype">
+                  <tr typeof="rdfs:Property" resource="http://schema.org/associatedDisease">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#associatedDisease">associatedDisease</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/MedicalCondition" /><a   href="http://schema.org/MedicalCondition">MedicalCondition</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Disease associated to this BioChemEntity. Such disease can be a MedicalCondition or a URL. If you want to add an evidence supporting the association, please use PropertyValue.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/bioChemInteraction">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#bioChemInteraction">bioChemInteraction</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A BioChemEntity that is known to interact with this item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/bioChemSimilarity">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#bioChemSimilarity">bioChemSimilarity</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A similar molecular entity, e.g., obtained by fingerprint similarity algorithms.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/biologicalRole">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#biologicalRole">biologicalRole</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A role played by the molecular entity within a biological context.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasBioChemEntityPart">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasBioChemEntityPart">hasBioChemEntityPart</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Indicates a BioChemEntity that (in some sense) has this BioChemEntity as a part.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isPartOfBioChemEntity">isPartOfBioChemEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasMolecularFunction">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasMolecularFunction">hasMolecularFunction</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Molecular function performed by this BioChemEntity; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasRepresentation">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasRepresentation">hasRepresentation</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A common representation such as a protein sequence or chemical structure for this entity. For images use schema.org/image.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasSequenceAnnotation">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasSequenceAnnotation">hasSequenceAnnotation</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/SequenceAnnotation" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/SequenceAnnotation">SequenceAnnotation</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Pointer to a sequence annotation; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isEncodedByBioChemEntity">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isEncodedByBioChemEntity">isEncodedByBioChemEntity</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/DNA" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/DNA">DNA</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Gene" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/Gene">Gene</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/RNA" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/RNA">RNA</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Another BioChemEntity encoding by this one.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#encodesBioChemEntity">encodesBioChemEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isInvolvedInBiologicalProcess">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isInvolvedInBiologicalProcess">isInvolvedInBiologicalProcess</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Biological process this BioChemEntity is involved in; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isLocatedInSubcellularLocation">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isLocatedInSubcellularLocation">isLocatedInSubcellularLocation</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Subcellular location where this BioChemEntity is located; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isMatchedBy">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isMatchedBy">isMatchedBy</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/SequenceMatchingModel" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/SequenceMatchingModel">SequenceMatchingModel</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A model matching this BioChemEntity.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isPartOfBioChemEntity">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isPartOfBioChemEntity">isPartOfBioChemEntity</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Indicates a BioChemEntity that is (in some sense) a part of this BioChemEntity.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasBioChemEntityPart">hasBioChemEntityPart</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/taxonomicRange">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#taxonomicRange">taxonomicRange</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Taxon" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/Taxon">Taxon</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"><link property="domainIncludes" href="http://schema.org/Phenotype"></td><td class="prop-desc" property="rdfs:comment">The taxonomic grouping of the organism that expresses, encodes, or in someway related to the BioChemEntity.</td></tr><tr class="supertype">
+                     <th class="supertype-name" colspan="3">Properties from <a   href="http://schema.org/Thing">Thing</a></th>
+
+                </tr>
+
+                <tbody class="supertype">
+                  <tr typeof="rdfs:Property" resource="http://schema.org/additionalType">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/additionalType">additionalType</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax - the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those defined externally.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/alternateName">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/alternateName">alternateName</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An alias for the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/description">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/description">description</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A description of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/disambiguatingDescription">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/identifier">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/identifier">identifier</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The identifier property represents any kind of identifier for any kind of <a class="localLink" href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/image">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/image">image</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/ImageObject" /><a   href="http://schema.org/ImageObject">ImageObject</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An image of the item. This can be a <a class="localLink" href="http://schema.org/URL">URL</a> or a fully described <a class="localLink" href="http://schema.org/ImageObject">ImageObject</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/mainEntityOfPage">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/> Inverse property: <a   href="http://schema.org/mainEntity">mainEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/name">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/name">name</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The name of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/potentialAction">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/potentialAction">potentialAction</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Action" /><a   href="http://schema.org/Action">Action</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sameAs">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/sameAs">sameAs</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/subjectOf">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/subjectOf">subjectOf</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Event" /><a   href="http://schema.org/Event">Event</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A CreativeWork or Event about this Thing..<br/> Inverse property: <a   href="http://schema.org/about">about</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/url">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/url">url</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of the item.</td></tr>
+
+                </table>
+               </section>
+             </div>
+           </div>
+      </div>
+      {% include footer.html %}
+
+
+
+   </body>
+</html>

--- a/_devTypes/BioChemStructure.html
+++ b/_devTypes/BioChemStructure.html
@@ -6,7 +6,7 @@ description: WwPDB and related data including modelled and hypothetical data. As
 hierarchy:
 - Thing
 - BioChemEntity
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Enzyme
+gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20BioChemStructure
 group: chemicals
 name: BioChemStructure
 parent_type: BioChemEntity

--- a/_devTypes/DNA.html
+++ b/_devTypes/DNA.html
@@ -1,9 +1,10 @@
 ---
-redirect_from: 
+redirect_from:
 - "devTypes/DNA/specification"
 - "devTypes/DNA/specification/"
 - "/devTypes/DNA/"
-dateModified: 2018-11-13
+- "/DNA"
+dateModified: 2019-06-20
 description: "DNA"
 hierarchy:
 - Thing
@@ -14,7 +15,7 @@ name: DNA
 parent_type: BioChemEntity
 spec_type: Type
 status: revision
-version: '0.1-DRAFT'
+version: '0.2-DRAFT'
 
 bsc: #0B794B;
 pending: #0000CC;
@@ -35,224 +36,237 @@ external: #454547;
            <div id="main-content-wrapper" class="outer">
               <section id="main_content" class="inner">
                 {% include type_start.html %}
+                <table class="definition-table">
+                        <thead>
+                  <tr><th>Property</th><th>Expected Type</th><th>Description</th>
+                  </tr>
+                  </thead>
 
-                <table class="bioschemas_properties bsc_type">
-                   <thead>
-                      <tr>
-                         <th>Property</th>
-                         <th>Expected Type</th>
-                         <th>Description</th>
-                      </tr>
-                   </thead>
-                   <tbody>
-                     <tr class="new_props_sdo">
-                        <td colspan="3">
-                           Properties from <a style="color: #0B794B;" href="/{{page.name}}">{{page.name}}</a> (pending schema.org integration).
-                        </td>
-                     </tr>
-                     <tr class="new_props_sdo">
-                        <td colspan="3">
-                           Properties from <a style="color: #0B794B;" href="/BioChemEntity">BioChemEntity</a> (pending schema.org integration).
-                        </td>
-                     </tr>
-                     <tr id="additionalProperty">
-                       <th><a href="http://schema.org/additionalProperty">additionalProperty</th>
-                       <td>
-                         <a href="http://schema.org/PropertyValue">PropertyValue</a>
-                       </td>
-                       <td>A property-value pair representing an additional characteristics of the entitity, e.g. a product feature or another characteristic for which there is no matching property in schema.org. <br/>
-                         Note: Publishers should be aware that applications designed to use specific schema.org properties (e.g. http://schema.org/width, http://schema.org/color, http://schema.org/gtin13, ...) will typically expect such data to be provided using those properties, rather than using the generic property/value mechanism.<br />
-                      </td>
-                     </tr>
-                     <tr id="associatedDisease">
-                       <th style="color: #0B794B;">associatedDisease</th>
-                       <td>
-                         <a href="http://schema.org/MedicalCondition">MedicalCondition</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Disease associated to this BioChemEntity.
-                       </td>
-                     </tr>
-                     <tr id="hasBioChemEntityPart">
-                       <th style="color: #0B794B;">hasBioChemEntityPart</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/BioChemEntity">BioChemEntity</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Indicates a BioChemEntity that (in some sense) has this BioChemEntity as a part.<br/>
-                         Inverse property: isPartOfBioChemEntity
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a style="color: #0000CC;" href="http://pending.schema.org/hasCategoryCode">hasCategoryCode</a></th>
-                       <td>
-                         <a style="color: #0000CC;" href="http://pending.schema.org/CategoryCode">CategoryCode</a>
-                       </td>
-                       <td>
-                         A Category code contained in this code set.
-                       </td>
-                     </tr>
-                     <tr id="hasRepresentation">
-                       <th style="color: #0B794B;">hasRepresentation</th>
-                       <td>
-                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-                         <a href="http://schema.org/Text">Text</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         A common representation such as a protein sequence or chemical structure for this entity. For images use schema.org/image.
-                       </td>
-                     </tr>
-                     <tr id="isPartOfBioChemEntity">
-                       <th style="color: #0B794B;">isPartOfBioChemEntity</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/BioChemEntity">BioChemEntity</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Indicates a BioChemEntity that is (in some sense) a part of this BioChemEntity. <br/>
-                         Inverse property: hasBioChemEntityPart
-                       </td>
-                     </tr>
-                     <tr id="taxonomicRange">
-                       <th style="color: #0B794B;">taxonomicRange</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/Taxon">Taxon</a> or<br/>
-                         <a href="http://schema.org/Text">Text</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         The taxonomic grouping of the organism that expresses, encodes, or in someway related to the BioChemEntity.
-                       </td>
-                     </tr>
-                     <tr class="reu_props_sdo">
-                        <td colspan="3">Properties from <a href="http://schema.org/Thing">Thing</a></td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/additionalType">additionalType</a></th>
-                       <td>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax.
-                         This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax -
-                         the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those
-                         defined externally.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/alternateName">alternateName</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         An alias for the item.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/description">description</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         A descripton of the item.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/identifier">identifier</a></th>
-                       <td>
-                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-                         <a href="http://schema.org/Text">Text</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         The identifier property represents any kind of identifier for any kind of <a href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc.
-                         Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links.
-                         See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/image">image</a></th>
-                       <td>
-                         <a href="http://schema.org/ImageObject">ImageObject</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         An image of the item. This can be a <a href="http://schema.org/URL">URL</a> or a fully described <a href="http://schema.org/ImageObject">ImageObject</a>.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></th>
-                       <td>
-                         <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See
-                         <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/>
-                         Inverse property: <a href="http://schema.org/mainEntity">mainEntity</a>
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/name">name</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         The name of the item.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/potentialAction">potentialAction</a></th>
-                       <td>
-                         <a href="http://schema.org/Action">Action</a>
-                       </td>
-                       <td>
-                         Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/sameAs">sameAs</a></th>
-                       <td>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a style="color: #0000CC;" href="http://pending.schema.org/subjectOf">subjectOf</a></th>
-                       <td>
-                         <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
-                         <a href="http://schema.org/Event">Event</a>
-                       </td>
-                       <td>
-                         A CreativeWork or Event about this Thing..<br/>
-                         Inverse property: <a href="http://schema.org/about">about</a>.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/url">url</a></th>
-                       <td>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         URL of the item.
-                       </td>
-                     </tr>
-                   </tbody>
-                 </table>
+                <tr class="supertype">
+                     <th class="supertype-name" colspan="3">Properties from <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/DNA">DNA</a></th>
+
+                </tr>
+
+                <tbody class="supertype">
+                  <tr typeof="rdfs:Property" resource="http://schema.org/encodesBioChemEntity">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#encodesBioChemEntity">encodesBioChemEntity</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/DNA"><link property="domainIncludes" href="http://schema.org/Gene"><link property="domainIncludes" href="http://schema.org/RNA"></td><td class="prop-desc" property="rdfs:comment">Another BioChemEntity encoded by this one.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isEncodedByBioChemEntity">isEncodedByBioChemEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasSequence">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasSequence">hasSequence</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="./Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/DNA"><link property="domainIncludes" href="http://schema.org/Gene"><link property="domainIncludes" href="http://schema.org/Protein"><link property="domainIncludes" href="http://schema.org/RNA"></td><td class="prop-desc" property="rdfs:comment">Nucleotide or amino acid sequence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/topology">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#topology">One of Linear|Circular|Unspecified</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="./Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/DNA"></td><td class="prop-desc" property="rdfs:comment">-</td></tr><tr class="supertype">
+                  <th class="supertype-name" colspan="3">Properties from <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a></th>
+
+             </tr>
+
+             <tbody class="supertype">
+               <tr typeof="rdfs:Property" resource="http://schema.org/associatedDisease">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#associatedDisease">associatedDisease</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/MedicalCondition" /><a   href="http://schema.org/MedicalCondition">MedicalCondition</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Disease associated to this BioChemEntity. Such disease can be a MedicalCondition or a URL. If you want to add an evidence supporting the association, please use PropertyValue.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/bioChemInteraction">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#bioChemInteraction">bioChemInteraction</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A BioChemEntity that is known to interact with this item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/bioChemSimilarity">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#bioChemSimilarity">bioChemSimilarity</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A similar molecular entity, e.g., obtained by fingerprint similarity algorithms.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/biologicalRole">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#biologicalRole">biologicalRole</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A role played by the molecular entity within a biological context.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasBioChemEntityPart">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasBioChemEntityPart">hasBioChemEntityPart</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Indicates a BioChemEntity that (in some sense) has this BioChemEntity as a part.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isPartOfBioChemEntity">isPartOfBioChemEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasMolecularFunction">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasMolecularFunction">hasMolecularFunction</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Molecular function performed by this BioChemEntity; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasRepresentation">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasRepresentation">hasRepresentation</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A common representation such as a protein sequence or chemical structure for this entity. For images use schema.org/image.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasSequenceAnnotation">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasSequenceAnnotation">hasSequenceAnnotation</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/SequenceAnnotation" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/SequenceAnnotation">SequenceAnnotation</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Pointer to a sequence annotation; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isEncodedByBioChemEntity">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isEncodedByBioChemEntity">isEncodedByBioChemEntity</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/DNA" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/DNA">DNA</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Gene" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/Gene">Gene</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/RNA" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/RNA">RNA</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Another BioChemEntity encoding by this one.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#encodesBioChemEntity">encodesBioChemEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isInvolvedInBiologicalProcess">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isInvolvedInBiologicalProcess">isInvolvedInBiologicalProcess</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Biological process this BioChemEntity is involved in; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isLocatedInSubcellularLocation">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isLocatedInSubcellularLocation">isLocatedInSubcellularLocation</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Subcellular location where this BioChemEntity is located; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isMatchedBy">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isMatchedBy">isMatchedBy</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/SequenceMatchingModel" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/SequenceMatchingModel">SequenceMatchingModel</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A model matching this BioChemEntity.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isPartOfBioChemEntity">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isPartOfBioChemEntity">isPartOfBioChemEntity</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Indicates a BioChemEntity that is (in some sense) a part of this BioChemEntity.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasBioChemEntityPart">hasBioChemEntityPart</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/taxonomicRange">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#taxonomicRange">taxonomicRange</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Taxon" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/Taxon">Taxon</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"><link property="domainIncludes" href="http://schema.org/Phenotype"></td><td class="prop-desc" property="rdfs:comment">The taxonomic grouping of the organism that expresses, encodes, or in someway related to the BioChemEntity.</td></tr><tr class="supertype">
+                  <th class="supertype-name" colspan="3">Properties from <a   href="http://schema.org/Thing">Thing</a></th>
+
+             </tr>
+
+             <tbody class="supertype">
+               <tr typeof="rdfs:Property" resource="http://schema.org/additionalType">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/additionalType">additionalType</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax - the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those defined externally.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/alternateName">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/alternateName">alternateName</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An alias for the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/description">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/description">description</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A description of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/disambiguatingDescription">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/identifier">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/identifier">identifier</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The identifier property represents any kind of identifier for any kind of <a class="localLink" href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/image">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/image">image</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/ImageObject" /><a   href="http://schema.org/ImageObject">ImageObject</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An image of the item. This can be a <a class="localLink" href="http://schema.org/URL">URL</a> or a fully described <a class="localLink" href="http://schema.org/ImageObject">ImageObject</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/mainEntityOfPage">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/> Inverse property: <a   href="http://schema.org/mainEntity">mainEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/name">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/name">name</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The name of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/potentialAction">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/potentialAction">potentialAction</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/Action" /><a   href="http://schema.org/Action">Action</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sameAs">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/sameAs">sameAs</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/subjectOf">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/subjectOf">subjectOf</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Event" /><a   href="http://schema.org/Event">Event</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A CreativeWork or Event about this Thing..<br/> Inverse property: <a   href="http://schema.org/about">about</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/url">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/url">url</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of the item.</td></tr>
+
+             </table>
+
                </section>
              </div>
            </div>

--- a/_devTypes/DNA.html
+++ b/_devTypes/DNA.html
@@ -36,7 +36,7 @@ external: #454547;
            <div id="main-content-wrapper" class="outer">
               <section id="main_content" class="inner">
                 {% include type_start.html %}
-                <table class="definition-table">
+                <table class="definition-table bsc_type">
                         <thead>
                   <tr><th>Property</th><th>Expected Type</th><th>Description</th>
                   </tr>

--- a/_devTypes/DNA.html
+++ b/_devTypes/DNA.html
@@ -62,7 +62,7 @@ external: #454547;
                 <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasSequence">hasSequence</a></code>
                     </th>
                  <td class="prop-ect">
-                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="./Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/DNA"><link property="domainIncludes" href="http://schema.org/Gene"><link property="domainIncludes" href="http://schema.org/Protein"><link property="domainIncludes" href="http://schema.org/RNA"></td><td class="prop-desc" property="rdfs:comment">Nucleotide or amino acid sequence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/topology">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/DNA"><link property="domainIncludes" href="http://schema.org/Gene"><link property="domainIncludes" href="http://schema.org/Protein"><link property="domainIncludes" href="http://schema.org/RNA"></td><td class="prop-desc" property="rdfs:comment">Nucleotide or amino acid sequence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/topology">
 
                       <th class="prop-nam" scope="row">
 

--- a/_devTypes/DataRecord.html
+++ b/_devTypes/DataRecord.html
@@ -39,7 +39,7 @@ external: #454547;
               <section id="main_content" class="inner">
                 {% include type_start.html %}
 
-                <table class="definition-table">
+                <table class="definition-table bsc_type">
                         <thead>
                   <tr><th>Property</th><th>Expected Type</th><th>Description</th>
                   </tr>

--- a/_devTypes/DataRecord.html
+++ b/_devTypes/DataRecord.html
@@ -1,21 +1,21 @@
 ---
-redirect_from: 
+redirect_from:
 - "devTypes/DataRecord/specification"
 - "devTypes/DataRecord/specification/"
 - "/devTypes/DataRecord/"
-dateModified: 2018-11-06
-description: "A DataRecord acts itself as a dataset although it refers to what could be seen as the minimum compact, complete and auto-descriptive unit in a dataset."
+- "/DataRecord"
+dateModified: 2019-06-20
+description: "A DataRecord is a part of a Dataset. Not all datasets naturally fall into parts, and some kinds of datasets (eg. relational and tabular) can be mapped into different senses of \"data record\". Although data records can themselves be viewed as datasets, for simplicity we do not declare this explicitly; if this perspective is needed it can be added using multiple typing."
 gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20DataRecord
 group: data
 hierarchy:
 - Thing
 - CreativeWork
-- Dataset
 name: DataRecord
-parent_type: Dataset
+parent_type: CreativeWork
 spec_type: Type
 status: revision
-version: '0.2-DRAFT'
+version: '0.3-DRAFT'
 
 bsc: #0B794B;
 pending: #0000CC;
@@ -39,1055 +39,769 @@ external: #454547;
               <section id="main_content" class="inner">
                 {% include type_start.html %}
 
-                <table class="bioschemas_properties bsc_type">
-                   <thead>
-                      <tr>
-                         <th>Property</th>
-                         <th>Expected Type</th>
-                         <th>Description</th>
-                      </tr>
-                   </thead>
-                   <tbody>
-                     <tr class="new_props_sdo">
-                        <td colspan="3">
-                           Properties from <a style="color: #0B794B;" href="/{{page.name}}">{{page.name}}</a> (pending schema.org integration).
-                        </td>
-                     </tr>
-                     <tr id="additionalProperty">
-                       <th><a href="http://schema.org/additionalProperty">additionalProperty</th>
-                       <td>
-                         <a href="http://schema.org/PropertyValue">PropertyValue</a>
-                       </td>
-                       <td>A property-value pair representing an additional characteristics of the entitity, e.g. a product feature or another characteristic for which there is no matching property in schema.org. <br/>
-                         Note: Publishers should be aware that applications designed to use specific schema.org properties (e.g. http://schema.org/width, http://schema.org/color, http://schema.org/gtin13, ...) will typically expect such data to be provided using those properties, rather than using the generic property/value mechanism.<br />
-                      </td>
-                     </tr>
-                     <tr id="isBasisFor">
-                        <th style="color: #0B794B;">isBasisFor</th>
-                        <td>
-                           <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
-                           <a href="http://schema.org/Product">Product</a> or<br/>
-                           <a href="http://schema.org/URL">URL</a>
-                        </td>
-                        <td>
-                          A resource for which this resource is the basis for.<br/>
-                          Inverse property: isBasedOn
-                        </td>
-                     </tr>
-                     <tr id="seeAlso">
-                        <th style="color: #0B794B;">seeAlso</th>
-                        <td>
-                           <a href="http://schema.org/Thing">Thing</a> or<br/>
-                           <a href="http://schema.org/URL">URL</a>
-                        </td>
-                        <td>
-                          A pointer to any (somehow related) Thing. To be used whenever you are not so sure about the nature of the relation. Otherwise, use more precise terms from pre-existing Controlled Vocabularies.
-                        </td>
-                     </tr>
-<!-- Dataset -->
-                     <tr class="reu_props_sdo">
-                        <td colspan="3">Properties from <a href="http://schema.org/Dataset">Dataset</a></td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/distribution">distribution</a></th>
-                        <td>
-                           <a href="http://schema.org/DataDownload">DataDownload</a>
-                        </td>
-                        <td>
-                          A downloadable form of this dataset, at a specific location, in a specific format.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th>
-                          <a href="http://schema.org/includedInDataCatalog">includedInDataCatalog</a></th>
-                        <td>
-                           <a href="http://schema.org/DataCatalog">DataCatalog</a>
-                        </td>
-                        <td>
-                          A data catalog which contains this dataset. Supersedes <a href="https://schema.org/catalog">catalog</a>, <a href="https://schema.org/includedDataCatalog">includedDataCatalog</a>.<br/> Inverse property: <a href="http://schema.org/dataset">dataset</a>.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/issn">issn</a></th>
-                        <td>
-                           <a href="http://schema.org/Text">Text</a>
-                        </td>
-                        <td>
-                          The International Standard Serial Number (ISSN) that identifies this serial publication. You can repeat this property to identify different formats of, or the linking ISSN (ISSN-L) for, this serial publication.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th>
-                          <a style="color: #0000CC;" href="http://pending.schema.org/measurementTechnique">measurementTechnique</a>
-                        </th>
-                        <td>
-                           <a href="http://schema.org/Text">Text</a> or<br/>
-                           <a href="http://schema.org/URL">URL</a>
-                        </td>
-                        <td>
-                          	A technique or technology used in a <a href="https://schema.org/Dataset">Dataset</a> (or <a href="https://schema.org/DataDownload">DataDownload</a>, <a href="https://schema.org/DataCatalog">DataCatalog</a>), corresponding to the method used for measuring the corresponding variable(s) (described using <a style="color: #0000CC;" href="http://pending.schema.org/variableMeasured">variableMeasured</a>). This is oriented towards scientific and scholarly dataset publication but may have broader applicability; it is not intended as a full representation of measurement, but rather as a high level summary for dataset discovery.<br/>
-                            For example, if <a style="color: #0000CC;" href="http://pending.schema.org/variableMeasured">variableMeasured</a> is: molecule concentration, <a style="color: #0000CC;" href="http://pending.schema.org/measurementTechnique">measurementTechnique</a> could be: "mass spectrometry" or "nmr spectroscopy" or "colorimetry" or "immunofluorescence".<br/>
-                            If the <a style="color: #0000CC;" href="http://pending.schema.org/variableMeasured">variableMeasured</a> is "depression rating", the <a style="color: #0000CC;" href="http://pending.schema.org/measurementTechnique">measurementTechnique</a> could be "Zung Scale" or "HAM-D" or "Beck Depression Inventory".<br/>
-                            If there are several <a style="color: #0000CC;" href="http://pending.schema.org/variableMeasured">variableMeasured</a> properties recorded for some given data object, use a <a href="http://schema.org/PropertyValue">PropertyValue</a> for each <a style="color: #0000CC;" href="http://pending.schema.org/variableMeasured">variableMeasured</a> and attach the corresponding <a style="color: #0000CC;" href="http://pending.schema.org/measurementTechnique">measurementTechnique</a>.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th>
-                          <a style="color: #0000CC;" href="http://pending.schema.org/variableMeasured">variableMeasured</a>
-                        </th>
-                        <td>
-                           <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-                           <a href="http://schema.org/Text">Text</a>
-                        </td>
-                        <td>
-                          	The variableMeasured property can indicate (repeated as necessary) the variables that are measured in some dataset, either described as text or as pairs of identifier and description using <a href="http://schema.org/PropertyValue">PropertyValue</a>.
-                        </td>
-                     </tr>
-<!-- CREATIVEWORK -->
-                     <tr class="reu_props_sdo">
-                       <td colspan="3">Properties from <a href="http://schema.org/CreativeWork">CreativeWork</a></td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/about">about</a></th>
-                        <td>
-                           <a href="http://schema.org/Thing">Thing</a>
-                        </td>
-                        <td>
-                          The subject matter of the content. <br/>
-                          Inverse property: subjectOf.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/accessMode">accessMode</a></th>
-                        <td>
-                           <a href="http://schema.org/Text">Text</a>
-                        </td>
-                        <td>
-                          The human sensory perceptual system or cognitive faculty through which a person may process or perceive information. Expected values include: auditory, tactile, textual, visual, colorDependent, chartOnVisual, chemOnVisual, diagramOnVisual, mathOnVisual, musicOnVisual, textOnVisual.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/accessModeSufficient">accessModeSufficient</a></th>
-                        <td>
-                           <a href="http://schema.org/Text">Text</a>
-                        </td>
-                        <td>
-                          A list of single or combined accessModes that are sufficient to understand all the intellectual content of a resource. Expected values include: auditory, tactile, textual, visual.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/accessibilityAPI">accessibilityAPI</a></th>
-                        <td>
-                           <a href="http://schema.org/Text">Text</a>
-                        </td>
-                        <td>
-                          Indicates that the resource is compatible with the referenced accessibility API (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/accessibilityControl">accessibilityControl</a></th>
-                        <td>
-                           <a href="http://schema.org/Text">Text</a>
-                        </td>
-                        <td>
-                          Identifies input methods that are sufficient to fully control the described resource (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/accessibilityFeature">accessibilityFeature</a></th>
-                        <td>
-                           <a href="http://schema.org/Text">Text</a>
-                        </td>
-                        <td>
-                          Content features of the resource, such as accessible media, alternatives and supported enhancements for accessibility (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/accessibilityHazard">accessibilityHazard</a></th>
-                        <td>
-                           <a href="http://schema.org/Text">Text</a>
-                        </td>
-                        <td>
-                          A characteristic of the described resource that is physiologically dangerous to some users. Related to WCAG 2.0 guideline 2.3 (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/accessibilitySummary">accessibilitySummary</a></th>
-                        <td>
-                           <a href="http://schema.org/Text">Text</a>
-                        </td>
-                        <td>
-                          A human-readable summary of specific accessibility features or deficiencies, consistent with the other accessibility metadata but expressing subtleties such as "short descriptions are present but long descriptions will be needed for non-visual users" or "short descriptions are present and no long descriptions are needed."
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/accountablePerson">accountablePerson</a></th>
-                        <td>
-                           <a href="http://schema.org/Person">Person</a>
-                        </td>
-                        <td>
-                          Specifies the Person that is legally accountable for the CreativeWork.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/aggregateRating">aggregateRating</a></th>
-                        <td>
-                           <a href="http://schema.org/AggregateRating">AggregateRating</a>
-                        </td>
-                        <td>
-                          The overall rating, based on a collection of reviews or ratings, of the item.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/alternativeHeadline">alternativeHeadline</a></th>
-                        <td>
-                           <a href="http://schema.org/Text">Text</a>
-                        </td>
-                        <td>
-                          A secondary title of the CreativeWork.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/associatedMedia">associatedMedia</a></th>
-                        <td>
-                           <a href="http://schema.org/MediaObject">MediaObject</a>
-                        </td>
-                        <td>
-                          A media object that encodes this CreativeWork. This property is a synonym for encoding.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/audience">audience</a></th>
-                        <td>
-                           <a href="http://schema.org/Audience">Audience</a>
-                        </td>
-                        <td>
-                          An intended audience, i.e. a group for whom something was created. Supersedes <a href="https://schema.org/serviceAudience">serviceAudience</a>.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/audio">audio</a></th>
-                        <td>
-                           <a href="http://schema.org/AudioObject">AudioObject</a>
-                        </td>
-                        <td>
-                          An embedded audio object.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/author">author</a></th>
-                        <td>
-                           <a href="http://schema.org/Organization">Organization</a> or<br/>
-                           <a href="http://schema.org/Person">Person</a>
-                        </td>
-                        <td>
-                          The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/award">award</a></th>
-                        <td>
-                           <a href="http://schema.org/Text">Text</a>
-                        </td>
-                        <td>
-                          An award won by or for this item. Supersedes <a href="https://schema.org/awards">awards</a>.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/character">character</a></th>
-                        <td>
-                           <a href="http://schema.org/Person">Person</a>
-                        </td>
-                        <td>
-                          Fictional person connected with a creative work.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/citation">citation</a></th>
-                        <td>
-                           <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
-                           <a href="http://schema.org/Text">Text</a>
-                        </td>
-                        <td>
-                          A citation or reference to another creative work, such as another publication, web page, scholarly article, etc.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/comment">comment</a></th>
-                        <td>
-                           <a href="http://schema.org/Comment">Comment</a>
-                        </td>
-                        <td>
-                          Comments, typically from users.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/commentCount">commentCount</a></th>
-                        <td>
-                           <a href="http://schema.org/Integer">Integer</a>
-                        </td>
-                        <td>
-                          The number of comments this CreativeWork (e.g. Article, Question or Answer) has received. This is most applicable to works published in Web sites with commenting system; additional comments may exist elsewhere.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/contentLocation">contentLocation</a></th>
-                        <td>
-                           <a href="http://schema.org/Place">Place</a>
-                        </td>
-                        <td>
-                          The location depicted or described in the content. For example, the location in a photograph or painting.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/contentRating">contentRating</a></th>
-                        <td>
-                           <a href="http://schema.org/Text">Text</a>
-                        </td>
-                        <td>
-                          Official rating of a piece of content—for example,'MPAA PG-13'.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a style="color: #0000CC;" href="http://pending.schema.org/contentReferenceTime">contentReferenceTime</a></th>
-                        <td>
-                           <a href="http://schema.org/DateTime">DateTime</a>
-                        </td>
-                        <td>
-                          The specific time described by a creative work, for works (e.g. articles, video objects etc.) that emphasise a particular moment within an Event.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/contributor">contributor</a></th>
-                        <td>
-                           <a href="http://schema.org/Organization">Organization</a> or<br/><a href="http://schema.org/Person">Person</a>
-                        </td>
-                        <td>
-                          A secondary contributor to the CreativeWork or Event.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/copyrightHolder">copyrightHolder</a></th>
-                        <td>
-                           <a href="http://schema.org/Organization">Organization</a> or<br/><a href="http://schema.org/Person">Person</a>
-                        </td>
-                        <td>
-                          The party holding the legal copyright to the CreativeWork.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/copyrightYear">copyrightYear</a></th>
-                        <td>
-                           <a href="http://schema.org/Number">Number</a>
-                        </td>
-                        <td>
-                          The year during which the claimed copyright for the CreativeWork was first asserted.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th>
-                          <a style="color: #0000CC;" href="http://pending.schema.org/correction">correction</a>
-                        </th>
-                        <td>
-                           <a href="http://pending.schema.org/CorrectionComment">CorrectionComment</a> or<br/>
-                           <a href="http://schema.org/Text">Text</a> or<br/>
-                           <a href="http://schema.org/URL">URL</a>
-                        </td>
-                        <td>
-                          Indicates a correction to a <a href="https://schema.org/CreativeWork">CreativeWork</a>, either via a <a href="https://schema.org/CorrectionComment">CorrectionComment</a>, textually or in another document.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/creator">creator</a></th>
-                        <td>
-                           <a href="http://schema.org/Number">Organization</a> or<br/><a href="http://schema.org/Person">Person</a>
-                        </td>
-                        <td>
-                          The creator/author of this CreativeWork. This is the same as the Author property for CreativeWork.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/dateCreated">dateCreated</a></th>
-                        <td>
-                           <a href="http://schema.org/Date">Date</a> or<br/>
-                           <a href="http://schema.org/DateTime">DateTime</a>
-                        </td>
-                        <td>The date on which the CreativeWork was created or the item was added to a DataFeed.</td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/dateModified">dateModified</a></th>
-                        <td>
-                           <a href="http://schema.org/Date">Date</a> or<br/>
-                           <a href="http://schema.org/DateTime">DateTime</a>
-                        </td>
-                        <td>The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.</td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/datePublished">datePublished</a></th>
-                        <td>
-                           <a href="http://schema.org/Date">Date</a>
-                        </td>
-                        <td>Date of first broadcast/publication.</td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/discussionUrl">discussionUrl</a></th>
-                        <td>
-                           <a href="http://schema.org/URL">URL</a>
-                        </td>
-                        <td>
-                          A link to the page containing the comments of the CreativeWork.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/editor">editor</a></th>
-                        <td>
-                           <a href="http://schema.org/Person">Person</a>
-                        </td>
-                        <td>
-                          Specifies the Person who edited the CreativeWork.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/educationalAlignment">educationalAlignment</a></th>
-                        <td>
-                           <a href="http://schema.org/AlignmentObject">AlignmentObject</a>
-                        </td>
-                        <td>
-                          An alignment to an established educational framework.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/educationalUse">educationalUse</a></th>
-                        <td>
-                           <a href="http://schema.org/Text">Text</a>
-                        </td>
-                        <td>
-                          The purpose of a work in the context of education; for example, 'assignment', 'group work'.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/encoding">encoding</a></th>
-                        <td>
-                           <a href="http://schema.org/MediaObject">MediaObject</a>
-                        </td>
-                        <td>
-                          A media object that encodes this CreativeWork. This property is a synonym for associatedMedia. Supersedes <a href="https://schema.org/encodings">encodings</a>.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/encodingFormat">encodingFormat</a></th>
-                        <td>
-                           <a href="http://schema.org/Text">Text</a> or<br/>
-                           <a href="http://schema.org/URL">URL</a>
-                        </td>
-                        <td>
-                          Media type typically expressed using a MIME format (see <a href="http://www.iana.org/assignments/media-types/media-types.xhtml">IANA</a> site and <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MDN reference</a>) e.g. application/zip for a SoftwareApplication binary, audio/mpeg for .mp3 etc.).
-                          <br/>
-                          In cases where a <a href="https://schema.org/CreativeWork">CreativeWork</a> has several media type representations, <a href="https://schema.org/encoding">encoding</a> can be used to indicate each <a href="https://schema.org/MediaObject">MediaObject</a> alongside particular <a href="https://schema.org/encodingFormat">encodingFormat</a> information.
-                          <br/>
-                          Unregistered or niche encoding and file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia/Wikidata entry. Supersedes <a href="https://schema.org/fileFormat">fileFormat</a>.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/exampleOfWork">exampleOfWork</a></th>
-                        <td>
-                           <a href="http://schema.org/CreativeWork">CreativeWork</a>
-                        </td>
-                        <td>
-                          A creative work that this work is an example/instance/realization/derivation of.<br/>
-                          Inverse property: <a href="http://schema.org/workExample">workExample</a>.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/expires">expires</a></th>
-                        <td>
-                           <a href="http://schema.org/Date">Date</a>
-                        </td>
-                        <td>
-                          Date the content expires and is no longer useful or available. For example a <a href="http://schema.org/VideoObject">VideoObject</a> or <a href="http://schema.org/NewsArticle">NewsArticle</a> whose availability or relevance is time-limited, or a <a href="http://schema.org/ClaimReview">ClaimReview</a> fact check whose publisher wants to indicate that it may no longer be relevant (or helpful to highlight) after some date.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/funder">funder</a></th>
-                        <td>
-                           <a href="http://schema.org/Organization">Organization</a> or<br/>
-                           <a href="http://schema.org/Person">Person</a>
-                        </td>
-                        <td>
-                          A person or organization that supports (sponsors) something through some kind of financial contribution.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/genre">genre</a></th>
-                        <td>
-                           <a href="http://schema.org/Text">Text</a> or<br/>
-                           <a href="http://schema.org/URL">URL</a>
-                        </td>
-                        <td>
-                          Genre of the creative work, broadcast channel or group.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/hasPart">hasPart</a></th>
-                        <td>
-                           <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
-                           <a href="http://schema.org/Trip">Trip</a>
-                        </td>
-                        <td>
-                          Indicates a CreativeWork that is (in some sense) a part of this CreativeWork.<br/>
-                          Inverse property: <a href="http://schema.org/isPartOf">isPartOf</a>.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/headline">headline</a></th>
-                        <td>
-                           <a href="http://schema.org/Text">Text</a>
-                        </td>
-                        <td>
-                          Headline of the article.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/inLanguage">inLanguage</a></th>
-                        <td>
-                           <a href="http://schema.org/Language">Language</a> or<br/>
-                           <a href="http://schema.org/Text">Text</a>
-                        </td>
-                        <td>
-                          The language of the content or performance or used in an action. Please use one of the language codes from the <a href="http://tools.ietf.org/html/bcp47">IETF BCP 47 standard</a>. See also <a href="http://schema.org/availableLanguage">availableLanguage</a>. Supersedes <a href="https://schema.org/language">language</a>.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/interactionStatistic">interactionStatistic</a></th>
-                        <td>
-                           <a href="http://schema.org/InteractionCounter">InteractionCounter</a>
-                        </td>
-                        <td>
-                          The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used. Supersedes <a href="https://schema.org/interactionCount">interactionCount</a>.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/interactivityType">interactivityType</a></th>
-                        <td>
-                           <a href="http://schema.org/Text">Text</a>
-                        </td>
-                        <td>
-                          The predominant mode of learning supported by the learning resource. Acceptable values are 'active', 'expositive', or 'mixed'.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/isAccessibleForFree">isAccessibleForFree</a></th>
-                        <td>
-                           <a href="http://schema.org/Boolean">Boolean</a>
-                        </td>
-                        <td>
-                          A flag to signal that the item, event, or place is accessible for free. Supersedes <a href="https://schema.org/free">free</a>.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/isBasedOn">isBasedOn</a></th>
-                        <td>
-                           <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
-                           <a href="http://schema.org/Product">Product</a> or<br/>
-                           <a href="http://schema.org/URL">URL</a>
-                        </td>
-                        <td>
-                          A resource that was used in the creation of this resource. This term can be repeated for multiple sources. For example, http://example.com/great-multiplication-intro.html. Supersedes <a href="https://schema.org/isBasedOnUrl">isBasedOnUrl</a>.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/isFamilyFriendly">isFamilyFriendly</a></th>
-                        <td>
-                           <a href="http://schema.org/Boolean">Boolean</a>
-                        </td>
-                        <td>
-                          Indicates whether this content is family friendly.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/isPartOf">isPartOf</a></th>
-                        <td>
-                           <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
-                           <a href="http://schema.org/Trip">Trip</a>
-                        </td>
-                        <td>
-                          Indicates an item or CreativeWork that this item, or CreativeWork (in some sense), is part of.<br/>
-                          Inverse property: <a href="http://schema.org/hasPart">hasPart</a>.
-                        </td>
-                     </tr>
-                     <tr>
-                        <th><a href="http://schema.org/keywords">keywords</a></th>
-                        <td>
-                           <a href="http://schema.org/Text">Text</a>
-                        </td>
-                        <td>Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.</td>
-                      </tr>
-                      <tr>
-                         <th><a href="http://schema.org/learningResourceType">learningResourceType</a></th>
-                         <td>
-                            <a href="http://schema.org/Text">Text</a>
-                         </td>
-                         <td>
-                           The predominant type or kind characterizing the learning resource. For example, 'presentation', 'handout'.
-                         </td>
-                      </tr>
-                      <tr>
-                         <th><a href="http://schema.org/license">license</a></th>
-                         <td>
-                            <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
-                            <a href="http://schema.org/URL">URL</a>
-                         </td>
-                         <td>
-                           A license document that applies to this content, typically indicated by URL.
-                         </td>
-                      </tr>
-                      <tr>
-                         <th><a href="http://schema.org/locationCreated">locationCreated</a></th>
-                         <td>
-                            <a href="http://schema.org/Place">Place</a>
-                         </td>
-                         <td>
-                           The location where the CreativeWork was created, which may not be the same as the location depicted in the CreativeWork.
-                         </td>
-                      </tr>
-                      <tr>
-                         <th><a href="http://schema.org/mainEntity">mainEntity</a></th>
-                         <td>
-                           <a href="http://schema.org/Thing">Thing</a>
-                         </td>
-                         <td>
-                           Indicates the primary entity described in some page or other CreativeWork. <br/>
-                           Inverse-property: <a href="http:schema.org/mainEntityOfPage">mainEntityOfPage</a>.
-                         </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/material">material</a></th>
-                          <td>
-                             <a href="http://schema.org/Product">Product</a> or<br/>
-                             <a href="http://schema.org/Text">Text</a> or<br/>
-                             <a href="http://schema.org/URL">URL</a>
-                          </td>
-                          <td>
-                            A material that something is made from, e.g. leather, wool, cotton, paper.
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/mentions">mentions</a></th>
-                          <td>
-                             <a href="http://schema.org/Thing">Thing</a>
-                          </td>
-                          <td>
-                            Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept.
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/offers">offers</a></th>
-                          <td>
-                             <a href="http://schema.org/Offer">Offer</a>
-                          </td>
-                          <td>
-                            An offer to provide this item—for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/position">position</a></th>
-                          <td>
-                             <a href="http://schema.org/Integer">Integer</a> or<br/>
-                             <a href="http://schema.org/Text">Text</a>
-                          </td>
-                          <td>
-                            The position of an item in a series or sequence of items.
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/producer">producer</a></th>
-                          <td>
-                             <a href="http://schema.org/Organization">Organization</a> or<br/>
-                             <a href="http://schema.org/Person">Person</a>
-                          </td>
-                          <td>
-                            The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.).
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/provider">provider</a></th>
-                          <td>
-                             <a href="http://schema.org/Organization">Organization</a> or<br/>
-                             <a href="http://schema.org/Person">Person</a>
-                          </td>
-                          <td>
-                            The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller. Supersedes <a href="https://schema.org/carrier">carrier</a>.
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/publication">publication</a></th>
-                          <td>
-                             <a href="http://schema.org/PublicationEvent">PublicationEvent</a>
-                          </td>
-                          <td>
-                            A publication event associated with the item.
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/publication">publisher</a></th>
-                          <td>
-                             <a href="http://schema.org/Organization">Organization</a> or<br/>
-                             <a href="http://schema.org/Person">Person</a>
-                          </td>
-                          <td>
-                            The publisher of the creative work.
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a class="pending" href="http://pending.schema.org/publisherImprint">publisherImprint</a></th>
-                          <td>
-                             <a href="http://schema.org/Organization">Organization</a>
-                          </td>
-                          <td>
-                            The publishing division which published the comic.
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/publishingPrinciples">publishingPrinciples</a></th>
-                          <td>
-                             <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
-                             <a href="http://schema.org/URL">URL</a>
-                          </td>
-                          <td>
-                            The publishingPrinciples property indicates (typically via <a href="https://schema.org/URL">URL</a>) a document describing the editorial principles of an <a href="http://schema.org/Organization">Organization</a> (or individual e.g. a <a href="http://schema.org/Person">Person</a> writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a <a href="http://schema.org/CreativeWork">CreativeWork</a> (e.g. <a href="http://schema.org/NewsArticle">NewsArticle</a>) the principles are those of the party primarily responsible for the creation of the <a href="http://schema.org/CreativeWork">CreativeWork</a>. <br />
-                            While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a <a href="http://schema.org/funder">funder</a>) can be expressed using schema.org terminology.
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/recordedAt">recordedAt</a></th>
-                          <td>
-                             <a href="http://schema.org/Event">Event</a>
-                          </td>
-                          <td>
-                            The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event. <br/>
-                            Inverse property: <a href="http://schema.org/recordedIn">recordedIn</a>.
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/releasedEvent">releasedEvent</a></th>
-                          <td>
-                             <a href="http://schema.org/PublicationEvent">PublicationEvent</a>
-                          </td>
-                          <td>
-                            The place and time the release was issued, expressed as a PublicationEvent.
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/review">review</a></th>
-                          <td>
-                             <a href="http://schema.org/Review">Review</a>
-                          </td>
-                          <td>
-                            A review of the item. Supersedes <a href="https://schema.org/reviews">reviews</a>.
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/schemaVersion">schemaVersion</a></th>
-                          <td>
-                             <a href="http://schema.org/Text">Text</a> or<br/>
-                             <a href="http://schema.org/URL">URL</a>
-                          </td>
-                          <td>
-                            Indicates (by URL or string) a particular version of a schema used in some CreativeWork. For example, a document could declare a schemaVersion using an URL such as http://schema.org/version/2.0/ if precise indication of schema version was required by some application.
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a class="pending" href="http://pending.schema.org/sdDatePublished">sdDatePublished</a></th>
-                          <td>
-                             <a href="http://schema.org/Date">Date</a>
-                          </td>
-                          <td>
-                            Indicates the date on which the current structured data was generated / published. Typically used alongside <a href="https://schema.org/sdPublisher">sdPublisher</a>
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a class="pending" href="http://pending.schema.org/sdLicense">sdLicense</a></th>
-                          <td>
-                             <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
-                             <a href="http://schema.org/URL">URL</a>
-                          </td>
-                          <td>
-                            A license document that applies to this structured data, typically indicated by URL.
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a class="pending" href="http://pending.schema.org/sdPublisher">sdPublisher</a></th>
-                          <td>
-                             <a href="http://schema.org/Organization">Organization</a> or<br/>
-                             <a href="http://schema.org/Person">Person</a>
-                          </td>
-                          <td>
-                            Indicates the party responsible for generating and publishing the current structured data markup, typically in cases where the structured data is derived automatically from existing published content but published on a different site. For example, student projects and open data initiatives often re-publish existing content with more explicitly structured metadata. The <a href="https://schema.org/sdPublisher">sdPublisher</a> property helps make such practices more explicit.
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/sourceOrganization">sourceOrganization</a></th>
-                          <td>
-                             <a href="http://schema.org/Organization">Organization</a>
-                          </td>
-                          <td>
-                            The Organization on whose behalf the creator was working.
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/spatialCoverage">spatialCoverage</a></th>
-                          <td>
-                             <a href="http://schema.org/Place">Place</a>
-                          </td>
-                          <td>
-                            The spatialCoverage of a CreativeWork indicates the place(s) which are the focus of the content. It is a subproperty of contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York. Supersedes <a href="https://schema.org/spatial">spatial</a>.
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/sponsor">sponsor</a></th>
-                          <td>
-                             <a href="http://schema.org/Organization">Organization</a> or<br/>
-                             <a href="http://schema.org/Person">Person</a>
-                          </td>
-                          <td>
-                            A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/temporalCoverage">temporalCoverage</a></th>
-                          <td>
-                             <a href="http://schema.org/DateTime">DateTime</a> or<br/>
-                             <a href="http://schema.org/Text">Text</a> or<br/>
-                             <a href="http://schema.org/URL">URL</a>
-                          </td>
-                          <td>
-                            The temporalCoverage of a CreativeWork indicates the period that the content applies to, i.e. that it describes, either as a DateTime or as a textual string indicating a time period in <a href="https://en.wikipedia.org/wiki/ISO_8601#Time_intervals">ISO 8601 time interval format</a>. In the case of a Dataset it will typically indicate the relevant time period in a precise notation (e.g. for a 2011 census dataset, the year 2011 would be written "2011/2012"). Other forms of content e.g. ScholarlyArticle, Book, TVSeries or TVEpisode may indicate their temporalCoverage in broader terms - textually or via well-known URL. Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945".
-                            <br/>
-                            Open-ended date ranges can be written with ".." in place of the end date. For example, "2015-11/.." indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated. Supersedes <a href="https://schema.org/datasetTimeInterval">datasetTimeInterval</a>, <a href="https://schema.org/temporal">temporal</a>.
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/text">text</a></th>
-                          <td>
-                             <a href="http://schema.org/Text">Text</a>
-                          </td>
-                          <td>
-                            The textual content of this CreativeWork.
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/thumbnailUrl">thumbnailUrl</a></th>
-                          <td>
-                             <a href="http://schema.org/URL">URL</a>
-                          </td>
-                          <td>
-                            A thumbnail image relevant to the Thing.
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/timeRequired">timeRequired</a></th>
-                          <td>
-                             <a href="http://schema.org/Duration">Duration</a>
-                          </td>
-                          <td>
-                            Approximate or typical time it takes to work with or through this learning resource for the typical intended target audience, e.g. 'P30M', 'P1H25M'.
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a style="color: #0000CC;"  href="http://pending.schema.org/translationOfWork">translationOfWork</a></th>
-                          <td>
-                             <a href="http://schema.org/CreativeWork">CreativeWork</a>
-                          </td>
-                          <td>
-                            The work that this work has been translated from. e.g. 物种起源 is a translationOf “On the Origin of Species”. <br/>
-                            Inverse property: <a style="color: #0000CC;"  href="http://pending.schema.org/workTranslation">workTranslation</a>.
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/translator">translator</a></th>
-                          <td>
-                             <a href="http://schema.org/Organization">Organization</a> or<br/>
-                             <a href="http://schema.org/Person">Person</a>
-                          </td>
-                          <td>
-                            Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/typicalAgeRange">typicalAgeRange</a></th>
-                          <td>
-                             <a href="http://schema.org/Text">Text</a>
-                          </td>
-                          <td>
-                            The typical expected age range, e.g. '7-9', '11-'.
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/version">version</a></th>
-                          <td>
-                             <a href="http://schema.org/Number">Number</a> or<br/>
-                             <a href="http://schema.org/Text">Text</a>
-                          </td>
-                          <td>
-                            The version of the CreativeWork embodied by a specified resource.
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/video">video</a></th>
-                          <td>
-                             <a href="http://schema.org/VideoObject">VideoObject</a>
-                          </td>
-                          <td>
-                            An embedded video object.
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a href="http://schema.org/workExample">workExample</a></th>
-                          <td>
-                             <a href="http://schema.org/CreativeWork">CreativeWork</a>
-                          </td>
-                          <td>
-                            Example/instance/realization/derivation of the concept of this creative work. eg. The paperback edition, first edition, or eBook. <br/>
-                            Inverse property: <a href="http://schema.org/exampleOfWork">exampleOfWork</a>.
-                          </td>
-                       </tr>
-                       <tr>
-                          <th><a style="color: #0000CC;"  href="http://pending.schema.org/workTranslation">workTranslation</a></th>
-                          <td>
-                             <a href="http://schema.org/CreativeWork">CreativeWork</a>
-                          </td>
-                          <td>
-                            A work that is a translation of the content of this work. e.g. 西遊記 has an English workTranslation “Journey to the West”,a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese translation Tây du ký bình khảo. <br/>
-                            Inverse property: <a style="color: #0000CC;"  href="http://pending.schema.org/translationOfWork">translationOfWork</a>.
-                          </td>
-                       </tr>
-<!-- Thing -->
-                       <tr class="reu_props_sdo">
-                          <td colspan="3">Properties from <a href="http://schema.org/Thing">Thing</a></td>
-                       </tr>
-                       <tr>
-                         <th><a href="http://schema.org/additionalType">additionalType</a></th>
-                         <td>
-                           <a href="http://schema.org/URL">URL</a>
-                         </td>
-                         <td>
-                           An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax.
-                           This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax -
-                           the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those
-                           defined externally.
-                         </td>
-                       </tr>
-                       <tr>
-                         <th><a href="http://schema.org/alternateName">alternateName</a></th>
-                         <td>
-                           <a href="http://schema.org/Text">Text</a>
-                         </td>
-                         <td>
-                           An alias for the item.
-                         </td>
-                       </tr>
-                       <tr>
-                         <th><a href="http://schema.org/description">description</a></th>
-                         <td>
-                           <a href="http://schema.org/Text">Text</a>
-                         </td>
-                         <td>
-                           A descripton of the item.
-                         </td>
-                       </tr>
-                       <tr>
-                         <th><a href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></th>
-                         <td>
-                           <a href="http://schema.org/Text">Text</a>
-                         </td>
-                         <td>
-                           A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.
-                         </td>
-                       </tr>
-                       <tr>
-                         <th><a href="http://schema.org/identifier">identifier</a></th>
-                         <td>
-                           <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-                           <a href="http://schema.org/Text">Text</a> or<br/>
-                           <a href="http://schema.org/URL">URL</a>
-                         </td>
-                         <td>
-                           The identifier property represents any kind of identifier for any kind of <a href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc.
-                           Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links.
-                           See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.
-                         </td>
-                       </tr>
-                       <tr>
-                         <th><a href="http://schema.org/image">image</a></th>
-                         <td>
-                           <a href="http://schema.org/ImageObject">ImageObject</a> or<br/>
-                           <a href="http://schema.org/URL">URL</a>
-                         </td>
-                         <td>
-                           An image of the item. This can be a <a href="http://schema.org/URL">URL</a> or a fully described <a href="http://schema.org/ImageObject">ImageObject</a>.
-                         </td>
-                       </tr>
-                       <tr>
-                         <th><a href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></th>
-                         <td>
-                           <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
-                           <a href="http://schema.org/URL">URL</a>
-                         </td>
-                         <td>
-                           Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See
-                           <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/>
-                           Inverse property: <a href="http://schema.org/mainEntity">mainEntity</a>
-                         </td>
-                       </tr>
-                       <tr>
-                         <th><a href="http://schema.org/name">name</a></th>
-                         <td>
-                           <a href="http://schema.org/Text">Text</a>
-                         </td>
-                         <td>
-                           The name of the item.
-                         </td>
-                       </tr>
-                       <tr>
-                         <th><a href="http://schema.org/potentialAction">potentialAction</a></th>
-                         <td>
-                           <a href="http://schema.org/Action">Action</a>
-                         </td>
-                         <td>
-                           Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.
-                         </td>
-                       </tr>
-                       <tr>
-                         <th><a href="http://schema.org/sameAs">sameAs</a></th>
-                         <td>
-                           <a href="http://schema.org/URL">URL</a>
-                         </td>
-                         <td>
-                           URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.
-                         </td>
-                       </tr>
-                       <tr>
-                         <th><a style="color: #0000CC;" href="http://pending.schema.org/subjectOf">subjectOf</a></th>
-                         <td>
-                           <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
-                           <a href="http://schema.org/Event">Event</a>
-                         </td>
-                         <td>
-                           A CreativeWork or Event about this Thing..<br/>
-                           Inverse property: <a href="http://schema.org/about">about</a>.
-                         </td>
-                       </tr>
-                       <tr>
-                         <th><a href="http://schema.org/url">url</a></th>
-                         <td>
-                           <a href="http://schema.org/URL">URL</a>
-                         </td>
-                         <td>
-                           URL of the item.
-                         </td>
-                       </tr>
-                   </tbody>
-                 </table>
+                <table class="definition-table">
+                        <thead>
+                  <tr><th>Property</th><th>Expected Type</th><th>Description</th>
+                  </tr>
+                  </thead>
+
+                <tr class="supertype">
+                     <th class="supertype-name" colspan="3">Properties from <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/DataRecord">DataRecord</a></th>
+
+                </tr>
+
+                <tbody class="supertype">
+                  <tr typeof="rdfs:Property" resource="http://schema.org/includedInDataset">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#includedInDataset">includedInDataset</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Dataset" /><a   href="http://schema.org/Dataset">Dataset</a>&nbsp;<link property="domainIncludes" href="http://schema.org/DataRecord"></td><td class="prop-desc" property="rdfs:comment">A Dataset which contains this DataRecord.</td></tr><tr class="supertype">
+                     <th class="supertype-name" colspan="3">Properties from <a   href="http://schema.org/CreativeWork">CreativeWork</a></th>
+
+                </tr>
+
+                <tbody class="supertype">
+                  <tr typeof="rdfs:Property" resource="http://schema.org/about">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/about">about</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Thing" /><a   href="http://schema.org/Thing">Thing</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CommunicateAction"><link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"></td><td class="prop-desc" property="rdfs:comment">The subject matter of the content.<br/> Inverse property: <a   href="http://schema.org/subjectOf">subjectOf</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accessMode">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/accessMode">accessMode</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The human sensory perceptual system or cognitive faculty through which a person may process or perceive information. Expected values include: auditory, tactile, textual, visual, colorDependent, chartOnVisual, chemOnVisual, diagramOnVisual, mathOnVisual, musicOnVisual, textOnVisual.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accessModeSufficient">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/accessModeSufficient">accessModeSufficient</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A list of single or combined accessModes that are sufficient to understand all the intellectual content of a resource. Expected values include:  auditory, tactile, textual, visual.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accessibilityAPI">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/accessibilityAPI">accessibilityAPI</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates that the resource is compatible with the referenced accessibility API (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accessibilityControl">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/accessibilityControl">accessibilityControl</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Identifies input methods that are sufficient to fully control the described resource (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accessibilityFeature">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/accessibilityFeature">accessibilityFeature</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Content features of the resource, such as accessible media, alternatives and supported enhancements for accessibility (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accessibilityHazard">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/accessibilityHazard">accessibilityHazard</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A characteristic of the described resource that is physiologically dangerous to some users. Related to WCAG 2.0 guideline 2.3 (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accessibilitySummary">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/accessibilitySummary">accessibilitySummary</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A human-readable summary of specific accessibility features or deficiencies, consistent with the other accessibility metadata but expressing subtleties such as "short descriptions are present but long descriptions will be needed for non-visual users" or "short descriptions are present and no long descriptions are needed."</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accountablePerson">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/accountablePerson">accountablePerson</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Specifies the Person that is legally accountable for the CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/aggregateRating">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/aggregateRating">aggregateRating</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/AggregateRating" /><a   href="http://schema.org/AggregateRating">AggregateRating</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Brand"><link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/Offer"><link property="domainIncludes" href="http://schema.org/Organization"><link property="domainIncludes" href="http://schema.org/Place"><link property="domainIncludes" href="http://schema.org/Product"><link property="domainIncludes" href="http://schema.org/Service"></td><td class="prop-desc" property="rdfs:comment">The overall rating, based on a collection of reviews or ratings, of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/alternativeHeadline">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/alternativeHeadline">alternativeHeadline</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A secondary title of the CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/associatedMedia">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/associatedMedia">associatedMedia</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/MediaObject" /><a   href="http://schema.org/MediaObject">MediaObject</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A media object that encodes this CreativeWork. This property is a synonym for encoding.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/audience">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/audience">audience</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Audience" /><a   href="http://schema.org/Audience">Audience</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/LodgingBusiness"><link property="domainIncludes" href="http://schema.org/PlayAction"><link property="domainIncludes" href="http://schema.org/Product"><link property="domainIncludes" href="http://schema.org/Service"></td><td class="prop-desc" property="rdfs:comment">An intended audience, i.e. a group for whom something was created. Supersedes <a   href="http://schema.org/serviceAudience">serviceAudience</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/audio">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/audio">audio</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/AudioObject" /><a   href="http://schema.org/AudioObject">AudioObject</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Clip" /><a   href="http://schema.org/Clip">Clip</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">An embedded audio object.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/author">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/author">author</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Rating"></td><td class="prop-desc" property="rdfs:comment">The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/award">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/award">award</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Organization"><link property="domainIncludes" href="http://schema.org/Person"><link property="domainIncludes" href="http://schema.org/Product"><link property="domainIncludes" href="http://schema.org/Service"></td><td class="prop-desc" property="rdfs:comment">An award won by or for this item. Supersedes <a   href="http://schema.org/awards">awards</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/character">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/character">character</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Fictional person connected with a creative work.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/citation">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/citation">citation</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A citation or reference to another creative work, such as another publication, web page, scholarly article, etc.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/comment">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/comment">comment</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Comment" /><a   href="http://schema.org/Comment">Comment</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/RsvpAction"></td><td class="prop-desc" property="rdfs:comment">Comments, typically from users.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/commentCount">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/commentCount">commentCount</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Integer" /><a   href="http://schema.org/Integer">Integer</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The number of comments this CreativeWork (e.g. Article, Question or Answer) has received. This is most applicable to works published in Web sites with commenting system; additional comments may exist elsewhere.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/contentLocation">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/contentLocation">contentLocation</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Place" /><a   href="http://schema.org/Place">Place</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The location depicted or described in the content. For example, the location in a photograph or painting.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/contentRating">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/contentRating">contentRating</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Rating" /><a   href="http://schema.org/Rating">Rating</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Official rating of a piece of content&#x2014;for example,'MPAA PG-13'.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/contentReferenceTime">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/contentReferenceTime">contentReferenceTime</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/DateTime" /><a   href="http://schema.org/DateTime">DateTime</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The specific time described by a creative work, for works (e.g. articles, video objects etc.) that emphasise a particular moment within an Event.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/contributor">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/contributor">contributor</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"></td><td class="prop-desc" property="rdfs:comment">A secondary contributor to the CreativeWork or Event.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/copyrightHolder">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/copyrightHolder">copyrightHolder</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The party holding the legal copyright to the CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/copyrightYear">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/copyrightYear">copyrightYear</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Number" /><a   href="http://schema.org/Number">Number</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The year during which the claimed copyright for the CreativeWork was first asserted.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/correction">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/correction">correction</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CorrectionComment" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/CorrectionComment">CorrectionComment</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates a correction to a <a class="localLink" href="http://schema.org/CreativeWork">CreativeWork</a>, either via a <a class="localLink" href="http://schema.org/CorrectionComment">CorrectionComment</a>, textually or in another document.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/creator">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/creator">creator</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/UserComments"></td><td class="prop-desc" property="rdfs:comment">The creator/author of this CreativeWork. This is the same as the Author property for CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/dateCreated">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/dateCreated">dateCreated</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Date" /><a   href="http://schema.org/Date">Date</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/DateTime" /><a   href="http://schema.org/DateTime">DateTime</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioSample"><link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/DataFeedItem"></td><td class="prop-desc" property="rdfs:comment">The date on which the CreativeWork was created or the item was added to a DataFeed.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/dateModified">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/dateModified">dateModified</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Date" /><a   href="http://schema.org/Date">Date</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/DateTime" /><a   href="http://schema.org/DateTime">DateTime</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/DataFeedItem"></td><td class="prop-desc" property="rdfs:comment">The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/datePublished">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/datePublished">datePublished</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Date" /><a   href="http://schema.org/Date">Date</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Date of first broadcast/publication.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/discussionUrl">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/discussionUrl">discussionUrl</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A link to the page containing the comments of the CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/editor">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/editor">editor</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Specifies the Person who edited the CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/educationalAlignment">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/educationalAlignment">educationalAlignment</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/AlignmentObject" /><a   href="http://schema.org/AlignmentObject">AlignmentObject</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">An alignment to an established educational framework.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/educationalUse">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/educationalUse">educationalUse</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The purpose of a work in the context of education; for example, 'assignment', 'group work'.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/encoding">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/encoding">encoding</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/MediaObject" /><a   href="http://schema.org/MediaObject">MediaObject</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A media object that encodes this CreativeWork. This property is a synonym for associatedMedia. Supersedes <a   href="http://schema.org/encodings">encodings</a>.<br/> Inverse property: <a   href="http://schema.org/encodesCreativeWork">encodesCreativeWork</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/encodingFormat">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/encodingFormat">encodingFormat</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/MediaObject"></td><td class="prop-desc" property="rdfs:comment">Media type typically expressed using a MIME format (see <a href="http://www.iana.org/assignments/media-types/media-types.xhtml">IANA site</a> and <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MDN reference</a>) e.g. application/zip for a SoftwareApplication binary, audio/mpeg for .mp3 etc.).<br/><br/>
+
+                In cases where a <a class="localLink" href="http://schema.org/CreativeWork">CreativeWork</a> has several media type representations, <a class="localLink" href="http://schema.org/encoding">encoding</a> can be used to indicate each <a class="localLink" href="http://schema.org/MediaObject">MediaObject</a> alongside particular <a class="localLink" href="http://schema.org/encodingFormat">encodingFormat</a> information.<br/><br/>
+
+                Unregistered or niche encoding and file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia/Wikidata entry. Supersedes <a   href="http://schema.org/fileFormat">fileFormat</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/exampleOfWork">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/exampleOfWork">exampleOfWork</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A creative work that this work is an example/instance/realization/derivation of.<br/> Inverse property: <a   href="http://schema.org/workExample">workExample</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/expires">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/expires">expires</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Date" /><a   href="http://schema.org/Date">Date</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Date the content expires and is no longer useful or available. For example a <a class="localLink" href="http://schema.org/VideoObject">VideoObject</a> or <a class="localLink" href="http://schema.org/NewsArticle">NewsArticle</a> whose availability or relevance is time-limited, or a <a class="localLink" href="http://schema.org/ClaimReview">ClaimReview</a> fact check whose publisher wants to indicate that it may no longer be relevant (or helpful to highlight) after some date.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/funder">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/funder">funder</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/MonetaryGrant"><link property="domainIncludes" href="http://schema.org/Organization"><link property="domainIncludes" href="http://schema.org/Person"></td><td class="prop-desc" property="rdfs:comment">A person or organization that supports (sponsors) something through some kind of financial contribution.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/genre">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/genre">genre</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BroadcastChannel"><link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/MusicGroup"></td><td class="prop-desc" property="rdfs:comment">Genre of the creative work, broadcast channel or group.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasPart">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/hasPart">hasPart</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates an item or CreativeWork that is part of this item, or CreativeWork (in some sense).<br/> Inverse property: <a   href="http://schema.org/isPartOf">isPartOf</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/headline">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/headline">headline</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Headline of the article.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/inLanguage">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/inLanguage">inLanguage</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Language" /><a   href="http://schema.org/Language">Language</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CommunicateAction"><link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/LinkRole"><link property="domainIncludes" href="http://schema.org/WriteAction"></td><td class="prop-desc" property="rdfs:comment">The language of the content or performance or used in an action. Please use one of the language codes from the <a href="http://tools.ietf.org/html/bcp47">IETF BCP 47 standard</a>. See also <a class="localLink" href="http://schema.org/availableLanguage">availableLanguage</a>. Supersedes <a   href="http://schema.org/language">language</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/interactionStatistic">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/interactionStatistic">interactionStatistic</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/InteractionCounter" /><a   href="http://schema.org/InteractionCounter">InteractionCounter</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used. Supersedes <a   href="http://schema.org/interactionCount">interactionCount</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/interactivityType">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/interactivityType">interactivityType</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The predominant mode of learning supported by the learning resource. Acceptable values are 'active', 'expositive', or 'mixed'.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isAccessibleForFree">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/isAccessibleForFree">isAccessibleForFree</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Boolean" /><a   href="http://schema.org/Boolean">Boolean</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/Place"><link property="domainIncludes" href="http://schema.org/PublicationEvent"></td><td class="prop-desc" property="rdfs:comment">A flag to signal that the item, event, or place is accessible for free. Supersedes <a   href="http://schema.org/free">free</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isBasedOn">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/isBasedOn">isBasedOn</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Product" /><a   href="http://schema.org/Product">Product</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A resource from which this work is derived or from which it is a modification or adaption. Supersedes <a   href="http://schema.org/isBasedOnUrl">isBasedOnUrl</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isBasisFor">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/isBasisFor">isBasisFor</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A resource that was (somehow) created using this resource as a basis for.<br/> Inverse property: <a   href="http://schema.org/isBasedOn">isBasedOn</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isFamilyFriendly">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/isFamilyFriendly">isFamilyFriendly</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Boolean" /><a   href="http://schema.org/Boolean">Boolean</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates whether this content is family friendly.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isPartOf">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/isPartOf">isPartOf</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates an item or CreativeWork that this item, or CreativeWork (in some sense), is part of.<br/> Inverse property: <a   href="http://schema.org/hasPart">hasPart</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/keywords">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/keywords">keywords</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/learningResourceType">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/learningResourceType">learningResourceType</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The predominant type or kind characterizing the learning resource. For example, 'presentation', 'handout'.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/license">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/license">license</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A license document that applies to this content, typically indicated by URL.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/locationCreated">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/locationCreated">locationCreated</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Place" /><a   href="http://schema.org/Place">Place</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioSample"><link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The location where the CreativeWork was created, which may not be the same as the location depicted in the CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/mainEntity">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/mainEntity">mainEntity</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Thing" /><a   href="http://schema.org/Thing">Thing</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates the primary entity described in some page or other CreativeWork.<br/> Inverse property: <a   href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/material">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/material">material</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Product" /><a   href="http://schema.org/Product">Product</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Product"></td><td class="prop-desc" property="rdfs:comment">A material that something is made from, e.g. leather, wool, cotton, paper.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/materialExtent">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/materialExtent">materialExtent</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/QuantitativeValue" /><a   href="http://schema.org/QuantitativeValue">QuantitativeValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The quantity of the materials being described or an expression of the physical space they occupy.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/mentions">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/mentions">mentions</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Thing" /><a   href="http://schema.org/Thing">Thing</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/offers">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/offers">offers</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Offer" /><a   href="http://schema.org/Offer">Offer</a>&nbsp;<link property="domainIncludes" href="http://schema.org/AggregateOffer"><link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/MenuItem"><link property="domainIncludes" href="http://schema.org/Product"><link property="domainIncludes" href="http://schema.org/Service"><link property="domainIncludes" href="http://schema.org/Trip"></td><td class="prop-desc" property="rdfs:comment">An offer to provide this item&#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/position">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/position">position</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Integer" /><a   href="http://schema.org/Integer">Integer</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/ListItem"></td><td class="prop-desc" property="rdfs:comment">The position of an item in a series or sequence of items.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/producer">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/producer">producer</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.).</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/provider">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/provider">provider</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Invoice"><link property="domainIncludes" href="http://schema.org/ParcelDelivery"><link property="domainIncludes" href="http://schema.org/Reservation"><link property="domainIncludes" href="http://schema.org/Service"><link property="domainIncludes" href="http://schema.org/Trip"></td><td class="prop-desc" property="rdfs:comment">The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller. Supersedes <a   href="http://schema.org/carrier">carrier</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/publication">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/publication">publication</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/PublicationEvent" /><a   href="http://schema.org/PublicationEvent">PublicationEvent</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A publication event associated with the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/publisher">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/publisher">publisher</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The publisher of the creative work.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/publisherImprint">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bib.schema.org"  class="ext ext-bib"  href="http://bib.localhost:8080/publisherImprint">publisherImprint</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The publishing division which published the comic.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/publishingPrinciples">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/publishingPrinciples">publishingPrinciples</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Organization"><link property="domainIncludes" href="http://schema.org/Person"></td><td class="prop-desc" property="rdfs:comment">The publishingPrinciples property indicates (typically via <a class="localLink" href="http://schema.org/URL">URL</a>) a document describing the editorial principles of an <a class="localLink" href="http://schema.org/Organization">Organization</a> (or individual e.g. a <a class="localLink" href="http://schema.org/Person">Person</a> writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a <a class="localLink" href="http://schema.org/CreativeWork">CreativeWork</a> (e.g. <a class="localLink" href="http://schema.org/NewsArticle">NewsArticle</a>) the principles are those of the party primarily responsible for the creation of the <a class="localLink" href="http://schema.org/CreativeWork">CreativeWork</a>.<br/><br/>
+
+                While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a <a class="localLink" href="http://schema.org/funder">funder</a>) can be expressed using schema.org terminology.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/recordedAt">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/recordedAt">recordedAt</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Event" /><a   href="http://schema.org/Event">Event</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event.<br/> Inverse property: <a   href="http://schema.org/recordedIn">recordedIn</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/releasedEvent">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/releasedEvent">releasedEvent</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/PublicationEvent" /><a   href="http://schema.org/PublicationEvent">PublicationEvent</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The place and time the release was issued, expressed as a PublicationEvent.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/review">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/review">review</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Review" /><a   href="http://schema.org/Review">Review</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Brand"><link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/Offer"><link property="domainIncludes" href="http://schema.org/Organization"><link property="domainIncludes" href="http://schema.org/Place"><link property="domainIncludes" href="http://schema.org/Product"><link property="domainIncludes" href="http://schema.org/Service"></td><td class="prop-desc" property="rdfs:comment">A review of the item. Supersedes <a   href="http://schema.org/reviews">reviews</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/schemaVersion">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/schemaVersion">schemaVersion</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates (by URL or string) a particular version of a schema used in some CreativeWork. For example, a document could declare a schemaVersion using an URL such as http://schema.org/version/2.0/ if precise indication of schema version was required by some application.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sdDatePublished">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/sdDatePublished">sdDatePublished</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Date" /><a   href="http://schema.org/Date">Date</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates the date on which the current structured data was generated / published. Typically used alongside <a class="localLink" href="http://schema.org/sdPublisher">sdPublisher</a></td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sdLicense">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/sdLicense">sdLicense</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A license document that applies to this structured data, typically indicated by URL.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sdPublisher">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/sdPublisher">sdPublisher</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates the party responsible for generating and publishing the current structured data markup, typically in cases where the structured data is derived automatically from existing published content but published on a different site. For example, student projects and open data initiatives often re-publish existing content with more explicitly structured metadata. The
+                <a class="localLink" href="http://schema.org/sdPublisher">sdPublisher</a> property helps make such practices more explicit.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sourceOrganization">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/sourceOrganization">sourceOrganization</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The Organization on whose behalf the creator was working.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/spatial">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/spatial">spatial</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Place" /><a   href="http://schema.org/Place">Place</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The "spatial" property can be used in cases when more specific properties
+                (e.g. <a class="localLink" href="http://schema.org/locationCreated">locationCreated</a>, <a class="localLink" href="http://schema.org/spatialCoverage">spatialCoverage</a>, <a class="localLink" href="http://schema.org/contentLocation">contentLocation</a>) are not known to be appropriate.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/spatialCoverage">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/spatialCoverage">spatialCoverage</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Place" /><a   href="http://schema.org/Place">Place</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The spatialCoverage of a CreativeWork indicates the place(s) which are the focus of the content. It is a subproperty of
+                      contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates
+                      areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sponsor">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/sponsor">sponsor</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/Grant"><link property="domainIncludes" href="http://schema.org/MedicalStudy"><link property="domainIncludes" href="http://schema.org/Organization"><link property="domainIncludes" href="http://schema.org/Person"></td><td class="prop-desc" property="rdfs:comment">A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/temporal">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/temporal">temporal</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/DateTime" /><a   href="http://schema.org/DateTime">DateTime</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The "temporal" property can be used in cases where more specific properties
+                (e.g. <a class="localLink" href="http://schema.org/temporalCoverage">temporalCoverage</a>, <a class="localLink" href="http://schema.org/dateCreated">dateCreated</a>, <a class="localLink" href="http://schema.org/dateModified">dateModified</a>, <a class="localLink" href="http://schema.org/datePublished">datePublished</a>) are not known to be appropriate.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/temporalCoverage">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/temporalCoverage">temporalCoverage</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/DateTime" /><a   href="http://schema.org/DateTime">DateTime</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The temporalCoverage of a CreativeWork indicates the period that the content applies to, i.e. that it describes, either as a DateTime or as a textual string indicating a time period in <a href="https://en.wikipedia.org/wiki/ISO_8601#Time_intervals">ISO 8601 time interval format</a>. In
+                      the case of a Dataset it will typically indicate the relevant time period in a precise notation (e.g. for a 2011 census dataset, the year 2011 would be written "2011/2012"). Other forms of content e.g. ScholarlyArticle, Book, TVSeries or TVEpisode may indicate their temporalCoverage in broader terms - textually or via well-known URL.
+                      Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945".<br/><br/>
+
+                Open-ended date ranges can be written with ".." in place of the end date. For example, "2015-11/.." indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated. Supersedes <a   href="http://schema.org/datasetTimeInterval">datasetTimeInterval</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/text">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/text">text</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The textual content of this CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/thumbnailUrl">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/thumbnailUrl">thumbnailUrl</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A thumbnail image relevant to the Thing.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/timeRequired">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/timeRequired">timeRequired</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Duration" /><a   href="http://schema.org/Duration">Duration</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Approximate or typical time it takes to work with or through this learning resource for the typical intended target audience, e.g. 'PT30M', 'PT1H25M'.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/translationOfWork">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bib.schema.org"  class="ext ext-bib"  href="http://bib.localhost:8080/translationOfWork">translationOfWork</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The work that this work has been translated from. e.g. 物种起源 is a translationOf “On the Origin of Species”<br/> Inverse property: <a title="Defined in extension: bib.schema.org"  class="ext ext-bib"  href="http://bib.localhost:8080/workTranslation">workTranslation</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/translator">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/translator">translator</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"></td><td class="prop-desc" property="rdfs:comment">Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/typicalAgeRange">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/typicalAgeRange">typicalAgeRange</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"></td><td class="prop-desc" property="rdfs:comment">The typical expected age range, e.g. '7-9', '11-'.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/version">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/version">version</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Number" /><a   href="http://schema.org/Number">Number</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The version of the CreativeWork embodied by a specified resource.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/video">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/video">video</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Clip" /><a   href="http://schema.org/Clip">Clip</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/VideoObject" /><a   href="http://schema.org/VideoObject">VideoObject</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">An embedded video object.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/workExample">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/workExample">workExample</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Example/instance/realization/derivation of the concept of this creative work. eg. The paperback edition, first edition, or eBook.<br/> Inverse property: <a   href="http://schema.org/exampleOfWork">exampleOfWork</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/workTranslation">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bib.schema.org"  class="ext ext-bib"  href="http://bib.localhost:8080/workTranslation">workTranslation</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A work that is a translation of the content of this work. e.g. 西遊記 has an English workTranslation “Journey to the West”,a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese  translation Tây du ký bình khảo.<br/> Inverse property: <a title="Defined in extension: bib.schema.org"  class="ext ext-bib"  href="http://bib.localhost:8080/translationOfWork">translationOfWork</a>.</td></tr><tr class="supertype">
+                     <th class="supertype-name" colspan="3">Properties from <a   href="http://schema.org/Thing">Thing</a></th>
+
+                </tr>
+
+                <tbody class="supertype">
+                  <tr typeof="rdfs:Property" resource="http://schema.org/additionalType">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/additionalType">additionalType</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax - the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those defined externally.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/alternateName">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/alternateName">alternateName</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An alias for the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/description">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/description">description</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A description of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/disambiguatingDescription">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/identifier">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/identifier">identifier</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The identifier property represents any kind of identifier for any kind of <a class="localLink" href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/image">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/image">image</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/ImageObject" /><a   href="http://schema.org/ImageObject">ImageObject</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An image of the item. This can be a <a class="localLink" href="http://schema.org/URL">URL</a> or a fully described <a class="localLink" href="http://schema.org/ImageObject">ImageObject</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/mainEntityOfPage">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/> Inverse property: <a   href="http://schema.org/mainEntity">mainEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/name">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/name">name</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The name of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/potentialAction">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/potentialAction">potentialAction</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Action" /><a   href="http://schema.org/Action">Action</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sameAs">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/sameAs">sameAs</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/subjectOf">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/subjectOf">subjectOf</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Event" /><a   href="http://schema.org/Event">Event</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A CreativeWork or Event about this Thing..<br/> Inverse property: <a   href="http://schema.org/about">about</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/url">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/url">url</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of the item.</td></tr>
+
+                </table>
                </section>
              </div>
            </div>

--- a/_devTypes/Enzyme.html
+++ b/_devTypes/Enzyme.html
@@ -34,347 +34,264 @@ external: #454547;
               <section id="main_content" class="inner">
                 {% include type_start.html %}
 
-                <table class="bioschemas_properties bsc_type">
-                   <thead>
-                      <tr>
-                         <th>Property</th>
-                         <th>Expected Type</th>
-                         <th>Description</th>
-                      </tr>
-                   </thead>
-                   <tbody>
-                     <tr class="new_props_sdo">
-                        <td colspan="3">
-                           Properties from <a style="color: #0B794B;" href="/{{page.name}}">{{page.name}}</a> (being developed for schema.org integration).
-                        </td>
-                     </tr>
-                     <tr id="hasAssocitatedBioChemEntity">
-                       <th style="color: #0B794B;">hasAssocitatedBioChemEntity</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/Protein">Protein</a> or <br />
-                         <a style="color: #0B794B;" href="/types/drafts/RNA">RNA</a>
-                       </td>
-                       <td>
-                         Used to define the actual protein or RNA.
-                       </td>
-                     </tr>
-                     </tr>
-                     <tr id="hasCoenzyme">
-                       <th style="color: #0B794B;">hasCoenzyme</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/BioChemEntity">BioChemEntity</a>
-                       </td>
-                       <td>
-                         Conenzymes helping this enzyme in turning substrates into products.
-                       </td>
-                     </tr>
-                     <tr id="hasCofactor">
-                       <th style="color: #0B794B;">hasCofactor</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/ChemicalSubstance">ChemicalSubstance</a>
-                       </td>
-                       <td>
-                         Cofactor helping this enzyme to function.
-                       </td>
-                     </tr>
-                     <tr id="hasECNumber">
-                       <th style="color: #0B794B;">hasECNumber</th>
-                       <td>
-                         <a href="https://schema.org/DefinedTerm">DefinedTerm</a> or <br />
-                         <a href="https://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         Corresponding Enzyme Commission number.
-                       </td>
-                     </tr>
-                     <tr id="hasKineticRate">
-                       <th style="color: #0B794B;">hasKineticRate</th>
-                       <td>
-                         <a href="https://schema.org/Text">Text</a>
-                       </td>
-                       <td>
+                <table class="definition-table">
+                        <thead>
+                  <tr><th>Property</th><th>Expected Type</th><th>Description</th>
+                  </tr>
+                  </thead>
 
-                       </td>
-                     </tr>
-                     <tr id="optimalPH">
-                       <th style="color: #0B794B;">optimalPH</th>
-                       <td>
-                         <a href="https://schema.org/Number">Number</a>
-                       </td>
-                       <td>
-                         Optimal PHs.
-                       </td>
-                     </tr>
-                     <tr id="optimalTemperature">
-                       <th style="color: #0B794B;">optimalTemperature</th>
-                       <td>
-                         <a href="https://schema.org/Quantity">Quantity</a>
-                       </td>
-                       <td>
-                         Optimal temperature in the form '&lt;Number&gt; &lt;Temperature unit of measure&gt;', for example '8 Celsius', at which this enzyme performs best.
-                       </td>
-                     </tr>
+                <tr class="supertype">
+                     <th class="supertype-name" colspan="3">Properties from <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/Enzyme">Enzyme</a></th>
 
+                </tr>
 
+                <tbody class="supertype">
+                  <tr typeof="rdfs:Property" resource="http://schema.org/hasAssociatedBioChemEntity">
 
-                     <!-- BCE -->
-                     <tr class="reu_props_sdo">
-                        <td colspan="3">Properties from <a style="color: #0B794B;" href="/BioChemEntity">BioChemEntity</a> (pending schema.org integration).</td>
-                     </tr>
-                    <tr id="associatedDisease">
-                       <th style="color: #0B794B;">associatedDisease</th>
-                       <td>
-                         <a href="http://schema.org/MedicalCondition">MedicalCondition</a> or<br/>
-                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Disease associated to this BioChemEntity. Such a disease can be a MedicalCondition or a URL. If you want to add an evidence supporting the association, please use PropertyValue.
-                       </td>
-                     </tr>
-                     <tr id="bioChemInteraction">
-                       <th style="color: #0B794B;">bioChemInteraction</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/BioChemEntity">BioChemEntity</a>
-                       </td>
-                       <td>
-                        A BioChemEntity that is know to interact with this item.
-                       </td>
-                     </tr>
-                     <tr id="bioChemSimilarity">
-                       <th style="color: #0B794B;">bioChemSimilarity</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/BioChemEntity">BioChemEntity</a>
-                       </td>
-                       <td>
-                        A similar molecular entity, e.g., obtained by fingerprint similarity algorithm.
-                       </td>
-                     </tr>
-                     <tr id="biogicalRole">
-                       <th style="color: #0B794B;">biogicalRole</th>
-                       <td>
-                         <a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a>
-                       </td>
-                       <td>
-                        A role played by the molecular entity within a biological context.
-                       </td>
-                     </tr>
-                     <tr id="hasBioChemEntityPart">
-                       <th style="color: #0B794B;">hasBioChemEntityPart</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/BioChemEntity">BioChemEntity</a>
-                       </td>
-                       <td>
-                         Indicates a BioChemEntity that (in some sense) has this BioChemEntity as a part.<br/>
-                         Inverse property: <span style="color: #0B794B;">isPartOfBioChemEntity</span>
-                       </td>
-                     </tr>
-                      <tr id="hasMolecularFunction">
-                       <th style="color: #0B794B;">hasMolecularFunction</th>
-                       <td>
-                         <a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a> or<br/>
-                         <a href="http://schema.org/PropertyValue">PropertyValue</a>or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Molecular function performed by this BioChemEntity; please use PropertyValue if you want to include any evidence.
-                       </td>
-                     </tr>
-                     <tr id="hasRepresentation">
-                       <th style="color: #0B794B;">hasRepresentation</th>
-                       <td>
-                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-                         <a href="http://schema.org/Text">Text</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         A common representation such as a protein sequence or chemical structure for this entity. For images use schema.org/image.
-                       </td>
-                     </tr>
-                     <tr id="isEncodedByBioChemEntity">
-                       <th style="color: #0B794B;">isEncodedByBioChemEntity</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/Gene">Gene</a>
-                       </td>
-                       <td>
-                         Another BioChemEntity encoding this one. <br/>
-                         Inverse property: <span style="color: #0B794B;">encodesBioChemEntity</span>
-                       </td>
-                     </tr>
-                     <tr id="isInvolvedInBiologicalProcess">
-                       <th style="color: #0B794B;">isInvolvedInBiologicalProcess</th>
-                       <td>
-							<a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a> or</b>
-							<a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-							<a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Biological process this BioChemEntity is involved in; please use PropertyValue if you want to include any evidence.
-                       </td>
-                     </tr>
-                     <tr id="isLocatedInSubcellularLocation">
-                       <th style="color: #0B794B;">isLocatedInSubcellularLocation</th>
-                       <td>
-							<a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a> or</b>
-							<a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-							<a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Subcellular location where this BioChemEntity is located; please use PropertyValue if you want to include any evidence.
-                       </td>
-                     </tr>
-                     <tr id="isPartOfBioChemEntity">
-                       <th style="color: #0B794B;">isPartOfBioChemEntity</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/BioChemEntity">BioChemEntity</a>
-                       </td>
-                       <td>
-                         Indicates a BioChemEntity that is (in some sense) a part of this BioChemEntity. <br/>
-                         Inverse property: <span style="color: #0B794B;">hasBioChemEntityPart</span>
-                       </td>
-                     </tr>
-                     <tr id="taxonomicRange">
-                       <th style="color: #0B794B;">taxonomicRange</th>
-                       <td>
-                       	 <a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a> or</b>
-                         <a style="color: #0B794B;" href="/types/drafts/Taxon">Taxon</a> or<br/>
-                         <a href="http://schema.org/Text">Text</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         The taxonomic grouping of the organism that expresses, encodes, or in someway related to the BioChemEntity.
-                       </td>
-                     </tr>
+                      <th class="prop-nam" scope="row">
 
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasAssociatedBioChemEntity">hasAssociatedBioChemEntity</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Protein" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/Protein">Protein</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/RNA" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/RNA">RNA</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemStructure"><link property="domainIncludes" href="http://schema.org/Enzyme"></td><td class="prop-desc" property="rdfs:comment">Used to define the actual protein or RNA.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasCoenzyme">
 
+                      <th class="prop-nam" scope="row">
 
-       				<!-- THING -->
-                     <tr class="reu_props_sdo">
-                        <td colspan="3">Properties from <a href="http://schema.org/Thing">Thing</a></td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/additionalType">additionalType</a></th>
-                       <td>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax.
-                         This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax -
-                         the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those
-                         defined externally.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/alternateName">alternateName</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         An alias for the item.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/description">description</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         A descripton of the item.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/identifier">identifier</a></th>
-                       <td>
-                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-                         <a href="http://schema.org/Text">Text</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         The identifier property represents any kind of identifier for any kind of <a href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc.
-                         Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links.
-                         See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/image">image</a></th>
-                       <td>
-                         <a href="http://schema.org/ImageObject">ImageObject</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         An image of the item. This can be a <a href="http://schema.org/URL">URL</a> or a fully described <a href="http://schema.org/ImageObject">ImageObject</a>.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></th>
-                       <td>
-                         <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See
-                         <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/>
-                         Inverse property: <a href="http://schema.org/mainEntity">mainEntity</a>
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/name">name</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         The name of the item.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/potentialAction">potentialAction</a></th>
-                       <td>
-                         <a href="http://schema.org/Action">Action</a>
-                       </td>
-                       <td>
-                         Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/sameAs">sameAs</a></th>
-                       <td>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/subjectOf">subjectOf</a></th>
-                       <td>
-                         <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
-                         <a href="http://schema.org/Event">Event</a>
-                       </td>
-                       <td>
-                         A CreativeWork or Event about this Thing..<br/>
-                         Inverse property: <a href="http://schema.org/about">about</a>.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/url">url</a></th>
-                       <td>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         URL of the item.
-                       </td>
-                     </tr>
-                   </tbody>
-                 </table>
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasCoenzyme">hasCoenzyme</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Enzyme"></td><td class="prop-desc" property="rdfs:comment">Conenzymes helping this enzyme in turning substrates into products.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasCofactor">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasCofactor">hasCofactor</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/ChemicalSubstance" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/ChemicalSubstance">ChemicalSubstance</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Enzyme"></td><td class="prop-desc" property="rdfs:comment">Cofactor helping this enzyme to function.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasECNumber">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasECNumber">hasECNumber</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Enzyme"></td><td class="prop-desc" property="rdfs:comment">Corresponding Enzyme Commission number.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasKineticRate">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasKineticRate">hasKineticRate</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Enzyme"></td><td class="prop-desc" property="rdfs:comment">-</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/optimalPH">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#optimalPH">optimalPH</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Number" /><a   href="http://schema.org/Number">Number</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Enzyme"></td><td class="prop-desc" property="rdfs:comment">Optimal PHs.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/optimalTemperature">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#optimalTemperature">optimalTemperature</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Quantity" /><a   href="http://schema.org/Quantity">Quantity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Enzyme"></td><td class="prop-desc" property="rdfs:comment">Optimal temperature in the form '&lt;Number&gt; &lt;Temperature unit of measure&gt;', for example '8 Celsius', at which this enzyme performs best.</td></tr><tr class="supertype">
+                  <th class="supertype-name" colspan="3">Properties from <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a></th>
+
+             </tr>
+
+             <tbody class="supertype">
+               <tr typeof="rdfs:Property" resource="http://schema.org/associatedDisease">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#associatedDisease">associatedDisease</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/MedicalCondition" /><a   href="http://schema.org/MedicalCondition">MedicalCondition</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Disease associated to this BioChemEntity. Such disease can be a MedicalCondition or a URL. If you want to add an evidence supporting the association, please use PropertyValue.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/bioChemInteraction">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#bioChemInteraction">bioChemInteraction</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A BioChemEntity that is known to interact with this item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/bioChemSimilarity">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#bioChemSimilarity">bioChemSimilarity</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A similar molecular entity, e.g., obtained by fingerprint similarity algorithms.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/biologicalRole">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#biologicalRole">biologicalRole</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A role played by the molecular entity within a biological context.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasBioChemEntityPart">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasBioChemEntityPart">hasBioChemEntityPart</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Indicates a BioChemEntity that (in some sense) has this BioChemEntity as a part.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isPartOfBioChemEntity">isPartOfBioChemEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasMolecularFunction">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasMolecularFunction">hasMolecularFunction</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Molecular function performed by this BioChemEntity; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasRepresentation">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasRepresentation">hasRepresentation</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A common representation such as a protein sequence or chemical structure for this entity. For images use schema.org/image.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasSequenceAnnotation">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasSequenceAnnotation">hasSequenceAnnotation</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/SequenceAnnotation" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/SequenceAnnotation">SequenceAnnotation</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Pointer to a sequence annotation; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isEncodedByBioChemEntity">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isEncodedByBioChemEntity">isEncodedByBioChemEntity</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/DNA" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/DNA">DNA</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Gene" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/Gene">Gene</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/RNA" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/RNA">RNA</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Another BioChemEntity encoding by this one.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#encodesBioChemEntity">encodesBioChemEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isInvolvedInBiologicalProcess">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isInvolvedInBiologicalProcess">isInvolvedInBiologicalProcess</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Biological process this BioChemEntity is involved in; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isLocatedInSubcellularLocation">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isLocatedInSubcellularLocation">isLocatedInSubcellularLocation</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Subcellular location where this BioChemEntity is located; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isMatchedBy">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isMatchedBy">isMatchedBy</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/SequenceMatchingModel" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/SequenceMatchingModel">SequenceMatchingModel</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A model matching this BioChemEntity.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isPartOfBioChemEntity">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isPartOfBioChemEntity">isPartOfBioChemEntity</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Indicates a BioChemEntity that is (in some sense) a part of this BioChemEntity.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasBioChemEntityPart">hasBioChemEntityPart</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/taxonomicRange">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#taxonomicRange">taxonomicRange</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Taxon" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/Taxon">Taxon</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"><link property="domainIncludes" href="http://schema.org/Phenotype"></td><td class="prop-desc" property="rdfs:comment">The taxonomic grouping of the organism that expresses, encodes, or in someway related to the BioChemEntity.</td></tr><tr class="supertype">
+                  <th class="supertype-name" colspan="3">Properties from <a   href="http://schema.org/Thing">Thing</a></th>
+
+             </tr>
+
+             <tbody class="supertype">
+               <tr typeof="rdfs:Property" resource="http://schema.org/additionalType">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/additionalType">additionalType</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax - the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those defined externally.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/alternateName">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/alternateName">alternateName</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An alias for the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/description">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/description">description</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A description of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/disambiguatingDescription">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/identifier">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/identifier">identifier</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The identifier property represents any kind of identifier for any kind of <a class="localLink" href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/image">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/image">image</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/ImageObject" /><a   href="http://schema.org/ImageObject">ImageObject</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An image of the item. This can be a <a class="localLink" href="http://schema.org/URL">URL</a> or a fully described <a class="localLink" href="http://schema.org/ImageObject">ImageObject</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/mainEntityOfPage">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/> Inverse property: <a   href="http://schema.org/mainEntity">mainEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/name">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/name">name</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The name of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/potentialAction">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/potentialAction">potentialAction</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/Action" /><a   href="http://schema.org/Action">Action</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sameAs">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/sameAs">sameAs</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/subjectOf">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/subjectOf">subjectOf</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Event" /><a   href="http://schema.org/Event">Event</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A CreativeWork or Event about this Thing..<br/> Inverse property: <a   href="http://schema.org/about">about</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/url">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/url">url</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of the item.</td></tr>
+
+             </table>
                </section>
              </div>
            </div>

--- a/_devTypes/Enzyme.html
+++ b/_devTypes/Enzyme.html
@@ -34,7 +34,7 @@ external: #454547;
               <section id="main_content" class="inner">
                 {% include type_start.html %}
 
-                <table class="definition-table">
+                <table class="definition-table bsc_type">
                         <thead>
                   <tr><th>Property</th><th>Expected Type</th><th>Description</th>
                   </tr>

--- a/_devTypes/Enzyme.html
+++ b/_devTypes/Enzyme.html
@@ -7,7 +7,7 @@ hierarchy:
 - Thing
 - BioChemEntity
 gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Enzyme
-group: protein
+group: proteins
 name: Enzyme
 parent_type: BioChemEntity
 spec_type: Type

--- a/_devTypes/Enzyme.html
+++ b/_devTypes/Enzyme.html
@@ -1,0 +1,387 @@
+---
+redirect_from:
+- "/Enzyme"
+dateModified: 2019-06-20
+description:
+hierarchy:
+- Thing
+- BioChemEntity
+gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Enzyme
+group: protein
+name: Enzyme
+parent_type: BioChemEntity
+spec_type: Type
+status: revision #Revert to revision when working on the next version
+version: '0.1-DRAFT'
+
+bsc: #0B794B;
+pending : #0000CC;
+external: #454547;
+
+---
+
+
+<!DOCTYPE HTML>
+<html>
+   {% include head.html %}
+
+   <body>
+      {% include header.html %}
+      {% include navbar.html %}
+      <div class="page-content">
+        <div class="wrapper">
+           <div id="main-content-wrapper" class="outer">
+              <section id="main_content" class="inner">
+                {% include type_start.html %}
+
+                <table class="bioschemas_properties bsc_type">
+                   <thead>
+                      <tr>
+                         <th>Property</th>
+                         <th>Expected Type</th>
+                         <th>Description</th>
+                      </tr>
+                   </thead>
+                   <tbody>
+                     <tr class="new_props_sdo">
+                        <td colspan="3">
+                           Properties from <a style="color: #0B794B;" href="/{{page.name}}">{{page.name}}</a> (being developed for schema.org integration).
+                        </td>
+                     </tr>
+                     <tr id="hasAssocitatedBioChemEntity">
+                       <th style="color: #0B794B;">hasAssocitatedBioChemEntity</th>
+                       <td>
+                         <a style="color: #0B794B;" href="/types/drafts/Protein">Protein</a> or <br />
+                         <a style="color: #0B794B;" href="/types/drafts/RNA">RNA</a>
+                       </td>
+                       <td>
+                         Used to define the actual protein or RNA.
+                       </td>
+                     </tr>
+                     </tr>
+                     <tr id="hasCoenzyme">
+                       <th style="color: #0B794B;">hasCoenzyme</th>
+                       <td>
+                         <a style="color: #0B794B;" href="/types/drafts/BioChemEntity">BioChemEntity</a>
+                       </td>
+                       <td>
+                         Conenzymes helping this enzyme in turning substrates into products.
+                       </td>
+                     </tr>
+                     <tr id="hasCofactor">
+                       <th style="color: #0B794B;">hasCofactor</th>
+                       <td>
+                         <a style="color: #0B794B;" href="/types/drafts/ChemicalSubstance">ChemicalSubstance</a>
+                       </td>
+                       <td>
+                         Cofactor helping this enzyme to function.
+                       </td>
+                     </tr>
+                     <tr id="hasECNumber">
+                       <th style="color: #0B794B;">hasECNumber</th>
+                       <td>
+                         <a href="https://schema.org/DefinedTerm">DefinedTerm</a> or <br />
+                         <a href="https://schema.org/Text">Text</a>
+                       </td>
+                       <td>
+                         Corresponding Enzyme Commission number.
+                       </td>
+                     </tr>
+                     <tr id="hasKineticRate">
+                       <th style="color: #0B794B;">hasKineticRate</th>
+                       <td>
+                         <a href="https://schema.org/Text">Text</a>
+                       </td>
+                       <td>
+
+                       </td>
+                     </tr>
+                     <tr id="optimalPH">
+                       <th style="color: #0B794B;">optimalPH</th>
+                       <td>
+                         <a href="https://schema.org/Number">Number</a>
+                       </td>
+                       <td>
+                         Optimal PHs.
+                       </td>
+                     </tr>
+                     <tr id="optimalTemperature">
+                       <th style="color: #0B794B;">optimalTemperature</th>
+                       <td>
+                         <a href="https://schema.org/Quantity">Quantity</a>
+                       </td>
+                       <td>
+                         Optimal temperature in the form '&lt;Number&gt; &lt;Temperature unit of measure&gt;', for example '8 Celsius', at which this enzyme performs best.
+                       </td>
+                     </tr>
+
+
+
+                     <!-- BCE -->
+                     <tr class="reu_props_sdo">
+                        <td colspan="3">Properties from <a style="color: #0B794B;" href="/BioChemEntity">BioChemEntity</a> (pending schema.org integration).</td>
+                     </tr>
+                    <tr id="associatedDisease">
+                       <th style="color: #0B794B;">associatedDisease</th>
+                       <td>
+                         <a href="http://schema.org/MedicalCondition">MedicalCondition</a> or<br/>
+                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         Disease associated to this BioChemEntity. Such a disease can be a MedicalCondition or a URL. If you want to add an evidence supporting the association, please use PropertyValue.
+                       </td>
+                     </tr>
+                     <tr id="bioChemInteraction">
+                       <th style="color: #0B794B;">bioChemInteraction</th>
+                       <td>
+                         <a style="color: #0B794B;" href="/types/drafts/BioChemEntity">BioChemEntity</a>
+                       </td>
+                       <td>
+                        A BioChemEntity that is know to interact with this item.
+                       </td>
+                     </tr>
+                     <tr id="bioChemSimilarity">
+                       <th style="color: #0B794B;">bioChemSimilarity</th>
+                       <td>
+                         <a style="color: #0B794B;" href="/types/drafts/BioChemEntity">BioChemEntity</a>
+                       </td>
+                       <td>
+                        A similar molecular entity, e.g., obtained by fingerprint similarity algorithm.
+                       </td>
+                     </tr>
+                     <tr id="biogicalRole">
+                       <th style="color: #0B794B;">biogicalRole</th>
+                       <td>
+                         <a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a>
+                       </td>
+                       <td>
+                        A role played by the molecular entity within a biological context.
+                       </td>
+                     </tr>
+                     <tr id="hasBioChemEntityPart">
+                       <th style="color: #0B794B;">hasBioChemEntityPart</th>
+                       <td>
+                         <a style="color: #0B794B;" href="/types/drafts/BioChemEntity">BioChemEntity</a>
+                       </td>
+                       <td>
+                         Indicates a BioChemEntity that (in some sense) has this BioChemEntity as a part.<br/>
+                         Inverse property: <span style="color: #0B794B;">isPartOfBioChemEntity</span>
+                       </td>
+                     </tr>
+                      <tr id="hasMolecularFunction">
+                       <th style="color: #0B794B;">hasMolecularFunction</th>
+                       <td>
+                         <a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a> or<br/>
+                         <a href="http://schema.org/PropertyValue">PropertyValue</a>or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         Molecular function performed by this BioChemEntity; please use PropertyValue if you want to include any evidence.
+                       </td>
+                     </tr>
+                     <tr id="hasRepresentation">
+                       <th style="color: #0B794B;">hasRepresentation</th>
+                       <td>
+                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
+                         <a href="http://schema.org/Text">Text</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         A common representation such as a protein sequence or chemical structure for this entity. For images use schema.org/image.
+                       </td>
+                     </tr>
+                     <tr id="isEncodedByBioChemEntity">
+                       <th style="color: #0B794B;">isEncodedByBioChemEntity</th>
+                       <td>
+                         <a style="color: #0B794B;" href="/types/drafts/Gene">Gene</a>
+                       </td>
+                       <td>
+                         Another BioChemEntity encoding this one. <br/>
+                         Inverse property: <span style="color: #0B794B;">encodesBioChemEntity</span>
+                       </td>
+                     </tr>
+                     <tr id="isInvolvedInBiologicalProcess">
+                       <th style="color: #0B794B;">isInvolvedInBiologicalProcess</th>
+                       <td>
+							<a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a> or</b>
+							<a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
+							<a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         Biological process this BioChemEntity is involved in; please use PropertyValue if you want to include any evidence.
+                       </td>
+                     </tr>
+                     <tr id="isLocatedInSubcellularLocation">
+                       <th style="color: #0B794B;">isLocatedInSubcellularLocation</th>
+                       <td>
+							<a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a> or</b>
+							<a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
+							<a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         Subcellular location where this BioChemEntity is located; please use PropertyValue if you want to include any evidence.
+                       </td>
+                     </tr>
+                     <tr id="isPartOfBioChemEntity">
+                       <th style="color: #0B794B;">isPartOfBioChemEntity</th>
+                       <td>
+                         <a style="color: #0B794B;" href="/types/drafts/BioChemEntity">BioChemEntity</a>
+                       </td>
+                       <td>
+                         Indicates a BioChemEntity that is (in some sense) a part of this BioChemEntity. <br/>
+                         Inverse property: <span style="color: #0B794B;">hasBioChemEntityPart</span>
+                       </td>
+                     </tr>
+                     <tr id="taxonomicRange">
+                       <th style="color: #0B794B;">taxonomicRange</th>
+                       <td>
+                       	 <a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a> or</b>
+                         <a style="color: #0B794B;" href="/types/drafts/Taxon">Taxon</a> or<br/>
+                         <a href="http://schema.org/Text">Text</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         The taxonomic grouping of the organism that expresses, encodes, or in someway related to the BioChemEntity.
+                       </td>
+                     </tr>
+
+
+
+       				<!-- THING -->
+                     <tr class="reu_props_sdo">
+                        <td colspan="3">Properties from <a href="http://schema.org/Thing">Thing</a></td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/additionalType">additionalType</a></th>
+                       <td>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax.
+                         This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax -
+                         the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those
+                         defined externally.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/alternateName">alternateName</a></th>
+                       <td>
+                         <a href="http://schema.org/Text">Text</a>
+                       </td>
+                       <td>
+                         An alias for the item.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/description">description</a></th>
+                       <td>
+                         <a href="http://schema.org/Text">Text</a>
+                       </td>
+                       <td>
+                         A descripton of the item.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></th>
+                       <td>
+                         <a href="http://schema.org/Text">Text</a>
+                       </td>
+                       <td>
+                         A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/identifier">identifier</a></th>
+                       <td>
+                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
+                         <a href="http://schema.org/Text">Text</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         The identifier property represents any kind of identifier for any kind of <a href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc.
+                         Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links.
+                         See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/image">image</a></th>
+                       <td>
+                         <a href="http://schema.org/ImageObject">ImageObject</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         An image of the item. This can be a <a href="http://schema.org/URL">URL</a> or a fully described <a href="http://schema.org/ImageObject">ImageObject</a>.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></th>
+                       <td>
+                         <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See
+                         <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/>
+                         Inverse property: <a href="http://schema.org/mainEntity">mainEntity</a>
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/name">name</a></th>
+                       <td>
+                         <a href="http://schema.org/Text">Text</a>
+                       </td>
+                       <td>
+                         The name of the item.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/potentialAction">potentialAction</a></th>
+                       <td>
+                         <a href="http://schema.org/Action">Action</a>
+                       </td>
+                       <td>
+                         Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/sameAs">sameAs</a></th>
+                       <td>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/subjectOf">subjectOf</a></th>
+                       <td>
+                         <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
+                         <a href="http://schema.org/Event">Event</a>
+                       </td>
+                       <td>
+                         A CreativeWork or Event about this Thing..<br/>
+                         Inverse property: <a href="http://schema.org/about">about</a>.
+                       </td>
+                     </tr>
+                     <tr>
+                       <th><a href="http://schema.org/url">url</a></th>
+                       <td>
+                         <a href="http://schema.org/URL">URL</a>
+                       </td>
+                       <td>
+                         URL of the item.
+                       </td>
+                     </tr>
+                   </tbody>
+                 </table>
+               </section>
+             </div>
+           </div>
+      </div>
+      {% include footer.html %}
+
+
+
+   </body>
+</html>

--- a/_devTypes/LabProtocol.html
+++ b/_devTypes/LabProtocol.html
@@ -4,11 +4,8 @@ redirect_from:
 - "devTypes/LabProtocol/specification/"
 - "/devTypes/LabProtocol/"
 cross_walk_url: https://docs.google.com/spreadsheets/d/1RWYIphvcBMHl8SLJl5-xRMZI0YaYrtJtClBSoOPL4xQ
-dateModified: 2018-03-09
-description: 'An experimental protocol is a sequence of tasks and operations executed to perform experimental research in biological and biomedical areas.
-Experimental protocols are fundamental information structures that support the description of the processes by means of which results are generated in experimental research [1]. Experimental protocols describe how the data were produced, the steps undertaken and conditions under which these steps were carried out.
-<br />
-[1]  Giraldo, O., García, A., López, F., & Corcho, O. (2017). Using semantics for representing experimental protocols. Journal of Biomedical Semantics, 8, 52. <a href="http://doi.org/10.1186/s13326-017-0160-y">http://doi.org/10.1186/s13326-017-0160-y</a>'
+dateModified: 2019-06-20
+description: 'An experimental protocol is a sequence of tasks and operations executed to perform experimental research in biological and biomedical areas.'
 gh_examples: https://docs.google.com/document/d/16KlB9fE2s-USAf0Vo9cTbh_wKEc0BmSxCgQmKQXKLQ8/
 gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20LabProtocol
 group: labprotocols
@@ -22,7 +19,7 @@ spec_type: Type
 status: revision
 subtitle: Bioschemas specification describing LabProtocol in the life-science.
 use_cases_url: ''
-version: '0.2-DRAFT'
+version: '0.3-DRAFT'
 
 bsc: #0B794B;
 pending: #0000CC;
@@ -40,979 +37,839 @@ external: #454547;
             <div id="main-content-wrapper" class="outer">
                <section id="main_content" class="inner">
                   {% include type_start.html %}
-                  <table class="bioschemas_properties bsc_type">
-                     <thead>
-                        <tr>
-                           <th>Property</th>
-                           <th>Expected Type</th>
-                           <th>Description</th>
-                        </tr>
-                     </thead>
-                     <tbody>
-                       <!-- NEW PROPERTIES -->
-                       <tr class="new_props_sdo">
-                          <td colspan="3">
-                             New properties for <a style="color: #0B794B;" href="#">{{page.name}}</a> (pending schema.org integration).
-                          </td>
-                        </tr>
-                       <tr>
-                          <th><a href="http://schema.org/duration">duration</a></th>
-                          <td>
-                             <a href="http://schema.org/Duration">Duration</a>
-                             <br>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: The duration of the item (movie, audio recording, event, etc.) in <a href="http://en.wikipedia.org/wiki/ISO_8601">ISO 8601 date format</a>.<br />
-                            <strong>Bioschemas</strong>: The time it takes to actually carry out the protocol, in <a href="http://en.wikipedia.org/wiki/ISO_8601">ISO 8601 date format</a>.
-                          </td>
-                       </tr>
-                       <tr>
-                            <th><a style="color: #0B794B" href="http://schema.org/instrument">instrument</a></th>
-                            <td>
-                               <a href="http://schema.org/Text">Text</a><br />
-                               <a href="http://schema.org/Thing">Thing</a><br />
-                               <a href="http://schema.org/URL">URL</a>
-                            </td>
-                            <td>
-                              <strong>Schema</strong>: The object that helped the agent perform the action. e.g. John wrote a book with a pen.<br />
-                              <strong>Bioschemas</strong>: For LabProtocols it would be a laboratory equipment use by a person to follow one or more steps described in this LabProtocol.<br />
-                              <u><strong>Note</strong></u>: Bioschemas have added the following to the list of Expected Types: <a href="http://schema.org/Text">Text</a>
-                              and <a href="http://schema.org/URL">URL</a>.
-                            </td>
-                         </tr>
-                        <tr id="purpose">
-                           <th><a style="color: #0B794B;" href="#">purpose</a></th>
-                           <td>
-                              <a href="http://schema.org/Text">Text</a>
-                              <br>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: A goal towards an action is taken. Can be concrete or abstract. <br />
-                             <u><strong>Note</strong></u>: Bioschemas have changed the Expected Types by removing <a href="http://health-lifesci.schema.org/MedicalDevicePurpose">
-                              MedicalDevicePurpose</a> and <a href="http://schema.org/Thing">Thing</a>, and adding <a href="http://schema.org/Text">Text</a>.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a style="color: #454547;" href="http://purl.obolibrary.org/obo/CHEBI_33893">ChEBI:reagent</a></th>
-                           <td>
-                             {% if status == 'revision' %}
-                             <a style="color: #0B794B" href="/devTypes/BioChemEntity/">BioChemEntity</a>
-                             {% else %}
-                             <a style="color: #0B794B" href="/types/BioChemEntity/">BioChemEntity</a>
-                             {% endif %}
-                              <br>
-                              <a href="http://schema.org/Text">Text</a><br />
-                              <a href="http://schema.org/URL">URL</a>
-                           </td>
-                           <td>
-                              <strong>Bioschemas</strong>: Reagent used in the protocol. It can be a record in a Dataset describing the reagent or a BioChemEntity corresponding to the reagent or a URL pointing to the type of reagent used. ChEBI and PubChem entities can be used whenever available. Commercial names are also acceptable (URL if possible)
-                           </td>
-                        </tr>
-                        <tr id="sample">
-                           <th><a style="color: #0B794B;" href="#">sample</a></th>
-                           <td>
-                             {% if status == 'revision' %}
-                             <a style="color: #0B794B" href="/devTypes/BioChemEntity/">BioChemEntity</a>
-                             {% else %}
-                             <a style="color: #0B794B" href="/types/BioChemEntity/">BioChemEntity</a>
-                             {% endif %}
-                              <br>
-                              <a href="http://schema.org/Text">Text</a><br />
-                              <a href="http://schema.org/URL">URL</a>
-                           </td>
-                           <td>
-                              <strong>Bioschemas</strong>: Sample used in the protocol. It could be a record in a Dataset describing the sample or a physical object corresponding to the sample or a URL pointing to the type of sample used.
-                           </td>
-                        </tr>
-                        <tr id="software">
-                           <th><a style="color: #0B794B;" href="#">software</a></th>
-                           <td>
-                              <a href="http://schema.org/SoftwareApplication">SoftwareApplication</a>
-                              <br>
-                           </td>
-                           <td>
-                              <strong>Bioschemas</strong>: An application that can complete the request.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/step">step</a></th>
-                           <td>
-                              <a href="http://schema.org/CreativeWork">CreativeWork</a><br />
-                              <a href="http://schema.org/HowToSection">HowToSection</a><br />
-                              <a href="http://schema.org/HowToStep">HowToStep</a><br />
-                              <a href="http://schema.org/Text">Text</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: A single step item (as HowToStep, text, document, video, etc.) or a HowToSection.<br />
-                             <strong>Bioschemas</strong>: Use in LabProtocol to include the step by step process followed in this protocol.
-                           </td>
-                        </tr>
+                  <table class="definition-table">
+                          <thead>
+                    <tr><th>Property</th><th>Expected Type</th><th>Description</th>
+                    </tr>
+                    </thead>
 
-<!-- CREATIVEWORK -->
-                        <tr class="reu_props_sdo">
-                           <td colspan="3">Properties from <a href="http://schema.org/Dataset">CreativeWork</a></td>
-                        </tr>
-                        <tr>
-                           <th><a style="color: #0000CC;" href="http://pending.schema.org/about">about</a></th>
-                           <td>
-                              <a href="http://schema.org/Thing">Thing</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: The subject matter of the content. <em>Inverse property: subjectOf.</em>
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/accessMode">accessMode</a></th>
-                           <td>
-                              <a href="http://schema.org/Text">Text</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: The human sensory perceptual system or cognitive faculty through which a person may process or perceive information. Expected values include: auditory, tactile, textual, visual, colorDependent, chartOnVisual, chemOnVisual, diagramOnVisual, mathOnVisual, musicOnVisual, textOnVisual.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/accessModeSufficient">accessModeSufficient</a></th>
-                           <td>
-                              <a href="http://schema.org/Text">Text</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: A list of single or combined accessModes that are sufficient to understand all the intellectual content of a resource. Expected values include: auditory, tactile, textual, visual.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/accessibilityAPI">accessibilityAPI</a></th>
-                           <td>
-                              <a href="http://schema.org/Text">Text</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: Indicates that the resource is compatible with the referenced accessibility API (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/accessibilityControl">accessibilityControl</a></th>
-                           <td>
-                              <a href="http://schema.org/Text">Text</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: Identifies input methods that are sufficient to fully control the described resource (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/accessibilityFeature">accessibilityFeature</a></th>
-                           <td>
-                              <a href="http://schema.org/Text">Text</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: Content features of the resource, such as accessible media, alternatives and supported enhancements for accessibility (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/accessibilityHazard">accessibilityHazard</a></th>
-                           <td>
-                              <a href="http://schema.org/Text">Text</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: A characteristic of the described resource that is physiologically dangerous to some users. Related to WCAG 2.0 guideline 2.3 (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/accessibilitySummary">accessibilitySummary</a></th>
-                           <td>
-                              <a href="http://schema.org/Text">Text</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: A human-readable summary of specific accessibility features or deficiencies, consistent with the other accessibility metadata but expressing subtleties such as "short descriptions are present but long descriptions will be needed for non-visual users" or "short descriptions are present and no long descriptions are needed."
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/accountablePerson">accountablePerson</a></th>
-                           <td>
-                              <a href="http://schema.org/Person">Person</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: Specifies the Person that is legally accountable for the CreativeWork.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/aggregateRating">aggregateRating</a></th>
-                           <td>
-                              <a href="http://schema.org/AggregateRating">AggregateRating</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: The overall rating, based on a collection of reviews or ratings, of the item.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/alternativeHeadline">alternativeHeadline</a></th>
-                           <td>
-                              <a href="http://schema.org/Text">Text</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: A secondary title of the CreativeWork.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/associatedMedia">associatedMedia</a></th>
-                           <td>
-                              <a href="http://schema.org/MediaObject">MediaObject</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: A media object that encodes this CreativeWork. This property is a synonym for encoding.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/audience">audience</a></th>
-                           <td>
-                              <a href="http://schema.org/Audience">Audience</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: An intended audience, i.e. a group for whom something was created. Supersedes serviceAudience.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/audio">audio</a></th>
-                           <td>
-                              <a href="http://schema.org/AudioObject">AudioObject</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: An embedded audio object.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/author">author</a></th>
-                           <td>
-                              <a href="http://schema.org/Organization">Organization</a><br />
-                              <a href="http://schema.org/Person">Person</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/award">award</a></th>
-                           <td>
-                              <a href="http://schema.org/Text">Text</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: An award won by or for this item. Supersedes awards.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/character">character</a></th>
-                           <td>
-                              <a href="http://schema.org/Person">Person</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: Fictional person connected with a creative work.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/citation">citation</a></th>
-                           <td>
-                              <a href="http://schema.org/CreativeWork">CreativeWork</a><br />
-                              <a href="http://schema.org/Text">Text</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: A citation or reference to another creative work, such as another publication, web page, scholarly article, etc.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/comment">comment</a></th>
-                           <td>
-                              <a href="http://schema.org/Comment">Comment</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: Comments, typically from users.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/commentCount">commentCount</a></th>
-                           <td>
-                              <a href="http://schema.org/Integer">Integer</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: The number of comments this CreativeWork (e.g. Article, Question or Answer) has received. This is most applicable to works published in Web sites with commenting system; additional comments may exist elsewhere.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/contentLocation">contentLocation</a></th>
-                           <td>
-                              <a href="http://schema.org/Place">Place</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: The location depicted or described in the content. For example, the location in a photograph or painting.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/contentRating">contentRating</a></th>
-                           <td>
-                              <a href="http://schema.org/Text">Text</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: Official rating of a piece of content—for example,'MPAA PG-13'.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a style="color: #0000CC;" href="http://pending.schema.org/contentReferenceTime">contentReferenceTime</a></th>
-                           <td>
-                              <a href="http://schema.org/DateTime">DateTime</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: The specific time described by a creative work, for works (e.g. articles, video objects etc.) that emphasise a particular moment within an Event.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/contributor">contributor</a></th>
-                           <td>
-                              <a href="http://schema.org/Organization">Organization</a><br /><a href="http://schema.org/Person">Person</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: A secondary contributor to the CreativeWork or Event.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/copyrightHolder">copyrightHolder</a></th>
-                           <td>
-                              <a href="http://schema.org/Organization">Organization</a><br /><a href="http://schema.org/Person">Person</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: The party holding the legal copyright to the CreativeWork.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/copyrightYear">copyrightYear</a></th>
-                           <td>
-                              <a href="http://schema.org/Number">Number</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: The year during which the claimed copyright for the CreativeWork was first asserted.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/creator">creator</a></th>
-                           <td>
-                              <a href="http://schema.org/Number">Organization</a><br /><a href="http://schema.org/Person">Person</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: The creator/author of this CreativeWork. This is the same as the Author property for CreativeWork.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/dateCreated">dateCreated</a></th>
-                           <td>
-                              <a href="http://schema.org/Date">Date</a><br />
-                              <a href="http://schema.org/DateTime">DateTime</a>
-                           </td>
-                           <td><strong>Schema</strong>: The date on which the CreativeWork was created or the item was added to a DataFeed.</td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/dateModified">dateModified</a></th>
-                           <td>
-                              <a href="http://schema.org/Date">Date</a><br />
-                              <a href="http://schema.org/DateTime">DateTime</a>
-                           </td>
-                           <td><strong>Schema</strong>: The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.</td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/datePublished">datePublished</a></th>
-                           <td>
-                              <a href="http://schema.org/Date">Date</a>
-                           </td>
-                           <td><strong>Schema</strong>: Date of first broadcast/publication.</td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/discussionUrl">discussionUrl</a></th>
-                           <td>
-                              <a href="http://schema.org/URL">URL</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: A link to the page containing the comments of the CreativeWork.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/editor">editor</a></th>
-                           <td>
-                              <a href="http://schema.org/Person">Person</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: Specifies the Person who edited the CreativeWork.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/educationalAlignment">educationalAlignment</a></th>
-                           <td>
-                              <a href="http://schema.org/AlignmentObject">AlignmentObject</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: An alignment to an established educational framework.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/educationalUse">educationalUse</a></th>
-                           <td>
-                              <a href="http://schema.org/Text">Text</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: The purpose of a work in the context of education; for example, 'assignment', 'group work'.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/encoding">encoding</a></th>
-                           <td>
-                              <a href="http://schema.org/MediaObject">MediaObject</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: A media object that encodes this CreativeWork. This property is a synonym for associatedMedia. Supersedes encodings.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/exampleOfWork">exampleOfWork</a></th>
-                           <td>
-                              <a href="http://schema.org/CreativeWork">CreativeWork</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: A creative work that this work is an example/instance/realization/derivation of. <em>Inverse property: <a href="http://schema.org/workExample">workExample</a>.</em>
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/expires">expires</a></th>
-                           <td>
-                              <a href="http://schema.org/Date">Date</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: Date the content expires and is no longer useful or available. For example a <a href="http://schema.org/VideoObject">VideoObject</a> or <a href="http://schema.org/NewsArticle">NewsArticle</a> whose availability or relevance is time-limited, or a <a href="http://schema.org/ClaimReview">ClaimReview</a> fact check whose publisher wants to indicate that it may no longer be relevant (or helpful to highlight) after some date.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/fileFormat">fileFormat</a></th>
-                           <td>
-                              <a href="http://schema.org/Text">Text</a><br /><a href="http://schema.org/URL">URL</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: Media type, typically MIME format (see <a href="http://www.iana.org/assignments/media-types/media-types.xhtml">IANA site</a>) of the content e.g. application/zip of a SoftwareApplication binary. In cases where a CreativeWork has several media type representations, 'encoding' can be used to indicate each MediaObject alongside particular fileFormat information. Unregistered or niche file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia entry.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/funder">funder</a></th>
-                           <td>
-                              <a href="http://schema.org/Organization">Organization</a><br /><a href="http://schema.org/Person">Person</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: A person or organization that supports (sponsors) something through some kind of financial contribution.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/genre">genre</a></th>
-                           <td>
-                              <a href="http://schema.org/Text">Text</a><br /><a href="http://schema.org/URL">URL</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: Genre of the creative work, broadcast channel or group.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/hasPart">hasPart</a></th>
-                           <td>
-                              <a href="http://schema.org/CreativeWork">CreativeWork</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: Indicates a CreativeWork that is (in some sense) a part of this CreativeWork. <em>Inverse property: <a href="http://schema.org/isPartOf">isPartOf</a>.</em><br />
-                             <strong>Bioschemas</strong>: A particular case in Bioschemas is LabProtocol where structural elements are used to described advantages (situations the Protocol has been successfully employed), limitations (situations the Protocol would be unreliable or otherwise unsuccessful), applications (Applications of the protocol list the full diversity of the applications of the method and support if is possible to extend the range of applications of the protocol. e.g. northern blot assays, sequencing, etc.), and outcomes (outcome or expected result by a protocol execution).<br />
-                             For LabProtocol, in the applicationType, please use <a href="http://purl.org/net/SMARTprotocol#AdvantageOfTheProtocol">http://purl.org/net/SMARTprotocol#AdvantageOfTheProtocol</a> for advantages, <a href="http://purl.org/net/SMARTprotocol#LimitationOfTheProtocol">http://purl.org/net/SMARTprotocol#LimitationfTheProtocol</a> for limitations, <a href="http://purl.org/net/SMARTprotocol#ApplicationOfTheProtocol">http://purl.org/net/SMARTprotocol#ApplicationOfTheProtocol</a> for applicability, and <a href="http://purl.org/net/SMARTprotocol#OutcomeOfTheProtocol">http://purl.org/net/SMARTprotocol#OutcomeOfTheProtocol</a> for outcomes.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/headline">headline</a></th>
-                           <td>
-                              <a href="http://schema.org/Text">Text</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: Headline of the article.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/inLanguage">inLanguage</a></th>
-                           <td>
-                              <a href="http://schema.org/Language">Language</a><br /><a href="http://schema.org/Text">Text</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: The language of the content or performance or used in an action. Please use one of the language codes from the <a href="http://tools.ietf.org/html/bcp47">IETF BCP 47 standard</a>. See also <a href="http://schema.org/availableLanguage">availableLanguage</a>. Supersedes language.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/interactionStatistic">interactionStatistic</a></th>
-                           <td>
-                              <a href="http://schema.org/InteractionCounter">InteractionCounter</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used. Supersedes interactionCount.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/interactivityType">interactivityType</a></th>
-                           <td>
-                              <a href="http://schema.org/Text">Text</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: The predominant mode of learning supported by the learning resource. Acceptable values are 'active', 'expositive', or 'mixed'.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/isAccessibleForFree">isAccessibleForFree</a></th>
-                           <td>
-                              <a href="http://schema.org/Boolean">Boolean</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: A flag to signal that the item, event, or place is accessible for free. Supersedes free.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a style="color: #0B794B;" href="http://schema.org/isBasedOn">isBasedOn</a></th>
-                           <td>
-                              <a href="http://schema.org/CreativeWork">CreativeWork</a><br />
-                              <a href="http://schema.org/URL">URL</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: A resource that was used in the creation of this resource. This term can be repeated for multiple sources. For example, http://example.com/great-multiplication-intro.html.<br />
-                             <u><strong>Note</strong></u>: Bioschemas have removed <a href="http://schema.org/Product">Product</a> from the Expected Types.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/isFamilyFriendly">isFamilyFriendly</a></th>
-                           <td>
-                              <a href="http://schema.org/Boolean">Boolean</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: Indicates whether this content is family friendly.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/isPartOf">isPartOf</a></th>
-                           <td>
-                              <a href="http://schema.org/CreativeWork">CreativeWork</a>
-                              <br>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: Indicates a CreativeWork that this CreativeWork is (in some sense) part of.
-                           </td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/keywords">keywords</a></th>
-                           <td>
-                              <a href="http://schema.org/Text">Text</a>
-                           </td>
-                           <td><strong>Schema</strong>: Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.</td>
-                         </tr>
-                         <tr>
-                            <th><a href="http://schema.org/learningResourceType">learningResourceType</a></th>
-                            <td>
-                               <a href="http://schema.org/Text">Text</a>
-                            </td>
-                            <td>
-                              <strong>Schema</strong>: The predominant type or kind characterizing the learning resource. For example, 'presentation', 'handout'.
-                            </td>
-                         </tr>
-                         <tr>
-                            <th><a href="http://schema.org/license">license</a></th>
-                            <td>
-                               <a href="http://schema.org/CreativeWork">CreativeWork</a><br /><a href="http://schema.org/URL">URL</a>
-                            </td>
-                            <td>
-                              <strong>Schema</strong>: A license document that applies to this content, typically indicated by URL.
-                            </td>
-                         </tr>
-                         <tr>
-                            <th><a href="http://schema.org/locationCreated">locationCreated</a></th>
-                            <td>
-                               <a href="http://schema.org/Place">Place</a>
-                            </td>
-                            <td>
-                              <strong>Schema</strong>: The location where the CreativeWork was created, which may not be the same as the location depicted in the CreativeWork.
-                            </td>
-                         </tr>
-                         <tr>
-                            <th><a href="http://schema.org/mainEntity">mainEntity</a></th>
-                            <td>
-                              <a href="http://schema.org/Thing">Thing</a>
-                            </td>
-                            <td>
-                              <strong>Schema</strong>: Indicates the primary entity described in some page or other CreativeWork. <em>Inverse-property: <a href="http:schema.org/mainEntityOfPage">mainEntityOfPage</a>.</em>
-                            </td>
-                          </tr>
-                          <tr>
-                             <th><a href="http://schema.org/material">material</a></th>
-                             <td>
-                                <a href="http://schema.org/Product">Product</a><br /><a href="http://schema.org/Text">Text</a><br /><a href="http://schema.org/URL">URL</a>
-                             </td>
-                             <td>
-                               <strong>Schema</strong>: A material that something is made from, e.g. leather, wool, cotton, paper.
-                             </td>
-                          </tr>
-                          <tr>
-                             <th><a href="http://schema.org/mentions">mentions</a></th>
-                             <td>
-                                <a href="http://schema.org/Thing">Thing</a>
-                             </td>
-                             <td>
-                               <strong>Schema</strong>: Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept.
-                             </td>
-                          </tr>
-                          <tr>
-                             <th><a href="http://schema.org/offers">offers</a></th>
-                             <td>
-                                <a href="http://schema.org/Offer">Offer</a>
-                             </td>
-                             <td>
-                               <strong>Schema</strong>: An offer to provide this item—for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.
-                             </td>
-                          </tr>
-                          <tr>
-                             <th><a href="http://schema.org/position">position</a></th>
-                             <td>
-                                <a href="http://schema.org/Integer">Integer</a><br /><a href="http://schema.org/Text">Text</a>
-                             </td>
-                             <td>
-                               <strong>Schema</strong>: The position of an item in a series or sequence of items.
-                             </td>
-                          </tr>
-                          <tr>
-                             <th><a href="http://schema.org/producer">producer</a></th>
-                             <td>
-                                <a href="http://schema.org/Organization">Organization</a><br /><a href="http://schema.org/Person">Person</a>
-                             </td>
-                             <td>
-                               <strong>Schema</strong>: The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.).
-                             </td>
-                          </tr>
-                          <tr>
-                             <th><a href="http://schema.org/provider">provider</a></th>
-                             <td>
-                                <a href="http://schema.org/Organization">Organization</a><br /><a href="http://schema.org/Person">Person</a>
-                             </td>
-                             <td>
-                               <strong>Schema</strong>: The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller. Supersedes carrier.
-                             </td>
-                          </tr>
-                          <tr>
-                             <th><a href="http://schema.org/publication">publication</a></th>
-                             <td>
-                                <a href="http://schema.org/PublicationEvent">PublicationEvent</a>
-                             </td>
-                             <td>
-                               <strong>Schema</strong>: A publication event associated with the item.
-                             </td>
-                          </tr>
-                          <tr>
-                             <th><a href="http://schema.org/publication">publisher</a></th>
-                             <td>
-                                <a href="http://schema.org/Organization">Organization</a><br /><a href="http://schema.org/Person">Person</a>
-                             </td>
-                             <td>
-                               <strong>Schema</strong>: The publisher of the creative work.
-                             </td>
-                          </tr>
-                          <tr>
-                             <th><a class="pending" href="http://schema.org/publisherImprint">publisherImprint</a></th>
-                             <td>
-                                <a href="http://schema.org/Organization">Organization</a>
-                             </td>
-                             <td>
-                               <strong>Schema</strong>: The publishing division which published the comic.
-                             </td>
-                          </tr>
-                          <tr>
-                             <th><a href="http://schema.org/publishingPrinciples">publishingPrinciples</a></th>
-                             <td>
-                                <a href="http://schema.org/CreativeWork">CreativeWork</a><br /><a href="http://schema.org/URL">URL</a>
-                             </td>
-                             <td>
-                               <strong>Schema</strong>: The publishingPrinciples property indicates (typically via URL) a document describing the editorial principles of an <a href="http://schema.org/Organization">Organization</a> (or individual e.g. a <a href="http://schema.org/Person">Person</a> writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a <a href="http://schema.org/CreativeWork">CreativeWork</a> (e.g. <a href="http://schema.org/NewsArticle">NewsArticle</a>) the principles are those of the party primarily responsible for the creation of the <a href="http://schema.org/CreativeWork">CreativeWork</a>. <br />While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a <a href="http://schema.org/funder">funder</a>) can be expressed using schema.org terminology.
-                             </td>
-                          </tr>
-                          <tr>
-                             <th><a href="http://schema.org/recordedAt">recordedAt</a></th>
-                             <td>
-                                <a href="http://schema.org/Event">Event</a>
-                             </td>
-                             <td>
-                               <strong>Schema</strong>: The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event. <em>Inverse property: <a href="http://schema.org/recordedIn">recordedIn</a>.</em>
-                             </td>
-                          </tr>
-                          <tr>
-                             <th><a href="http://schema.org/releasedEvent">releasedEvent</a></th>
-                             <td>
-                                <a href="http://schema.org/PublicationEvent">PublicationEvent</a>
-                             </td>
-                             <td>
-                               <strong>Schema</strong>: The place and time the release was issued, expressed as a PublicationEvent.
-                             </td>
-                          </tr>
-                          <tr>
-                             <th><a href="http://schema.org/review">review</a></th>
-                             <td>
-                                <a href="http://schema.org/Review">Review</a>
-                             </td>
-                             <td>
-                               <strong>Schema</strong>: A review of the item. Supersedes reviews.
-                             </td>
-                          </tr>
-                          <tr>
-                             <th><a href="http://schema.org/schemaVersion">schemaVersion</a></th>
-                             <td>
-                                <a href="http://schema.org/Text">Text</a><br /><a href="http://schema.org/URL">URL</a>
-                             </td>
-                             <td>
-                               <strong>Schema</strong>: Indicates (by URL or string) a particular version of a schema used in some CreativeWork. For example, a document could declare a schemaVersion using an URL such as http://schema.org/version/2.0/ if precise indication of schema version was required by some application.
-                             </td>
-                          </tr>
-                          <tr>
-                             <th><a href="http://schema.org/sourceOrganization">sourceOrganization</a></th>
-                             <td>
-                                <a href="http://schema.org/Organization">Organization</a>
-                             </td>
-                             <td>
-                               <strong>Schema</strong>: The Organization on whose behalf the creator was working.
-                             </td>
-                          </tr>
-                          <tr>
-                             <th><a href="http://schema.org/spatialCoverage">spatialCoverage</a></th>
-                             <td>
-                                <a href="http://schema.org/Place">Place</a>
-                             </td>
-                             <td>
-                               <strong>Schema</strong>: The spatialCoverage of a CreativeWork indicates the place(s) which are the focus of the content. It is a subproperty of contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York. Supersedes spatial.
-                             </td>
-                          </tr>
-                          <tr>
-                             <th><a href="http://schema.org/sponsor">sponsor</a></th>
-                             <td>
-                                <a href="http://schema.org/Organization">Organization</a><br /><a href="http://schema.org/Person">Person</a>
-                             </td>
-                             <td>
-                               <strong>Schema</strong>: A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
-                             </td>
-                          </tr>
-                          <tr>
-                             <th><a href="http://schema.org/temporalCoverage">temporalCoverage</a></th>
-                             <td>
-                                <a href="http://schema.org/DateTime">DateTime</a><br /><a href="http://schema.org/Text">Text</a><br /><a href="http://schema.org/URL">URL</a>
-                             </td>
-                             <td>
-                               <strong>Schema</strong>: The temporalCoverage of a CreativeWork indicates the period that the content applies to, i.e. that it describes, either as a DateTime or as a textual string indicating a time period in <a href="https://en.wikipedia.org/wiki/ISO_8601#Time_intervals">ISO 8601 time interval format</a>. In the case of a Dataset it will typically indicate the relevant time period in a precise notation (e.g. for a 2011 census dataset, the year 2011 would be written "2011/2012"). Other forms of content e.g. ScholarlyArticle, Book, TVSeries or TVEpisode may indicate their temporalCoverage in broader terms - textually or via well-known URL. Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945". Supersedes datasetTimeInterval, temporal.
-                             </td>
-                          </tr>
-                          <tr>
-                             <th><a href="http://schema.org/text">text</a></th>
-                             <td>
-                                <a href="http://schema.org/Text">Text</a>
-                             </td>
-                             <td>
-                               <strong>Schema</strong>: The textual content of this CreativeWork.
-                             </td>
-                          </tr>
-                          <tr>
-                             <th><a href="http://schema.org/thumbnailUrl">thumbnailUrl</a></th>
-                             <td>
-                                <a href="http://schema.org/URL">URL</a>
-                             </td>
-                             <td>
-                               <strong>Schema</strong>: A thumbnail image relevant to the Thing.
-                             </td>
-                          </tr>
-                          <tr>
-                             <th><a href="http://schema.org/timeRequired">timeRequired</a></th>
-                             <td>
-                                <a href="http://schema.org/Duration">Duration</a>
-                             </td>
-                             <td>
-                               <strong>Schema</strong>: Approximate or typical time it takes to work with or through this learning resource for the typical intended target audience, e.g. 'P30M', 'P1H25M'.
-                             </td>
-                          </tr>
-                          <tr>
-                             <th><a style="color: #0000CC;"  href="http://pending.schema.org/translationOfWork">translationOfWork</a></th>
-                             <td>
-                                <a href="http://schema.org/CreativeWork">CreativeWork</a>
-                             </td>
-                             <td>
-                               <strong>Schema</strong>: The work that this work has been translated from. e.g. 物种起源 is a translationOf “On the Origin of Species”. <em>Inverse property: <a style="color: #0000CC;"  href="http://pending.schema.org/workTranslation">workTranslation</a>.</em>
-                             </td>
-                          </tr>
-                          <tr>
-                             <th><a href="http://schema.org/translator">translator</a></th>
-                             <td>
-                                <a href="http://schema.org/Organization">Organization</a><br /><a href="http://schema.org/Person">Person</a>
-                             </td>
-                             <td>
-                               <strong>Schema</strong>: Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.
-                             </td>
-                          </tr>
-                          <tr>
-                             <th><a href="http://schema.org/typicalAgeRange">typicalAgeRange</a></th>
-                             <td>
-                                <a href="http://schema.org/Text">Text</a>
-                             </td>
-                             <td>
-                               <strong>Schema</strong>: The typical expected age range, e.g. '7-9', '11-'.
-                             </td>
-                          </tr>
-                          <tr>
-                             <th><a href="http://schema.org/version">version</a></th>
-                             <td>
-                                <a href="http://schema.org/Number">Number</a><br /><a href="http://schema.org/Text">Text</a>
-                             </td>
-                             <td>
-                               <strong>Schema</strong>: The version of the CreativeWork embodied by a specified resource.
-                             </td>
-                          </tr>
-                          <tr>
-                             <th><a href="http://schema.org/video">video</a></th>
-                             <td>
-                                <a href="http://schema.org/VideoObject">VideoObject</a>
-                             </td>
-                             <td>
-                               <strong>Schema</strong>: An embedded video object.
-                             </td>
-                          </tr>
-                          <tr>
-                             <th><a href="http://schema.org/workExample">workExample</a></th>
-                             <td>
-                                <a href="http://schema.org/CreativeWork">CreativeWork</a>
-                             </td>
-                             <td>
-                               <strong>Schema</strong>: Example/instance/realization/derivation of the concept of this creative work. eg. The paperback edition, first edition, or eBook. <em>Inverse property: <a href="http://schema.org/exampleOfWork">exampleOfWork</a>.</em>
-                             </td>
-                          </tr>
-                          <tr>
-                             <th><a style="color: #0000CC;"  href="http://pending.schema.org/workTranslation">workTranslation</a></th>
-                             <td>
-                                <a href="http://schema.org/CreativeWork">CreativeWork</a>
-                             </td>
-                             <td>
-                               <strong>Schema</strong>: A work that is a translation of the content of this work. e.g. 西遊記 has an English workTranslation “Journey to the West”,a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese translation Tây du ký bình khảo.
-                               <em>Inverse property: <a style="color: #0000CC;"  href="http://pending.schema.org/translationOfWork">translationOfWork</a>.</em>
-                             </td>
-                          </tr>
-   <!-- Thing -->
-                        <tr class="reu_props_sdo">
-                           <td colspan="3">Properties from <a href="http://schema.org/Thing">Thing</a></td>
-                        </tr>
-                        <tr>
-                           <th><a href="http://schema.org/additionalType">additionalType</a></th>
-                           <td>
-                              <a href="http://schema.org/URL">URL</a>
-                           </td>
-                           <td>
-                             <strong>Schema</strong>: An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between
-                             something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax - the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker
-                             understanding of extra types, in particular those defined externally.<br />
-                             <strong>Bioschemas</strong>: Optional for LabProtocol as it has its own type in schema.org. If used, the recommended URL is experimental protocol as defined by SMART Protocols (<a href="http://purl.org/net/SMARTprotocol#ExperimentalProtocol">SP:ExperimentalProtocol</a>).
-                           </td>
-                        </tr>
-                        <tr>
-                          <th><a href="http://schema.org/alternateName">alternateName</a></th>
-                          <td>
-                            <a href="http://schema.org/Text">Text</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: An alias for the item.
-                          </td>
-                        </tr>
-                        <tr>
-                          <th><a href="http://schema.org/description">description</a></th>
-                          <td>
-                            <a href="http://schema.org/Text">Text</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: A descripton of the item.<br />
-                          </td>
-                        </tr>
-                        <tr>
-                          <th><a href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></th>
-                          <td>
-                            <a href="http://schema.org/Text">Text</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: A sub property of description. A short description of the item used to disambiguate from other, similar items.
-                            Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.
-                          </td>
-                        </tr>
-                        <tr>
-                          <th><a href="http://schema.org/identifier">identifier</a></th>
-                          <td>
-                            <a href="http://schema.org/PropertyValue">PropertyValue</a><br /><a href="http://schema.org/Text">Text</a><br /><a href="http://schema.org/URL">URL</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: The identifier property represents any kind of identifier for any kind of <a href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc.
-                            Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links.
-                            See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.
-                          </td>
-                        </tr>
-                        <tr>
-                          <th><a href="http://schema.org/image">image</a></th>
-                          <td>
-                            <a href="http://schema.org/ImageObject">ImageObject</a><br /><a href="http://schema.org/URL">URL</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: An image of the item. This can be a <a href="http://schema.org/URL">URL</a> or a fully described <a href="http://schema.org/ImageObject">ImageObject</a>.
-                          </td>
-                        </tr>
-                        <tr>
-                          <th><a href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></th>
-                          <td>
-                            <a href="http://schema.org/CreativeWork">CreativeWork</a><br /><a href="http://schema.org/URL">URL</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See
-                            <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br />
-                          </td>
-                        </tr>
-                        <tr>
-                          <th><a href="http://schema.org/name">name</a></th>
-                          <td>
-                            <a href="http://schema.org/Text">Text</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: The name of the item.
-                          </td>
-                        </tr>
-                        <tr>
-                          <th><a href="http://schema.org/potentialAction">potentialAction</a></th>
-                          <td>
-                            <a href="http://schema.org/Action">Action</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.
-                          </td>
-                        </tr>
-                        <tr>
-                          <th><a href="http://schema.org/sameAs">sameAs</a></th>
-                          <td>
-                            <a href="http://schema.org/URL">URL</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.
-                          </td>
-                        </tr>
-                        <tr>
-                          <th><a style="color: #0000CC;" href="http://pending.schema.org/subjectOf">subjectOf</a></th>
-                          <td>
-                            <a href="http://schema.org/CreativeWork">CreativeWork</a><br /><a href="http://schema.org/Event">Event</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: A CreativeWork or Event about this Thing. <em>Inverse property: <a href="http://schema.org/about">about</a>.</em>
-                          </td>
-                        </tr>
-                        <tr>
-                          <th><a href="http://schema.org/url">url</a></th>
-                          <td>
-                            <a href="http://schema.org/URL">URL</a>
-                          </td>
-                          <td>
-                            <strong>Schema</strong>: URL of the item.
-                          </td>
-                        </tr>
-                     </tbody>
-                  </table>
+                  <tr class="supertype">
+                       <th class="supertype-name" colspan="3">Properties from <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/LabProtocol">LabProtocol</a></th>
+
+                  </tr>
+
+                  <tbody class="supertype">
+                    <tr typeof="rdfs:Property" resource="http://schema.org/executionTime">
+
+                        <th class="prop-nam" scope="row">
+
+                  <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#executionTime">executiontime</a></code>
+                      </th>
+                   <td class="prop-ect">
+                  <link  property="rangeIncludes" href="http://schema.org/Duration" /><a   href="http://schema.org/Duration">Duration</a>&nbsp;<link property="domainIncludes" href="http://schema.org/LabProtocol"></td><td class="prop-desc" property="rdfs:comment">The time it takes to actually carry out the protocol in <a href="http://en.wikipedia.org/wiki/ISO_8601">ISO 8601 date format</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/labEquipment">
+
+                        <th class="prop-nam" scope="row">
+
+                  <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#labEquipment">labEquipment</a></code>
+                      </th>
+                   <td class="prop-ect">
+                  <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/LabProtocol"></td><td class="prop-desc" property="rdfs:comment">For LabProtocols it would be a laboratory equipment use by a person to follow one or more steps described in this LabProtocol.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/protocolAdvantage">
+
+                        <th class="prop-nam" scope="row">
+
+                  <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#protocolAdvantage">protocolAdvantage</a></code>
+                      </th>
+                   <td class="prop-ect">
+                  <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/LabProtocol"></td><td class="prop-desc" property="rdfs:comment">Situations where the Protocol has been successfully employed.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/protocolApplication">
+
+                        <th class="prop-nam" scope="row">
+
+                  <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#protocolApplication">protocolLimitation</a></code>
+                      </th>
+                   <td class="prop-ect">
+                  <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/LabProtocol"></td><td class="prop-desc" property="rdfs:comment">Applications of the protocol list the full diversity of the applications of the method and support if is possible to extend the range of applications of the protocol. e.g. northern blot assays, sequencing, etc.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/protocolLimitation">
+
+                        <th class="prop-nam" scope="row">
+
+                  <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#protocolLimitation">protocolLimitation</a></code>
+                      </th>
+                   <td class="prop-ect">
+                  <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/LabProtocol"></td><td class="prop-desc" property="rdfs:comment">Situations where the Protocol would be unreliable or otherwise unsuccessful.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/protocolOutcome">
+
+                        <th class="prop-nam" scope="row">
+
+                  <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#protocolOutcome">protocolLimitation</a></code>
+                      </th>
+                   <td class="prop-ect">
+                  <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/LabProtocol"></td><td class="prop-desc" property="rdfs:comment">Outcome or expected result by a protocol execution.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/purpose">
+
+                        <th class="prop-nam" scope="row">
+
+                  <code property="rdfs:label"><a   href="http://schema.org/purpose">purpose</a></code>
+                      </th>
+                   <td class="prop-ect">
+                  <link  property="rangeIncludes" href="http://schema.org/MedicalDevicePurpose" /><a   href="http://schema.org/MedicalDevicePurpose">MedicalDevicePurpose</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Thing" /><a   href="http://schema.org/Thing">Thing</a>&nbsp;<link property="domainIncludes" href="http://schema.org/AllocateAction"><link property="domainIncludes" href="http://schema.org/LabProtocol"><link property="domainIncludes" href="http://schema.org/MedicalDevice"><link property="domainIncludes" href="http://schema.org/PayAction"></td><td class="prop-desc" property="rdfs:comment">A goal towards an action is taken. Can be concrete or abstract.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/reagent">
+
+                        <th class="prop-nam" scope="row">
+
+                  <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#reagent">reagent</a></code>
+                      </th>
+                   <td class="prop-ect">
+                  <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/LabProtocol"></td><td class="prop-desc" property="rdfs:comment">Reagent used in the protocol. It can be a record in a Dataset describing the reagent or a BioChemEntity corresponding to the reagent or a URL pointing to the type of reagent used. ChEBI and PubChem entities can be used whenever available. Commercial names are also acceptable (URL if possible).</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sampleUsed">
+
+                        <th class="prop-nam" scope="row">
+
+                  <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#sampleUsed">sampleUsed</a></code>
+                      </th>
+                   <td class="prop-ect">
+                  <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/BioSample" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioSample">BioSample</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/LabProtocol"></td><td class="prop-desc" property="rdfs:comment">Sample used in the protocol. It could be a record in a Dataset describing the sample or a physical object corresponding to the sample or a URL pointing to the type of sample used.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/software">
+
+                        <th class="prop-nam" scope="row">
+
+                  <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#software">software</a></code>
+                      </th>
+                   <td class="prop-ect">
+                  <link  property="rangeIncludes" href="http://schema.org/SoftwareApplication" /><a   href="http://schema.org/SoftwareApplication">SoftwareApplication</a>&nbsp;<link property="domainIncludes" href="http://schema.org/LabProtocol"></td><td class="prop-desc" property="rdfs:comment">Software or tool used as part of the lab protocol to complete a part of it.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/step">
+
+                        <th class="prop-nam" scope="row">
+
+                  <code property="rdfs:label"><a   href="http://schema.org/step">step</a></code>
+                      </th>
+                   <td class="prop-ect">
+                  <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/HowToSection" /><a   href="http://schema.org/HowToSection">HowToSection</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/HowToStep" /><a   href="http://schema.org/HowToStep">HowToStep</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/HowTo"><link property="domainIncludes" href="http://schema.org/LabProtocol"></td><td class="prop-desc" property="rdfs:comment">A single step item (as HowToStep, text, document, video, etc.) or a HowToSection. Supersedes <a   href="http://schema.org/steps">steps</a>.</td></tr><tr class="supertype">
+                    <th class="supertype-name" colspan="3">Properties from <a   href="http://schema.org/CreativeWork">CreativeWork</a></th>
+
+               </tr>
+
+               <tbody class="supertype">
+                 <tr typeof="rdfs:Property" resource="http://schema.org/about">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/about">about</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Thing" /><a   href="http://schema.org/Thing">Thing</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CommunicateAction"><link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"></td><td class="prop-desc" property="rdfs:comment">The subject matter of the content.<br/> Inverse property: <a   href="http://schema.org/subjectOf">subjectOf</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accessMode">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/accessMode">accessMode</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The human sensory perceptual system or cognitive faculty through which a person may process or perceive information. Expected values include: auditory, tactile, textual, visual, colorDependent, chartOnVisual, chemOnVisual, diagramOnVisual, mathOnVisual, musicOnVisual, textOnVisual.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accessModeSufficient">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/accessModeSufficient">accessModeSufficient</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A list of single or combined accessModes that are sufficient to understand all the intellectual content of a resource. Expected values include:  auditory, tactile, textual, visual.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accessibilityAPI">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/accessibilityAPI">accessibilityAPI</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates that the resource is compatible with the referenced accessibility API (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accessibilityControl">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/accessibilityControl">accessibilityControl</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Identifies input methods that are sufficient to fully control the described resource (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accessibilityFeature">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/accessibilityFeature">accessibilityFeature</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Content features of the resource, such as accessible media, alternatives and supported enhancements for accessibility (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accessibilityHazard">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/accessibilityHazard">accessibilityHazard</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A characteristic of the described resource that is physiologically dangerous to some users. Related to WCAG 2.0 guideline 2.3 (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accessibilitySummary">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/accessibilitySummary">accessibilitySummary</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A human-readable summary of specific accessibility features or deficiencies, consistent with the other accessibility metadata but expressing subtleties such as "short descriptions are present but long descriptions will be needed for non-visual users" or "short descriptions are present and no long descriptions are needed."</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accountablePerson">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/accountablePerson">accountablePerson</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Specifies the Person that is legally accountable for the CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/aggregateRating">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/aggregateRating">aggregateRating</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/AggregateRating" /><a   href="http://schema.org/AggregateRating">AggregateRating</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Brand"><link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/Offer"><link property="domainIncludes" href="http://schema.org/Organization"><link property="domainIncludes" href="http://schema.org/Place"><link property="domainIncludes" href="http://schema.org/Product"><link property="domainIncludes" href="http://schema.org/Service"></td><td class="prop-desc" property="rdfs:comment">The overall rating, based on a collection of reviews or ratings, of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/alternativeHeadline">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/alternativeHeadline">alternativeHeadline</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A secondary title of the CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/associatedMedia">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/associatedMedia">associatedMedia</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/MediaObject" /><a   href="http://schema.org/MediaObject">MediaObject</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A media object that encodes this CreativeWork. This property is a synonym for encoding.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/audience">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/audience">audience</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Audience" /><a   href="http://schema.org/Audience">Audience</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/LodgingBusiness"><link property="domainIncludes" href="http://schema.org/PlayAction"><link property="domainIncludes" href="http://schema.org/Product"><link property="domainIncludes" href="http://schema.org/Service"></td><td class="prop-desc" property="rdfs:comment">An intended audience, i.e. a group for whom something was created. Supersedes <a   href="http://schema.org/serviceAudience">serviceAudience</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/audio">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/audio">audio</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/AudioObject" /><a   href="http://schema.org/AudioObject">AudioObject</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Clip" /><a   href="http://schema.org/Clip">Clip</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">An embedded audio object.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/author">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/author">author</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Rating"></td><td class="prop-desc" property="rdfs:comment">The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/award">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/award">award</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Organization"><link property="domainIncludes" href="http://schema.org/Person"><link property="domainIncludes" href="http://schema.org/Product"><link property="domainIncludes" href="http://schema.org/Service"></td><td class="prop-desc" property="rdfs:comment">An award won by or for this item. Supersedes <a   href="http://schema.org/awards">awards</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/character">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/character">character</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Fictional person connected with a creative work.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/citation">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/citation">citation</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A citation or reference to another creative work, such as another publication, web page, scholarly article, etc.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/comment">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/comment">comment</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Comment" /><a   href="http://schema.org/Comment">Comment</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/RsvpAction"></td><td class="prop-desc" property="rdfs:comment">Comments, typically from users.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/commentCount">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/commentCount">commentCount</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Integer" /><a   href="http://schema.org/Integer">Integer</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The number of comments this CreativeWork (e.g. Article, Question or Answer) has received. This is most applicable to works published in Web sites with commenting system; additional comments may exist elsewhere.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/contentLocation">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/contentLocation">contentLocation</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Place" /><a   href="http://schema.org/Place">Place</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The location depicted or described in the content. For example, the location in a photograph or painting.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/contentRating">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/contentRating">contentRating</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Rating" /><a   href="http://schema.org/Rating">Rating</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Official rating of a piece of content&#x2014;for example,'MPAA PG-13'.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/contentReferenceTime">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/contentReferenceTime">contentReferenceTime</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/DateTime" /><a   href="http://schema.org/DateTime">DateTime</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The specific time described by a creative work, for works (e.g. articles, video objects etc.) that emphasise a particular moment within an Event.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/contributor">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/contributor">contributor</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"></td><td class="prop-desc" property="rdfs:comment">A secondary contributor to the CreativeWork or Event.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/copyrightHolder">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/copyrightHolder">copyrightHolder</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The party holding the legal copyright to the CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/copyrightYear">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/copyrightYear">copyrightYear</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Number" /><a   href="http://schema.org/Number">Number</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The year during which the claimed copyright for the CreativeWork was first asserted.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/correction">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/correction">correction</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CorrectionComment" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/CorrectionComment">CorrectionComment</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates a correction to a <a class="localLink" href="http://schema.org/CreativeWork">CreativeWork</a>, either via a <a class="localLink" href="http://schema.org/CorrectionComment">CorrectionComment</a>, textually or in another document.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/creator">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/creator">creator</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/UserComments"></td><td class="prop-desc" property="rdfs:comment">The creator/author of this CreativeWork. This is the same as the Author property for CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/dateCreated">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/dateCreated">dateCreated</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Date" /><a   href="http://schema.org/Date">Date</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/DateTime" /><a   href="http://schema.org/DateTime">DateTime</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioSample"><link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/DataFeedItem"></td><td class="prop-desc" property="rdfs:comment">The date on which the CreativeWork was created or the item was added to a DataFeed.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/dateModified">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/dateModified">dateModified</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Date" /><a   href="http://schema.org/Date">Date</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/DateTime" /><a   href="http://schema.org/DateTime">DateTime</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/DataFeedItem"></td><td class="prop-desc" property="rdfs:comment">The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/datePublished">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/datePublished">datePublished</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Date" /><a   href="http://schema.org/Date">Date</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Date of first broadcast/publication.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/discussionUrl">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/discussionUrl">discussionUrl</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A link to the page containing the comments of the CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/editor">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/editor">editor</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Specifies the Person who edited the CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/educationalAlignment">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/educationalAlignment">educationalAlignment</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/AlignmentObject" /><a   href="http://schema.org/AlignmentObject">AlignmentObject</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">An alignment to an established educational framework.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/educationalUse">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/educationalUse">educationalUse</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The purpose of a work in the context of education; for example, 'assignment', 'group work'.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/encoding">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/encoding">encoding</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/MediaObject" /><a   href="http://schema.org/MediaObject">MediaObject</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A media object that encodes this CreativeWork. This property is a synonym for associatedMedia. Supersedes <a   href="http://schema.org/encodings">encodings</a>.<br/> Inverse property: <a   href="http://schema.org/encodesCreativeWork">encodesCreativeWork</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/encodingFormat">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/encodingFormat">encodingFormat</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/MediaObject"></td><td class="prop-desc" property="rdfs:comment">Media type typically expressed using a MIME format (see <a href="http://www.iana.org/assignments/media-types/media-types.xhtml">IANA site</a> and <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MDN reference</a>) e.g. application/zip for a SoftwareApplication binary, audio/mpeg for .mp3 etc.).<br/><br/>
+
+               In cases where a <a class="localLink" href="http://schema.org/CreativeWork">CreativeWork</a> has several media type representations, <a class="localLink" href="http://schema.org/encoding">encoding</a> can be used to indicate each <a class="localLink" href="http://schema.org/MediaObject">MediaObject</a> alongside particular <a class="localLink" href="http://schema.org/encodingFormat">encodingFormat</a> information.<br/><br/>
+
+               Unregistered or niche encoding and file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia/Wikidata entry. Supersedes <a   href="http://schema.org/fileFormat">fileFormat</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/exampleOfWork">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/exampleOfWork">exampleOfWork</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A creative work that this work is an example/instance/realization/derivation of.<br/> Inverse property: <a   href="http://schema.org/workExample">workExample</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/expires">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/expires">expires</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Date" /><a   href="http://schema.org/Date">Date</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Date the content expires and is no longer useful or available. For example a <a class="localLink" href="http://schema.org/VideoObject">VideoObject</a> or <a class="localLink" href="http://schema.org/NewsArticle">NewsArticle</a> whose availability or relevance is time-limited, or a <a class="localLink" href="http://schema.org/ClaimReview">ClaimReview</a> fact check whose publisher wants to indicate that it may no longer be relevant (or helpful to highlight) after some date.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/funder">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/funder">funder</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/MonetaryGrant"><link property="domainIncludes" href="http://schema.org/Organization"><link property="domainIncludes" href="http://schema.org/Person"></td><td class="prop-desc" property="rdfs:comment">A person or organization that supports (sponsors) something through some kind of financial contribution.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/genre">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/genre">genre</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BroadcastChannel"><link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/MusicGroup"></td><td class="prop-desc" property="rdfs:comment">Genre of the creative work, broadcast channel or group.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasPart">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/hasPart">hasPart</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates an item or CreativeWork that is part of this item, or CreativeWork (in some sense).<br/> Inverse property: <a   href="http://schema.org/isPartOf">isPartOf</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/headline">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/headline">headline</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Headline of the article.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/inLanguage">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/inLanguage">inLanguage</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Language" /><a   href="http://schema.org/Language">Language</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CommunicateAction"><link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/LinkRole"><link property="domainIncludes" href="http://schema.org/WriteAction"></td><td class="prop-desc" property="rdfs:comment">The language of the content or performance or used in an action. Please use one of the language codes from the <a href="http://tools.ietf.org/html/bcp47">IETF BCP 47 standard</a>. See also <a class="localLink" href="http://schema.org/availableLanguage">availableLanguage</a>. Supersedes <a   href="http://schema.org/language">language</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/interactionStatistic">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/interactionStatistic">interactionStatistic</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/InteractionCounter" /><a   href="http://schema.org/InteractionCounter">InteractionCounter</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used. Supersedes <a   href="http://schema.org/interactionCount">interactionCount</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/interactivityType">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/interactivityType">interactivityType</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The predominant mode of learning supported by the learning resource. Acceptable values are 'active', 'expositive', or 'mixed'.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isAccessibleForFree">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/isAccessibleForFree">isAccessibleForFree</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Boolean" /><a   href="http://schema.org/Boolean">Boolean</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/Place"><link property="domainIncludes" href="http://schema.org/PublicationEvent"></td><td class="prop-desc" property="rdfs:comment">A flag to signal that the item, event, or place is accessible for free. Supersedes <a   href="http://schema.org/free">free</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isBasedOn">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/isBasedOn">isBasedOn</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Product" /><a   href="http://schema.org/Product">Product</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A resource from which this work is derived or from which it is a modification or adaption. Supersedes <a   href="http://schema.org/isBasedOnUrl">isBasedOnUrl</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isBasisFor">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/isBasisFor">isBasisFor</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A resource that was (somehow) created using this resource as a basis for.<br/> Inverse property: <a   href="http://schema.org/isBasedOn">isBasedOn</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isFamilyFriendly">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/isFamilyFriendly">isFamilyFriendly</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Boolean" /><a   href="http://schema.org/Boolean">Boolean</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates whether this content is family friendly.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isPartOf">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/isPartOf">isPartOf</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates an item or CreativeWork that this item, or CreativeWork (in some sense), is part of.<br/> Inverse property: <a   href="http://schema.org/hasPart">hasPart</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/keywords">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/keywords">keywords</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/learningResourceType">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/learningResourceType">learningResourceType</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The predominant type or kind characterizing the learning resource. For example, 'presentation', 'handout'.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/license">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/license">license</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A license document that applies to this content, typically indicated by URL.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/locationCreated">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/locationCreated">locationCreated</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Place" /><a   href="http://schema.org/Place">Place</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioSample"><link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The location where the CreativeWork was created, which may not be the same as the location depicted in the CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/mainEntity">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/mainEntity">mainEntity</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Thing" /><a   href="http://schema.org/Thing">Thing</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates the primary entity described in some page or other CreativeWork.<br/> Inverse property: <a   href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/material">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/material">material</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Product" /><a   href="http://schema.org/Product">Product</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Product"></td><td class="prop-desc" property="rdfs:comment">A material that something is made from, e.g. leather, wool, cotton, paper.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/materialExtent">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/materialExtent">materialExtent</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/QuantitativeValue" /><a   href="http://schema.org/QuantitativeValue">QuantitativeValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The quantity of the materials being described or an expression of the physical space they occupy.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/mentions">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/mentions">mentions</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Thing" /><a   href="http://schema.org/Thing">Thing</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/offers">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/offers">offers</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Offer" /><a   href="http://schema.org/Offer">Offer</a>&nbsp;<link property="domainIncludes" href="http://schema.org/AggregateOffer"><link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/MenuItem"><link property="domainIncludes" href="http://schema.org/Product"><link property="domainIncludes" href="http://schema.org/Service"><link property="domainIncludes" href="http://schema.org/Trip"></td><td class="prop-desc" property="rdfs:comment">An offer to provide this item&#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/position">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/position">position</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Integer" /><a   href="http://schema.org/Integer">Integer</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/ListItem"></td><td class="prop-desc" property="rdfs:comment">The position of an item in a series or sequence of items.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/producer">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/producer">producer</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.).</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/provider">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/provider">provider</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Invoice"><link property="domainIncludes" href="http://schema.org/ParcelDelivery"><link property="domainIncludes" href="http://schema.org/Reservation"><link property="domainIncludes" href="http://schema.org/Service"><link property="domainIncludes" href="http://schema.org/Trip"></td><td class="prop-desc" property="rdfs:comment">The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller. Supersedes <a   href="http://schema.org/carrier">carrier</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/publication">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/publication">publication</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/PublicationEvent" /><a   href="http://schema.org/PublicationEvent">PublicationEvent</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A publication event associated with the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/publisher">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/publisher">publisher</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The publisher of the creative work.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/publisherImprint">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a title="Defined in extension: bib.schema.org"  class="ext ext-bib"  href="http://bib.localhost:8080/publisherImprint">publisherImprint</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The publishing division which published the comic.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/publishingPrinciples">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/publishingPrinciples">publishingPrinciples</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Organization"><link property="domainIncludes" href="http://schema.org/Person"></td><td class="prop-desc" property="rdfs:comment">The publishingPrinciples property indicates (typically via <a class="localLink" href="http://schema.org/URL">URL</a>) a document describing the editorial principles of an <a class="localLink" href="http://schema.org/Organization">Organization</a> (or individual e.g. a <a class="localLink" href="http://schema.org/Person">Person</a> writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a <a class="localLink" href="http://schema.org/CreativeWork">CreativeWork</a> (e.g. <a class="localLink" href="http://schema.org/NewsArticle">NewsArticle</a>) the principles are those of the party primarily responsible for the creation of the <a class="localLink" href="http://schema.org/CreativeWork">CreativeWork</a>.<br/><br/>
+
+               While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a <a class="localLink" href="http://schema.org/funder">funder</a>) can be expressed using schema.org terminology.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/recordedAt">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/recordedAt">recordedAt</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Event" /><a   href="http://schema.org/Event">Event</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event.<br/> Inverse property: <a   href="http://schema.org/recordedIn">recordedIn</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/releasedEvent">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/releasedEvent">releasedEvent</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/PublicationEvent" /><a   href="http://schema.org/PublicationEvent">PublicationEvent</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The place and time the release was issued, expressed as a PublicationEvent.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/review">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/review">review</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Review" /><a   href="http://schema.org/Review">Review</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Brand"><link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/Offer"><link property="domainIncludes" href="http://schema.org/Organization"><link property="domainIncludes" href="http://schema.org/Place"><link property="domainIncludes" href="http://schema.org/Product"><link property="domainIncludes" href="http://schema.org/Service"></td><td class="prop-desc" property="rdfs:comment">A review of the item. Supersedes <a   href="http://schema.org/reviews">reviews</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/schemaVersion">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/schemaVersion">schemaVersion</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates (by URL or string) a particular version of a schema used in some CreativeWork. For example, a document could declare a schemaVersion using an URL such as http://schema.org/version/2.0/ if precise indication of schema version was required by some application.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sdDatePublished">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/sdDatePublished">sdDatePublished</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Date" /><a   href="http://schema.org/Date">Date</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates the date on which the current structured data was generated / published. Typically used alongside <a class="localLink" href="http://schema.org/sdPublisher">sdPublisher</a></td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sdLicense">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/sdLicense">sdLicense</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A license document that applies to this structured data, typically indicated by URL.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sdPublisher">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/sdPublisher">sdPublisher</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates the party responsible for generating and publishing the current structured data markup, typically in cases where the structured data is derived automatically from existing published content but published on a different site. For example, student projects and open data initiatives often re-publish existing content with more explicitly structured metadata. The
+               <a class="localLink" href="http://schema.org/sdPublisher">sdPublisher</a> property helps make such practices more explicit.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sourceOrganization">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/sourceOrganization">sourceOrganization</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The Organization on whose behalf the creator was working.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/spatial">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/spatial">spatial</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Place" /><a   href="http://schema.org/Place">Place</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The "spatial" property can be used in cases when more specific properties
+               (e.g. <a class="localLink" href="http://schema.org/locationCreated">locationCreated</a>, <a class="localLink" href="http://schema.org/spatialCoverage">spatialCoverage</a>, <a class="localLink" href="http://schema.org/contentLocation">contentLocation</a>) are not known to be appropriate.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/spatialCoverage">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/spatialCoverage">spatialCoverage</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Place" /><a   href="http://schema.org/Place">Place</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The spatialCoverage of a CreativeWork indicates the place(s) which are the focus of the content. It is a subproperty of
+                     contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates
+                     areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sponsor">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/sponsor">sponsor</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/Grant"><link property="domainIncludes" href="http://schema.org/MedicalStudy"><link property="domainIncludes" href="http://schema.org/Organization"><link property="domainIncludes" href="http://schema.org/Person"></td><td class="prop-desc" property="rdfs:comment">A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/temporal">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/temporal">temporal</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/DateTime" /><a   href="http://schema.org/DateTime">DateTime</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The "temporal" property can be used in cases where more specific properties
+               (e.g. <a class="localLink" href="http://schema.org/temporalCoverage">temporalCoverage</a>, <a class="localLink" href="http://schema.org/dateCreated">dateCreated</a>, <a class="localLink" href="http://schema.org/dateModified">dateModified</a>, <a class="localLink" href="http://schema.org/datePublished">datePublished</a>) are not known to be appropriate.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/temporalCoverage">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/temporalCoverage">temporalCoverage</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/DateTime" /><a   href="http://schema.org/DateTime">DateTime</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The temporalCoverage of a CreativeWork indicates the period that the content applies to, i.e. that it describes, either as a DateTime or as a textual string indicating a time period in <a href="https://en.wikipedia.org/wiki/ISO_8601#Time_intervals">ISO 8601 time interval format</a>. In
+                     the case of a Dataset it will typically indicate the relevant time period in a precise notation (e.g. for a 2011 census dataset, the year 2011 would be written "2011/2012"). Other forms of content e.g. ScholarlyArticle, Book, TVSeries or TVEpisode may indicate their temporalCoverage in broader terms - textually or via well-known URL.
+                     Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945".<br/><br/>
+
+               Open-ended date ranges can be written with ".." in place of the end date. For example, "2015-11/.." indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated. Supersedes <a   href="http://schema.org/datasetTimeInterval">datasetTimeInterval</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/text">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/text">text</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The textual content of this CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/thumbnailUrl">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/thumbnailUrl">thumbnailUrl</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A thumbnail image relevant to the Thing.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/timeRequired">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/timeRequired">timeRequired</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Duration" /><a   href="http://schema.org/Duration">Duration</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Approximate or typical time it takes to work with or through this learning resource for the typical intended target audience, e.g. 'PT30M', 'PT1H25M'.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/translationOfWork">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a title="Defined in extension: bib.schema.org"  class="ext ext-bib"  href="http://bib.localhost:8080/translationOfWork">translationOfWork</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The work that this work has been translated from. e.g. 物种起源 is a translationOf “On the Origin of Species”<br/> Inverse property: <a title="Defined in extension: bib.schema.org"  class="ext ext-bib"  href="http://bib.localhost:8080/workTranslation">workTranslation</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/translator">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/translator">translator</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"></td><td class="prop-desc" property="rdfs:comment">Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/typicalAgeRange">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/typicalAgeRange">typicalAgeRange</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"></td><td class="prop-desc" property="rdfs:comment">The typical expected age range, e.g. '7-9', '11-'.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/version">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/version">version</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Number" /><a   href="http://schema.org/Number">Number</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The version of the CreativeWork embodied by a specified resource.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/video">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/video">video</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Clip" /><a   href="http://schema.org/Clip">Clip</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/VideoObject" /><a   href="http://schema.org/VideoObject">VideoObject</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">An embedded video object.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/workExample">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/workExample">workExample</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Example/instance/realization/derivation of the concept of this creative work. eg. The paperback edition, first edition, or eBook.<br/> Inverse property: <a   href="http://schema.org/exampleOfWork">exampleOfWork</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/workTranslation">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a title="Defined in extension: bib.schema.org"  class="ext ext-bib"  href="http://bib.localhost:8080/workTranslation">workTranslation</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A work that is a translation of the content of this work. e.g. 西遊記 has an English workTranslation “Journey to the West”,a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese  translation Tây du ký bình khảo.<br/> Inverse property: <a title="Defined in extension: bib.schema.org"  class="ext ext-bib"  href="http://bib.localhost:8080/translationOfWork">translationOfWork</a>.</td></tr><tr class="supertype">
+                    <th class="supertype-name" colspan="3">Properties from <a   href="http://schema.org/Thing">Thing</a></th>
+
+               </tr>
+
+               <tbody class="supertype">
+                 <tr typeof="rdfs:Property" resource="http://schema.org/additionalType">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/additionalType">additionalType</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax - the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those defined externally.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/alternateName">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/alternateName">alternateName</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An alias for the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/description">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/description">description</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A description of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/disambiguatingDescription">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/identifier">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/identifier">identifier</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The identifier property represents any kind of identifier for any kind of <a class="localLink" href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/image">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/image">image</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/ImageObject" /><a   href="http://schema.org/ImageObject">ImageObject</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An image of the item. This can be a <a class="localLink" href="http://schema.org/URL">URL</a> or a fully described <a class="localLink" href="http://schema.org/ImageObject">ImageObject</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/mainEntityOfPage">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/> Inverse property: <a   href="http://schema.org/mainEntity">mainEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/name">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/name">name</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The name of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/potentialAction">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/potentialAction">potentialAction</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Action" /><a   href="http://schema.org/Action">Action</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sameAs">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/sameAs">sameAs</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/subjectOf">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/subjectOf">subjectOf</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Event" /><a   href="http://schema.org/Event">Event</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A CreativeWork or Event about this Thing..<br/> Inverse property: <a   href="http://schema.org/about">about</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/url">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/url">url</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of the item.</td></tr>
+
+               </table>
                </section>
             </div>
          </div>

--- a/_devTypes/LabProtocol.html
+++ b/_devTypes/LabProtocol.html
@@ -3,6 +3,7 @@ redirect_from:
 - "devTypes/LabProtocol/specification"
 - "devTypes/LabProtocol/specification/"
 - "/devTypes/LabProtocol/"
+- "/LabProtocol"
 cross_walk_url: https://docs.google.com/spreadsheets/d/1RWYIphvcBMHl8SLJl5-xRMZI0YaYrtJtClBSoOPL4xQ
 dateModified: 2019-06-20
 description: 'An experimental protocol is a sequence of tasks and operations executed to perform experimental research in biological and biomedical areas.'

--- a/_devTypes/LabProtocol.html
+++ b/_devTypes/LabProtocol.html
@@ -37,7 +37,7 @@ external: #454547;
             <div id="main-content-wrapper" class="outer">
                <section id="main_content" class="inner">
                   {% include type_start.html %}
-                  <table class="definition-table">
+                  <table class="definition-table bsc_type">
                           <thead>
                     <tr><th>Property</th><th>Expected Type</th><th>Description</th>
                     </tr>

--- a/_devTypes/Phenotype.html
+++ b/_devTypes/Phenotype.html
@@ -1,9 +1,10 @@
 ---
-redirect_from: 
+redirect_from:
 - "devTypes/Phenotype/specification"
 - "devTypes/Phenotype/specification/"
 - "/devTypes/Phenotype/"
-dateModified: 2018-11-14
+- "/Phenotype"
+dateModified: 2019-06-21
 description: "A phenotype."
 hierarchy:
 - Thing
@@ -13,7 +14,7 @@ name: Phenotype
 parent_type: Thing
 spec_type: Type
 status: revision
-version: '0.1-DRAFT'
+version: '0.2-DRAFT'
 
 bsc: #0B794B;
 pending: #0000CC;
@@ -35,180 +36,132 @@ external: #454547;
         <section id="main_content" class="inner">
           {% include type_start.html %}
 
-          <table class="bioschemas_properties bsc_type">
-            <thead>
-              <tr>
-                <th>Property</th>
-                <th>Expected Type</th>
-                <th>Description</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr class="new_props_sdo">
-                <td colspan="3">
-                  Properties from <a style="color: #0B794B;" href="/{{page.name}}">{{page.name}}</a> (pending
-                  schema.org integration).
-                </td>
-              </tr>
-              <!-- Phenotype properties begin here -->
-              <tr id="anatomicalLocation">
-                <th style="color: #0B794B;">anatomicalLocation</th>
-                <td>
-                  <a href="http://schema.org/DefinedTerm">DefinedTerm</a>
-                </td>
-                <td>
-                  Any part of an organism, typically a component of an anatomical system. Organs, tissues, and cells
-                  are all anatomical locations.
-                </td>
-              </tr>
-              <tr id="isAssociatedWith">
-                <th style="color: #0B794B;">isAssociatedWith</th>
-                <td>
-                  <a href="http://schema.org/DefinedTerm">DefinedTerm</a>
-                </td>
-                <td>
-                  BioChemEntity that has some association with this Phenotype
-                </td>
-              </tr>
-              <!-- Phenotype properties ENDS here -->
-              <tr class="reu_props_sdo">
-                <td colspan="3">Properties from <a href="http://schema.org/Thing">Thing</a></td>
-              </tr>
-              <tr>
-                <th><a href="http://schema.org/additionalType">additionalType</a></th>
-                <td>
-                  <a href="http://schema.org/URL">URL</a>
-                </td>
-                <td>
-                  An additional type for the item, typically used for adding more specific types from external
-                  vocabularies in microdata syntax.
-                  This is a relationship between something and a class that the thing is in. In RDFa syntax, it is
-                  better to use the native RDFa syntax -
-                  the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of
-                  extra types, in particular those
-                  defined externally.
-                </td>
-              </tr>
-              <tr>
-                <th><a href="http://schema.org/alternateName">alternateName</a></th>
-                <td>
-                  <a href="http://schema.org/Text">Text</a>
-                </td>
-                <td>
-                  An alias for the item.
-                </td>
-              </tr>
-              <tr>
-                <th><a href="http://schema.org/description">description</a></th>
-                <td>
-                  <a href="http://schema.org/Text">Text</a>
-                </td>
-                <td>
-                  A descripton of the item.
-                </td>
-              </tr>
-              <tr>
-                <th><a href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></th>
-                <td>
-                  <a href="http://schema.org/Text">Text</a>
-                </td>
-                <td>
-                  A sub property of description. A short description of the item used to disambiguate from other,
-                  similar items. Information from other properties (in particular, name) may be necessary for the
-                  description to be useful for disambiguation.
-                </td>
-              </tr>
-              <tr>
-                <th><a href="http://schema.org/identifier">identifier</a></th>
-                <td>
-                  <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br />
-                  <a href="http://schema.org/Text">Text</a> or<br />
-                  <a href="http://schema.org/URL">URL</a>
-                </td>
-                <td>
-                  The identifier property represents any kind of identifier for any kind of <a href="http://schema.org/Thing">Thing</a>,
-                  such as ISBNs, GTIN codes, UUIDs etc.
-                  Schema.org provides dedicated properties for representing many of these, either as textual strings or
-                  as URL (URI) links.
-                  See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more
-                  details.
-                </td>
-              </tr>
-              <tr>
-                <th><a href="http://schema.org/image">image</a></th>
-                <td>
-                  <a href="http://schema.org/ImageObject">ImageObject</a> or<br />
-                  <a href="http://schema.org/URL">URL</a>
-                </td>
-                <td>
-                  An image of the item. This can be a <a href="http://schema.org/URL">URL</a> or a fully described <a
-                    href="http://schema.org/ImageObject">ImageObject</a>.
-                </td>
-              </tr>
-              <tr>
-                <th><a href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></th>
-                <td>
-                  <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br />
-                  <a href="http://schema.org/URL">URL</a>
-                </td>
-                <td>
-                  Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See
-                  <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for
-                  details.<br />
-                  Inverse property: <a href="http://schema.org/mainEntity">mainEntity</a>
-                </td>
-              </tr>
-              <tr>
-                <th><a href="http://schema.org/name">name</a></th>
-                <td>
-                  <a href="http://schema.org/Text">Text</a>
-                </td>
-                <td>
-                  The name of the item.
-                </td>
-              </tr>
-              <tr>
-                <th><a href="http://schema.org/potentialAction">potentialAction</a></th>
-                <td>
-                  <a href="http://schema.org/Action">Action</a>
-                </td>
-                <td>
-                  Indicates a potential Action, which describes an idealized action in which this thing would play an
-                  'object' role.
-                </td>
-              </tr>
-              <tr>
-                <th><a href="http://schema.org/sameAs">sameAs</a></th>
-                <td>
-                  <a href="http://schema.org/URL">URL</a>
-                </td>
-                <td>
-                  URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the
-                  item's Wikipedia page, Wikidata entry, or official website.
-                </td>
-              </tr>
-              <tr>
-                <th><a style="color: #0000CC;" href="http://pending.schema.org/subjectOf">subjectOf</a></th>
-                <td>
-                  <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br />
-                  <a href="http://schema.org/Event">Event</a>
-                </td>
-                <td>
-                  A CreativeWork or Event about this Thing..<br />
-                  Inverse property: <a href="http://schema.org/about">about</a>.
-                </td>
-              </tr>
-              <tr>
-                <th><a href="http://schema.org/url">url</a></th>
-                <td>
-                  <a href="http://schema.org/URL">URL</a>
-                </td>
-                <td>
-                  URL of the item.
-                </td>
-              </tr>
-            </tbody>
-          </table>
+          <table class="definition-table">
+        <thead>
+  <tr><th>Property</th><th>Expected Type</th><th>Description</th>
+  </tr>
+  </thead>
+
+<tr class="supertype">
+     <th class="supertype-name" colspan="3">Properties from <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/Phenotype">Phenotype</a></th>
+
+</tr>
+
+<tbody class="supertype">
+  <tr typeof="rdfs:Property" resource="http://schema.org/anatomicalLocation">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#anatomicalLocation">anatomicalLocation</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Phenotype"></td><td class="prop-desc" property="rdfs:comment">-</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/taxonomicRange">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#taxonomicRange">taxonomicRange</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Taxon" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/Taxon">Taxon</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"><link property="domainIncludes" href="http://schema.org/Phenotype"></td><td class="prop-desc" property="rdfs:comment">The taxonomic grouping of the organism that expresses, encodes, or in someway related to the BioChemEntity.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/valueReference">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#valueReference">valueReference</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Enumeration" /><a   href="http://schema.org/Enumeration">Enumeration</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/QualitativeValue" /><a   href="http://schema.org/QualitativeValue">QualitativeValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/QuantitativeValue" /><a   href="http://schema.org/QuantitativeValue">QuantitativeValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/StructuredValue" /><a   href="http://schema.org/StructuredValue">StructuredValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Phenotype"><link property="domainIncludes" href="http://schema.org/PropertyValue"><link property="domainIncludes" href="http://schema.org/QualitativeValue"><link property="domainIncludes" href="http://schema.org/QuantitativeValue"><link property="domainIncludes" href="http://schema.org/SequenceAnnotation"></td><td class="prop-desc" property="rdfs:comment"> A pointer to a secondary value that provides additional information on the original value, e.g. a reference temperature.</td></tr><tr class="supertype">
+  <th class="supertype-name" colspan="3">Properties from <a   href="http://schema.org/Thing">Thing</a></th>
+
+</tr>
+
+<tbody class="supertype">
+<tr typeof="rdfs:Property" resource="http://schema.org/additionalType">
+
+   <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/additionalType">additionalType</a></code>
+ </th>
+<td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax - the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those defined externally.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/alternateName">
+
+   <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/alternateName">alternateName</a></code>
+ </th>
+<td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An alias for the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/description">
+
+   <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/description">description</a></code>
+ </th>
+<td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A description of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/disambiguatingDescription">
+
+   <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></code>
+ </th>
+<td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/identifier">
+
+   <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/identifier">identifier</a></code>
+ </th>
+<td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The identifier property represents any kind of identifier for any kind of <a class="localLink" href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/image">
+
+   <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/image">image</a></code>
+ </th>
+<td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/ImageObject" /><a   href="http://schema.org/ImageObject">ImageObject</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An image of the item. This can be a <a class="localLink" href="http://schema.org/URL">URL</a> or a fully described <a class="localLink" href="http://schema.org/ImageObject">ImageObject</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/mainEntityOfPage">
+
+   <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></code>
+ </th>
+<td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/> Inverse property: <a   href="http://schema.org/mainEntity">mainEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/name">
+
+   <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/name">name</a></code>
+ </th>
+<td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The name of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/potentialAction">
+
+   <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/potentialAction">potentialAction</a></code>
+ </th>
+<td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Action" /><a   href="http://schema.org/Action">Action</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sameAs">
+
+   <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/sameAs">sameAs</a></code>
+ </th>
+<td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/subjectOf">
+
+   <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/subjectOf">subjectOf</a></code>
+ </th>
+<td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Event" /><a   href="http://schema.org/Event">Event</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A CreativeWork or Event about this Thing..<br/> Inverse property: <a   href="http://schema.org/about">about</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/url">
+
+   <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/url">url</a></code>
+ </th>
+<td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of the item.</td></tr>
+
+</table>
         </section>
       </div>
     </div>

--- a/_devTypes/Phenotype.html
+++ b/_devTypes/Phenotype.html
@@ -36,7 +36,7 @@ external: #454547;
         <section id="main_content" class="inner">
           {% include type_start.html %}
 
-          <table class="definition-table">
+          <table class="definition-table bsc_type">
         <thead>
   <tr><th>Property</th><th>Expected Type</th><th>Description</th>
   </tr>

--- a/_devTypes/RNA.html
+++ b/_devTypes/RNA.html
@@ -36,7 +36,7 @@ external: #454547;
            <div id="main-content-wrapper" class="outer">
               <section id="main_content" class="inner">
                 {% include type_start.html %}
-                <table class="definition-table">
+                <table class="definition-table bsc_type">
                         <thead>
                   <tr><th>Property</th><th>Expected Type</th><th>Description</th>
                   </tr>

--- a/_devTypes/RNA.html
+++ b/_devTypes/RNA.html
@@ -1,0 +1,279 @@
+---
+redirect_from:
+- "devTypes/RNA/specification"
+- "devTypes/RNA/specification/"
+- "/devTypes/RNA/"
+- "/RNA"
+dateModified: 2019-06-21
+description: "RNA"
+hierarchy:
+- Thing
+- BioChemEntity
+gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20RNA
+group: dna
+name: RNA
+parent_type: BioChemEntity
+spec_type: Type
+status: revision
+version: '0.1-DRAFT'
+
+bsc: #0B794B;
+pending: #0000CC;
+external: #454547;
+
+---
+
+
+<!DOCTYPE HTML>
+<html>
+   {% include head.html %}
+
+   <body>
+      {% include header.html %}
+      {% include navbar.html %}
+      <div class="page-content">
+        <div class="wrapper">
+           <div id="main-content-wrapper" class="outer">
+              <section id="main_content" class="inner">
+                {% include type_start.html %}
+                <table class="definition-table">
+                        <thead>
+                  <tr><th>Property</th><th>Expected Type</th><th>Description</th>
+                  </tr>
+                  </thead>
+
+                <tr class="supertype">
+                     <th class="supertype-name" colspan="3">Properties from <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/RNA">RNA</a></th>
+
+                </tr>
+
+                <tbody class="supertype">
+                  <tr typeof="rdfs:Property" resource="http://schema.org/encodesBioChemEntity">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#encodesBioChemEntity">encodesBioChemEntity</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/DNA"><link property="domainIncludes" href="http://schema.org/Gene"><link property="domainIncludes" href="http://schema.org/RNA"></td><td class="prop-desc" property="rdfs:comment">Another BioChemEntity encoded by this one.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isEncodedByBioChemEntity">isEncodedByBioChemEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasSequence">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasSequence">hasSequence</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/DNA"><link property="domainIncludes" href="http://schema.org/Gene"><link property="domainIncludes" href="http://schema.org/Protein"><link property="domainIncludes" href="http://schema.org/RNA"></td><td class="prop-desc" property="rdfs:comment">Nucleotide or amino acid sequence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isCodingRNA">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isCodingRNA">isCodingRNA</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Boolean" /><a   href="http://schema.org/Boolean">Boolean</a>&nbsp;<link property="domainIncludes" href="http://schema.org/RNA"></td><td class="prop-desc" property="rdfs:comment">Indicates whether or not this RNA is a coding one.</td></tr><tr class="supertype">
+                  <th class="supertype-name" colspan="3">Properties from <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a></th>
+
+             </tr>
+
+             <tbody class="supertype">
+               <tr typeof="rdfs:Property" resource="http://schema.org/associatedDisease">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#associatedDisease">associatedDisease</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/MedicalCondition" /><a   href="http://schema.org/MedicalCondition">MedicalCondition</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Disease associated to this BioChemEntity. Such disease can be a MedicalCondition or a URL. If you want to add an evidence supporting the association, please use PropertyValue.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/bioChemInteraction">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#bioChemInteraction">bioChemInteraction</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A BioChemEntity that is known to interact with this item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/bioChemSimilarity">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#bioChemSimilarity">bioChemSimilarity</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A similar molecular entity, e.g., obtained by fingerprint similarity algorithms.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/biologicalRole">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#biologicalRole">biologicalRole</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A role played by the molecular entity within a biological context.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasBioChemEntityPart">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasBioChemEntityPart">hasBioChemEntityPart</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Indicates a BioChemEntity that (in some sense) has this BioChemEntity as a part.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isPartOfBioChemEntity">isPartOfBioChemEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasMolecularFunction">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasMolecularFunction">hasMolecularFunction</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Molecular function performed by this BioChemEntity; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasRepresentation">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasRepresentation">hasRepresentation</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A common representation such as a protein sequence or chemical structure for this entity. For images use schema.org/image.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasSequenceAnnotation">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasSequenceAnnotation">hasSequenceAnnotation</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/SequenceAnnotation" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/SequenceAnnotation">SequenceAnnotation</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Pointer to a sequence annotation; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isEncodedByBioChemEntity">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isEncodedByBioChemEntity">isEncodedByBioChemEntity</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/DNA" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/DNA">DNA</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Gene" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/Gene">Gene</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/RNA" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/RNA">RNA</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Another BioChemEntity encoding by this one.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#encodesBioChemEntity">encodesBioChemEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isInvolvedInBiologicalProcess">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isInvolvedInBiologicalProcess">isInvolvedInBiologicalProcess</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Biological process this BioChemEntity is involved in; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isLocatedInSubcellularLocation">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isLocatedInSubcellularLocation">isLocatedInSubcellularLocation</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Subcellular location where this BioChemEntity is located; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isMatchedBy">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isMatchedBy">isMatchedBy</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/SequenceMatchingModel" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/SequenceMatchingModel">SequenceMatchingModel</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A model matching this BioChemEntity.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isPartOfBioChemEntity">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isPartOfBioChemEntity">isPartOfBioChemEntity</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Indicates a BioChemEntity that is (in some sense) a part of this BioChemEntity.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasBioChemEntityPart">hasBioChemEntityPart</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/taxonomicRange">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#taxonomicRange">taxonomicRange</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Taxon" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/Taxon">Taxon</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"><link property="domainIncludes" href="http://schema.org/Phenotype"></td><td class="prop-desc" property="rdfs:comment">The taxonomic grouping of the organism that expresses, encodes, or in someway related to the BioChemEntity.</td></tr><tr class="supertype">
+                  <th class="supertype-name" colspan="3">Properties from <a   href="http://schema.org/Thing">Thing</a></th>
+
+             </tr>
+
+             <tbody class="supertype">
+               <tr typeof="rdfs:Property" resource="http://schema.org/additionalType">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/additionalType">additionalType</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax - the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those defined externally.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/alternateName">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/alternateName">alternateName</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An alias for the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/description">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/description">description</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A description of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/disambiguatingDescription">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/identifier">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/identifier">identifier</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The identifier property represents any kind of identifier for any kind of <a class="localLink" href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/image">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/image">image</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/ImageObject" /><a   href="http://schema.org/ImageObject">ImageObject</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An image of the item. This can be a <a class="localLink" href="http://schema.org/URL">URL</a> or a fully described <a class="localLink" href="http://schema.org/ImageObject">ImageObject</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/mainEntityOfPage">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/> Inverse property: <a   href="http://schema.org/mainEntity">mainEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/name">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/name">name</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The name of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/potentialAction">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/potentialAction">potentialAction</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/Action" /><a   href="http://schema.org/Action">Action</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sameAs">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/sameAs">sameAs</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/subjectOf">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/subjectOf">subjectOf</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Event" /><a   href="http://schema.org/Event">Event</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A CreativeWork or Event about this Thing..<br/> Inverse property: <a   href="http://schema.org/about">about</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/url">
+
+                   <th class="prop-nam" scope="row">
+
+             <code property="rdfs:label"><a   href="http://schema.org/url">url</a></code>
+                 </th>
+              <td class="prop-ect">
+             <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of the item.</td></tr>
+
+             </table>
+
+               </section>
+             </div>
+           </div>
+      </div>
+      {% include footer.html %}
+
+
+
+   </body>
+</html>

--- a/_devTypes/Sample.html
+++ b/_devTypes/Sample.html
@@ -1,8 +1,9 @@
 ---
-redirect_from: 
+redirect_from:
 - "devTypes/Sample/specification"
 - "devTypes/Sample/specification/"
 - "/devTypes/Sample/"
+- "/Sample"
 dateModified: 2018-11-09
 description: "A material entity that is representative of a whole. <p>Comments: Typically samples are intended to be representative of the whole or aspects thereof. Examples of samples include biomedical samples (blood, urine) and commercial samples (carpet, metal).</p>"
 hierarchy:

--- a/_devTypes/SequenceAnnotation.html
+++ b/_devTypes/SequenceAnnotation.html
@@ -1,0 +1,288 @@
+---
+redirect_from:
+- "/SequenceAnnotation"
+dateModified: 2019-06-21
+description:
+hierarchy:
+- Thing
+- BioChemEntity
+gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20SequenceAnnotation
+group: proteins
+name: SequenceAnnotation
+parent_type: BioChemEntity
+spec_type: Type
+status: revision #Revert to revision when working on the next version
+version: '0.1-DRAFT'
+
+bsc: #0B794B;
+pending : #0000CC;
+external: #454547;
+
+---
+
+
+<!DOCTYPE HTML>
+<html>
+   {% include head.html %}
+   <body>
+      {% include header.html %}
+      {% include navbar.html %}
+      <div class="page-content">
+        <div class="wrapper">
+           <div id="main-content-wrapper" class="outer">
+              <section id="main_content" class="inner">
+                {% include type_start.html %}
+                <table class="definition-table">
+        <thead>
+  <tr><th>Property</th><th>Expected Type</th><th>Description</th>
+  </tr>
+  </thead>
+
+<tr class="supertype">
+     <th class="supertype-name" colspan="3">Properties from <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/SequenceAnnotation">SequenceAnnotation</a></th>
+
+</tr>
+
+<tbody class="supertype">
+  <tr typeof="rdfs:Property" resource="http://schema.org/creationMethod">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#creationMethod">creationMethod</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemStructure"><link property="domainIncludes" href="http://schema.org/SequenceAnnotation"></td><td class="prop-desc" property="rdfs:comment">Method used to create or obtain this annotation or BioChemEntity; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sequenceLocation">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#sequenceLocation">sequenceLocation</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/SequenceRange" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/SequenceRange">SequenceRange</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemStructure"><link property="domainIncludes" href="http://schema.org/SequenceAnnotation"></td><td class="prop-desc" property="rdfs:comment">A range/position location where this annotation or BioChemEntity is located reagrding another BioChemEntity, for instance a BioChemStructure in a Protein.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sequenceOrientation">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#sequenceOrientation">sequenceOrientation</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Integer" /><a   href="http://schema.org/Integer">Integer</a>&nbsp;<link property="domainIncludes" href="http://schema.org/SequenceAnnotation"></td><td class="prop-desc" property="rdfs:comment">One of 1, 0 or -1.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sequenceValue">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#sequenceValue">sequenceValue</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/SequenceAnnotation"></td><td class="prop-desc" property="rdfs:comment">-</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/valueReference">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#valueReference">valueReference</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Enumeration" /><a   href="http://schema.org/Enumeration">Enumeration</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/QualitativeValue" /><a   href="http://schema.org/QualitativeValue">QualitativeValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/QuantitativeValue" /><a   href="http://schema.org/QuantitativeValue">QuantitativeValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/StructuredValue" /><a   href="http://schema.org/StructuredValue">StructuredValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Phenotype"><link property="domainIncludes" href="http://schema.org/PropertyValue"><link property="domainIncludes" href="http://schema.org/QualitativeValue"><link property="domainIncludes" href="http://schema.org/QuantitativeValue"><link property="domainIncludes" href="http://schema.org/SequenceAnnotation"></td><td class="prop-desc" property="rdfs:comment"> A pointer to a secondary value that provides additional information on the original value, e.g. a reference temperature.</td></tr><tr class="supertype">
+                     <th class="supertype-name" colspan="3">Properties from <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a></th>
+
+                </tr>
+
+                <tbody class="supertype">
+                  <tr typeof="rdfs:Property" resource="http://schema.org/associatedDisease">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#associatedDisease">associatedDisease</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/MedicalCondition" /><a   href="http://schema.org/MedicalCondition">MedicalCondition</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Disease associated to this BioChemEntity. Such disease can be a MedicalCondition or a URL. If you want to add an evidence supporting the association, please use PropertyValue.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/bioChemInteraction">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#bioChemInteraction">bioChemInteraction</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A BioChemEntity that is known to interact with this item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/bioChemSimilarity">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#bioChemSimilarity">bioChemSimilarity</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A similar molecular entity, e.g., obtained by fingerprint similarity algorithms.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/biologicalRole">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#biologicalRole">biologicalRole</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A role played by the molecular entity within a biological context.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasBioChemEntityPart">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasBioChemEntityPart">hasBioChemEntityPart</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Indicates a BioChemEntity that (in some sense) has this BioChemEntity as a part.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isPartOfBioChemEntity">isPartOfBioChemEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasMolecularFunction">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasMolecularFunction">hasMolecularFunction</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Molecular function performed by this BioChemEntity; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasRepresentation">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasRepresentation">hasRepresentation</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A common representation such as a protein sequence or chemical structure for this entity. For images use schema.org/image.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasSequenceAnnotation">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasSequenceAnnotation">hasSequenceAnnotation</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/SequenceAnnotation" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/SequenceAnnotation">SequenceAnnotation</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Pointer to a sequence annotation; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isEncodedByBioChemEntity">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isEncodedByBioChemEntity">isEncodedByBioChemEntity</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/DNA" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/DNA">DNA</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Gene" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/Gene">Gene</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/RNA" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/RNA">RNA</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Another BioChemEntity encoding by this one.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#encodesBioChemEntity">encodesBioChemEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isInvolvedInBiologicalProcess">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isInvolvedInBiologicalProcess">isInvolvedInBiologicalProcess</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Biological process this BioChemEntity is involved in; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isLocatedInSubcellularLocation">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isLocatedInSubcellularLocation">isLocatedInSubcellularLocation</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Subcellular location where this BioChemEntity is located; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isMatchedBy">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isMatchedBy">isMatchedBy</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/SequenceMatchingModel" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/SequenceMatchingModel">SequenceMatchingModel</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A model matching this BioChemEntity.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isPartOfBioChemEntity">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isPartOfBioChemEntity">isPartOfBioChemEntity</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Indicates a BioChemEntity that is (in some sense) a part of this BioChemEntity.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasBioChemEntityPart">hasBioChemEntityPart</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/taxonomicRange">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#taxonomicRange">taxonomicRange</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Taxon" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/Taxon">Taxon</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"><link property="domainIncludes" href="http://schema.org/Phenotype"></td><td class="prop-desc" property="rdfs:comment">The taxonomic grouping of the organism that expresses, encodes, or in someway related to the BioChemEntity.</td></tr><tr class="supertype">
+                     <th class="supertype-name" colspan="3">Properties from <a   href="http://schema.org/Thing">Thing</a></th>
+
+                </tr>
+
+                <tbody class="supertype">
+                  <tr typeof="rdfs:Property" resource="http://schema.org/additionalType">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/additionalType">additionalType</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax - the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those defined externally.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/alternateName">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/alternateName">alternateName</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An alias for the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/description">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/description">description</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A description of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/disambiguatingDescription">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/identifier">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/identifier">identifier</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The identifier property represents any kind of identifier for any kind of <a class="localLink" href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/image">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/image">image</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/ImageObject" /><a   href="http://schema.org/ImageObject">ImageObject</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An image of the item. This can be a <a class="localLink" href="http://schema.org/URL">URL</a> or a fully described <a class="localLink" href="http://schema.org/ImageObject">ImageObject</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/mainEntityOfPage">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/> Inverse property: <a   href="http://schema.org/mainEntity">mainEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/name">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/name">name</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The name of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/potentialAction">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/potentialAction">potentialAction</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Action" /><a   href="http://schema.org/Action">Action</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sameAs">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/sameAs">sameAs</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/subjectOf">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/subjectOf">subjectOf</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Event" /><a   href="http://schema.org/Event">Event</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A CreativeWork or Event about this Thing..<br/> Inverse property: <a   href="http://schema.org/about">about</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/url">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/url">url</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of the item.</td></tr>
+
+                </table>
+               </section>
+             </div>
+           </div>
+      </div>
+      {% include footer.html %}
+
+
+
+   </body>
+</html>

--- a/_devTypes/SequenceAnnotation.html
+++ b/_devTypes/SequenceAnnotation.html
@@ -32,7 +32,7 @@ external: #454547;
            <div id="main-content-wrapper" class="outer">
               <section id="main_content" class="inner">
                 {% include type_start.html %}
-                <table class="definition-table">
+                <table class="definition-table bsc_type">
         <thead>
   <tr><th>Property</th><th>Expected Type</th><th>Description</th>
   </tr>

--- a/_devTypes/SequenceMatchingModel.html
+++ b/_devTypes/SequenceMatchingModel.html
@@ -3,6 +3,7 @@ redirect_from:
 - "devTypes/SequenceMatchingModel/specification"
 - "devTypes/SequenceMatchingModel/specification/"
 - "/devTypes/SequenceMatchingModel/"
+- "/SequenceMatchingModel"
 dateModified: 2019-06-21
 description: 'A model used to determine sequence matches such as domains in proteins.'
 gh_examples:

--- a/_devTypes/SequenceMatchingModel.html
+++ b/_devTypes/SequenceMatchingModel.html
@@ -1,0 +1,831 @@
+---
+redirect_from:
+- "devTypes/SequenceMatchingModel/specification"
+- "devTypes/SequenceMatchingModel/specification/"
+- "/devTypes/SequenceMatchingModel/"
+dateModified: 2019-06-21
+description: 'A model used to determine sequence matches such as domains in proteins.'
+gh_examples:
+gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20SequenceMatchingModel
+group: protein
+hierarchy:
+- Thing
+- CreativeWork
+live_deploy: ''
+name: SequenceMatchingModel
+parent_type: CreativeWork
+spec_type: Type
+status: revision
+use_cases_url: ''
+version: '0.1-DRAFT'
+
+bsc: #0B794B;
+pending: #0000CC;
+external: #454547;
+---
+
+<!DOCTYPE HTML>
+<html>
+   {% include head.html %}
+   <body>
+      {% include header.html %}
+      {% include navbar.html %}
+      <div class="page-content">
+         <div class="wrapper">
+            <div id="main-content-wrapper" class="outer">
+               <section id="main_content" class="inner">
+                  {% include type_start.html %}
+                  <table class="definition-table">
+        <thead>
+  <tr><th>Property</th><th>Expected Type</th><th>Description</th>
+  </tr>
+  </thead>
+
+<tr class="supertype">
+     <th class="supertype-name" colspan="3">Properties from <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/SequenceMatchingModel">SequenceMatchingModel</a></th>
+
+</tr>
+
+<tbody class="supertype">
+  <tr typeof="rdfs:Property" resource="http://schema.org/biologicalType">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#biologicalType">biologicalType</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/SequenceMatchingModel"></td><td class="prop-desc" property="rdfs:comment">Biological type targeted by this model, for instance domains or sites in proteins.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/match">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#match">match</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/<built-in function id>" /><a   href="http://schema.org/todo"><built-in function id></a>&nbsp;<link property="domainIncludes" href="http://schema.org/SequenceMatchingModel"></td><td class="prop-desc" property="rdfs:comment">Entity matched by this model, for instance proteins where the domain targeted by this model are found.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isMatchedBy">isMatchedBy</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/modelDataset">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#modelDataset">modelDataset</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Dataset" /><a   href="http://schema.org/Dataset">Dataset</a>&nbsp;<link property="domainIncludes" href="http://schema.org/SequenceMatchingModel"></td><td class="prop-desc" property="rdfs:comment">Dataset where this matching model has been recorded.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/modelSignature">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#modelSignature">modelSignature</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/<built-in function id>" /><a   href="http://schema.org/Image"><built-in function id></a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/SequenceMatchingModel"></td><td class="prop-desc" property="rdfs:comment">Representation of the model such as regular expresion or image.</td></tr><tr class="supertype">
+                    <th class="supertype-name" colspan="3">Properties from <a   href="http://schema.org/CreativeWork">CreativeWork</a></th>
+
+               </tr>
+
+               <tbody class="supertype">
+                 <tr typeof="rdfs:Property" resource="http://schema.org/about">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/about">about</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Thing" /><a   href="http://schema.org/Thing">Thing</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CommunicateAction"><link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"></td><td class="prop-desc" property="rdfs:comment">The subject matter of the content.<br/> Inverse property: <a   href="http://schema.org/subjectOf">subjectOf</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accessMode">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/accessMode">accessMode</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The human sensory perceptual system or cognitive faculty through which a person may process or perceive information. Expected values include: auditory, tactile, textual, visual, colorDependent, chartOnVisual, chemOnVisual, diagramOnVisual, mathOnVisual, musicOnVisual, textOnVisual.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accessModeSufficient">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/accessModeSufficient">accessModeSufficient</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A list of single or combined accessModes that are sufficient to understand all the intellectual content of a resource. Expected values include:  auditory, tactile, textual, visual.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accessibilityAPI">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/accessibilityAPI">accessibilityAPI</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates that the resource is compatible with the referenced accessibility API (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accessibilityControl">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/accessibilityControl">accessibilityControl</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Identifies input methods that are sufficient to fully control the described resource (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accessibilityFeature">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/accessibilityFeature">accessibilityFeature</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Content features of the resource, such as accessible media, alternatives and supported enhancements for accessibility (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accessibilityHazard">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/accessibilityHazard">accessibilityHazard</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A characteristic of the described resource that is physiologically dangerous to some users. Related to WCAG 2.0 guideline 2.3 (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accessibilitySummary">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/accessibilitySummary">accessibilitySummary</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A human-readable summary of specific accessibility features or deficiencies, consistent with the other accessibility metadata but expressing subtleties such as "short descriptions are present but long descriptions will be needed for non-visual users" or "short descriptions are present and no long descriptions are needed."</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accountablePerson">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/accountablePerson">accountablePerson</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Specifies the Person that is legally accountable for the CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/aggregateRating">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/aggregateRating">aggregateRating</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/AggregateRating" /><a   href="http://schema.org/AggregateRating">AggregateRating</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Brand"><link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/Offer"><link property="domainIncludes" href="http://schema.org/Organization"><link property="domainIncludes" href="http://schema.org/Place"><link property="domainIncludes" href="http://schema.org/Product"><link property="domainIncludes" href="http://schema.org/Service"></td><td class="prop-desc" property="rdfs:comment">The overall rating, based on a collection of reviews or ratings, of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/alternativeHeadline">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/alternativeHeadline">alternativeHeadline</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A secondary title of the CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/associatedMedia">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/associatedMedia">associatedMedia</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/MediaObject" /><a   href="http://schema.org/MediaObject">MediaObject</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A media object that encodes this CreativeWork. This property is a synonym for encoding.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/audience">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/audience">audience</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Audience" /><a   href="http://schema.org/Audience">Audience</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/LodgingBusiness"><link property="domainIncludes" href="http://schema.org/PlayAction"><link property="domainIncludes" href="http://schema.org/Product"><link property="domainIncludes" href="http://schema.org/Service"></td><td class="prop-desc" property="rdfs:comment">An intended audience, i.e. a group for whom something was created. Supersedes <a   href="http://schema.org/serviceAudience">serviceAudience</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/audio">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/audio">audio</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/AudioObject" /><a   href="http://schema.org/AudioObject">AudioObject</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Clip" /><a   href="http://schema.org/Clip">Clip</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">An embedded audio object.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/author">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/author">author</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Rating"></td><td class="prop-desc" property="rdfs:comment">The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/award">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/award">award</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Organization"><link property="domainIncludes" href="http://schema.org/Person"><link property="domainIncludes" href="http://schema.org/Product"><link property="domainIncludes" href="http://schema.org/Service"></td><td class="prop-desc" property="rdfs:comment">An award won by or for this item. Supersedes <a   href="http://schema.org/awards">awards</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/character">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/character">character</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Fictional person connected with a creative work.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/citation">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/citation">citation</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A citation or reference to another creative work, such as another publication, web page, scholarly article, etc.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/comment">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/comment">comment</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Comment" /><a   href="http://schema.org/Comment">Comment</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/RsvpAction"></td><td class="prop-desc" property="rdfs:comment">Comments, typically from users.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/commentCount">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/commentCount">commentCount</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Integer" /><a   href="http://schema.org/Integer">Integer</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The number of comments this CreativeWork (e.g. Article, Question or Answer) has received. This is most applicable to works published in Web sites with commenting system; additional comments may exist elsewhere.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/contentLocation">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/contentLocation">contentLocation</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Place" /><a   href="http://schema.org/Place">Place</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The location depicted or described in the content. For example, the location in a photograph or painting.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/contentRating">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/contentRating">contentRating</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Rating" /><a   href="http://schema.org/Rating">Rating</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Official rating of a piece of content&#x2014;for example,'MPAA PG-13'.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/contentReferenceTime">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/contentReferenceTime">contentReferenceTime</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/DateTime" /><a   href="http://schema.org/DateTime">DateTime</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The specific time described by a creative work, for works (e.g. articles, video objects etc.) that emphasise a particular moment within an Event.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/contributor">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/contributor">contributor</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"></td><td class="prop-desc" property="rdfs:comment">A secondary contributor to the CreativeWork or Event.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/copyrightHolder">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/copyrightHolder">copyrightHolder</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The party holding the legal copyright to the CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/copyrightYear">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/copyrightYear">copyrightYear</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Number" /><a   href="http://schema.org/Number">Number</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The year during which the claimed copyright for the CreativeWork was first asserted.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/correction">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/correction">correction</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CorrectionComment" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/CorrectionComment">CorrectionComment</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates a correction to a <a class="localLink" href="http://schema.org/CreativeWork">CreativeWork</a>, either via a <a class="localLink" href="http://schema.org/CorrectionComment">CorrectionComment</a>, textually or in another document.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/creator">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/creator">creator</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/UserComments"></td><td class="prop-desc" property="rdfs:comment">The creator/author of this CreativeWork. This is the same as the Author property for CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/dateCreated">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/dateCreated">dateCreated</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Date" /><a   href="http://schema.org/Date">Date</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/DateTime" /><a   href="http://schema.org/DateTime">DateTime</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioSample"><link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/DataFeedItem"></td><td class="prop-desc" property="rdfs:comment">The date on which the CreativeWork was created or the item was added to a DataFeed.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/dateModified">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/dateModified">dateModified</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Date" /><a   href="http://schema.org/Date">Date</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/DateTime" /><a   href="http://schema.org/DateTime">DateTime</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/DataFeedItem"></td><td class="prop-desc" property="rdfs:comment">The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/datePublished">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/datePublished">datePublished</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Date" /><a   href="http://schema.org/Date">Date</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Date of first broadcast/publication.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/discussionUrl">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/discussionUrl">discussionUrl</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A link to the page containing the comments of the CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/editor">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/editor">editor</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Specifies the Person who edited the CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/educationalAlignment">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/educationalAlignment">educationalAlignment</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/AlignmentObject" /><a   href="http://schema.org/AlignmentObject">AlignmentObject</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">An alignment to an established educational framework.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/educationalUse">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/educationalUse">educationalUse</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The purpose of a work in the context of education; for example, 'assignment', 'group work'.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/encoding">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/encoding">encoding</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/MediaObject" /><a   href="http://schema.org/MediaObject">MediaObject</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A media object that encodes this CreativeWork. This property is a synonym for associatedMedia. Supersedes <a   href="http://schema.org/encodings">encodings</a>.<br/> Inverse property: <a   href="http://schema.org/encodesCreativeWork">encodesCreativeWork</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/encodingFormat">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/encodingFormat">encodingFormat</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/MediaObject"></td><td class="prop-desc" property="rdfs:comment">Media type typically expressed using a MIME format (see <a href="http://www.iana.org/assignments/media-types/media-types.xhtml">IANA site</a> and <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MDN reference</a>) e.g. application/zip for a SoftwareApplication binary, audio/mpeg for .mp3 etc.).<br/><br/>
+
+               In cases where a <a class="localLink" href="http://schema.org/CreativeWork">CreativeWork</a> has several media type representations, <a class="localLink" href="http://schema.org/encoding">encoding</a> can be used to indicate each <a class="localLink" href="http://schema.org/MediaObject">MediaObject</a> alongside particular <a class="localLink" href="http://schema.org/encodingFormat">encodingFormat</a> information.<br/><br/>
+
+               Unregistered or niche encoding and file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia/Wikidata entry. Supersedes <a   href="http://schema.org/fileFormat">fileFormat</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/exampleOfWork">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/exampleOfWork">exampleOfWork</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A creative work that this work is an example/instance/realization/derivation of.<br/> Inverse property: <a   href="http://schema.org/workExample">workExample</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/expires">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/expires">expires</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Date" /><a   href="http://schema.org/Date">Date</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Date the content expires and is no longer useful or available. For example a <a class="localLink" href="http://schema.org/VideoObject">VideoObject</a> or <a class="localLink" href="http://schema.org/NewsArticle">NewsArticle</a> whose availability or relevance is time-limited, or a <a class="localLink" href="http://schema.org/ClaimReview">ClaimReview</a> fact check whose publisher wants to indicate that it may no longer be relevant (or helpful to highlight) after some date.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/funder">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/funder">funder</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/MonetaryGrant"><link property="domainIncludes" href="http://schema.org/Organization"><link property="domainIncludes" href="http://schema.org/Person"></td><td class="prop-desc" property="rdfs:comment">A person or organization that supports (sponsors) something through some kind of financial contribution.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/genre">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/genre">genre</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BroadcastChannel"><link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/MusicGroup"></td><td class="prop-desc" property="rdfs:comment">Genre of the creative work, broadcast channel or group.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasPart">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/hasPart">hasPart</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates an item or CreativeWork that is part of this item, or CreativeWork (in some sense).<br/> Inverse property: <a   href="http://schema.org/isPartOf">isPartOf</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/headline">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/headline">headline</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Headline of the article.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/inLanguage">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/inLanguage">inLanguage</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Language" /><a   href="http://schema.org/Language">Language</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CommunicateAction"><link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/LinkRole"><link property="domainIncludes" href="http://schema.org/WriteAction"></td><td class="prop-desc" property="rdfs:comment">The language of the content or performance or used in an action. Please use one of the language codes from the <a href="http://tools.ietf.org/html/bcp47">IETF BCP 47 standard</a>. See also <a class="localLink" href="http://schema.org/availableLanguage">availableLanguage</a>. Supersedes <a   href="http://schema.org/language">language</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/interactionStatistic">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/interactionStatistic">interactionStatistic</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/InteractionCounter" /><a   href="http://schema.org/InteractionCounter">InteractionCounter</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used. Supersedes <a   href="http://schema.org/interactionCount">interactionCount</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/interactivityType">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/interactivityType">interactivityType</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The predominant mode of learning supported by the learning resource. Acceptable values are 'active', 'expositive', or 'mixed'.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isAccessibleForFree">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/isAccessibleForFree">isAccessibleForFree</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Boolean" /><a   href="http://schema.org/Boolean">Boolean</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/Place"><link property="domainIncludes" href="http://schema.org/PublicationEvent"></td><td class="prop-desc" property="rdfs:comment">A flag to signal that the item, event, or place is accessible for free. Supersedes <a   href="http://schema.org/free">free</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isBasedOn">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/isBasedOn">isBasedOn</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Product" /><a   href="http://schema.org/Product">Product</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A resource from which this work is derived or from which it is a modification or adaption. Supersedes <a   href="http://schema.org/isBasedOnUrl">isBasedOnUrl</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isBasisFor">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/isBasisFor">isBasisFor</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A resource that was (somehow) created using this resource as a basis for.<br/> Inverse property: <a   href="http://schema.org/isBasedOn">isBasedOn</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isFamilyFriendly">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/isFamilyFriendly">isFamilyFriendly</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Boolean" /><a   href="http://schema.org/Boolean">Boolean</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates whether this content is family friendly.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isPartOf">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/isPartOf">isPartOf</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates an item or CreativeWork that this item, or CreativeWork (in some sense), is part of.<br/> Inverse property: <a   href="http://schema.org/hasPart">hasPart</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/keywords">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/keywords">keywords</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/learningResourceType">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/learningResourceType">learningResourceType</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The predominant type or kind characterizing the learning resource. For example, 'presentation', 'handout'.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/license">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/license">license</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A license document that applies to this content, typically indicated by URL.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/locationCreated">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/locationCreated">locationCreated</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Place" /><a   href="http://schema.org/Place">Place</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioSample"><link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The location where the CreativeWork was created, which may not be the same as the location depicted in the CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/mainEntity">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/mainEntity">mainEntity</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Thing" /><a   href="http://schema.org/Thing">Thing</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates the primary entity described in some page or other CreativeWork.<br/> Inverse property: <a   href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/material">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/material">material</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Product" /><a   href="http://schema.org/Product">Product</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Product"></td><td class="prop-desc" property="rdfs:comment">A material that something is made from, e.g. leather, wool, cotton, paper.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/materialExtent">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/materialExtent">materialExtent</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/QuantitativeValue" /><a   href="http://schema.org/QuantitativeValue">QuantitativeValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The quantity of the materials being described or an expression of the physical space they occupy.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/mentions">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/mentions">mentions</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Thing" /><a   href="http://schema.org/Thing">Thing</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/offers">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/offers">offers</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Offer" /><a   href="http://schema.org/Offer">Offer</a>&nbsp;<link property="domainIncludes" href="http://schema.org/AggregateOffer"><link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/MenuItem"><link property="domainIncludes" href="http://schema.org/Product"><link property="domainIncludes" href="http://schema.org/Service"><link property="domainIncludes" href="http://schema.org/Trip"></td><td class="prop-desc" property="rdfs:comment">An offer to provide this item&#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/position">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/position">position</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Integer" /><a   href="http://schema.org/Integer">Integer</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/ListItem"></td><td class="prop-desc" property="rdfs:comment">The position of an item in a series or sequence of items.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/producer">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/producer">producer</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.).</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/provider">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/provider">provider</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Invoice"><link property="domainIncludes" href="http://schema.org/ParcelDelivery"><link property="domainIncludes" href="http://schema.org/Reservation"><link property="domainIncludes" href="http://schema.org/Service"><link property="domainIncludes" href="http://schema.org/Trip"></td><td class="prop-desc" property="rdfs:comment">The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller. Supersedes <a   href="http://schema.org/carrier">carrier</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/publication">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/publication">publication</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/PublicationEvent" /><a   href="http://schema.org/PublicationEvent">PublicationEvent</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A publication event associated with the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/publisher">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/publisher">publisher</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The publisher of the creative work.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/publisherImprint">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a title="Defined in extension: bib.schema.org"  class="ext ext-bib"  href="http://bib.localhost:8080/publisherImprint">publisherImprint</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The publishing division which published the comic.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/publishingPrinciples">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/publishingPrinciples">publishingPrinciples</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Organization"><link property="domainIncludes" href="http://schema.org/Person"></td><td class="prop-desc" property="rdfs:comment">The publishingPrinciples property indicates (typically via <a class="localLink" href="http://schema.org/URL">URL</a>) a document describing the editorial principles of an <a class="localLink" href="http://schema.org/Organization">Organization</a> (or individual e.g. a <a class="localLink" href="http://schema.org/Person">Person</a> writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a <a class="localLink" href="http://schema.org/CreativeWork">CreativeWork</a> (e.g. <a class="localLink" href="http://schema.org/NewsArticle">NewsArticle</a>) the principles are those of the party primarily responsible for the creation of the <a class="localLink" href="http://schema.org/CreativeWork">CreativeWork</a>.<br/><br/>
+
+               While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a <a class="localLink" href="http://schema.org/funder">funder</a>) can be expressed using schema.org terminology.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/recordedAt">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/recordedAt">recordedAt</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Event" /><a   href="http://schema.org/Event">Event</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event.<br/> Inverse property: <a   href="http://schema.org/recordedIn">recordedIn</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/releasedEvent">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/releasedEvent">releasedEvent</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/PublicationEvent" /><a   href="http://schema.org/PublicationEvent">PublicationEvent</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The place and time the release was issued, expressed as a PublicationEvent.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/review">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/review">review</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Review" /><a   href="http://schema.org/Review">Review</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Brand"><link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/Offer"><link property="domainIncludes" href="http://schema.org/Organization"><link property="domainIncludes" href="http://schema.org/Place"><link property="domainIncludes" href="http://schema.org/Product"><link property="domainIncludes" href="http://schema.org/Service"></td><td class="prop-desc" property="rdfs:comment">A review of the item. Supersedes <a   href="http://schema.org/reviews">reviews</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/schemaVersion">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/schemaVersion">schemaVersion</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates (by URL or string) a particular version of a schema used in some CreativeWork. For example, a document could declare a schemaVersion using an URL such as http://schema.org/version/2.0/ if precise indication of schema version was required by some application.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sdDatePublished">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/sdDatePublished">sdDatePublished</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Date" /><a   href="http://schema.org/Date">Date</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates the date on which the current structured data was generated / published. Typically used alongside <a class="localLink" href="http://schema.org/sdPublisher">sdPublisher</a></td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sdLicense">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/sdLicense">sdLicense</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A license document that applies to this structured data, typically indicated by URL.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sdPublisher">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/sdPublisher">sdPublisher</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates the party responsible for generating and publishing the current structured data markup, typically in cases where the structured data is derived automatically from existing published content but published on a different site. For example, student projects and open data initiatives often re-publish existing content with more explicitly structured metadata. The
+               <a class="localLink" href="http://schema.org/sdPublisher">sdPublisher</a> property helps make such practices more explicit.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sourceOrganization">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/sourceOrganization">sourceOrganization</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The Organization on whose behalf the creator was working.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/spatial">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/spatial">spatial</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Place" /><a   href="http://schema.org/Place">Place</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The "spatial" property can be used in cases when more specific properties
+               (e.g. <a class="localLink" href="http://schema.org/locationCreated">locationCreated</a>, <a class="localLink" href="http://schema.org/spatialCoverage">spatialCoverage</a>, <a class="localLink" href="http://schema.org/contentLocation">contentLocation</a>) are not known to be appropriate.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/spatialCoverage">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/spatialCoverage">spatialCoverage</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Place" /><a   href="http://schema.org/Place">Place</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The spatialCoverage of a CreativeWork indicates the place(s) which are the focus of the content. It is a subproperty of
+                     contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates
+                     areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sponsor">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/sponsor">sponsor</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/Grant"><link property="domainIncludes" href="http://schema.org/MedicalStudy"><link property="domainIncludes" href="http://schema.org/Organization"><link property="domainIncludes" href="http://schema.org/Person"></td><td class="prop-desc" property="rdfs:comment">A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/temporal">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/temporal">temporal</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/DateTime" /><a   href="http://schema.org/DateTime">DateTime</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The "temporal" property can be used in cases where more specific properties
+               (e.g. <a class="localLink" href="http://schema.org/temporalCoverage">temporalCoverage</a>, <a class="localLink" href="http://schema.org/dateCreated">dateCreated</a>, <a class="localLink" href="http://schema.org/dateModified">dateModified</a>, <a class="localLink" href="http://schema.org/datePublished">datePublished</a>) are not known to be appropriate.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/temporalCoverage">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/temporalCoverage">temporalCoverage</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/DateTime" /><a   href="http://schema.org/DateTime">DateTime</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The temporalCoverage of a CreativeWork indicates the period that the content applies to, i.e. that it describes, either as a DateTime or as a textual string indicating a time period in <a href="https://en.wikipedia.org/wiki/ISO_8601#Time_intervals">ISO 8601 time interval format</a>. In
+                     the case of a Dataset it will typically indicate the relevant time period in a precise notation (e.g. for a 2011 census dataset, the year 2011 would be written "2011/2012"). Other forms of content e.g. ScholarlyArticle, Book, TVSeries or TVEpisode may indicate their temporalCoverage in broader terms - textually or via well-known URL.
+                     Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945".<br/><br/>
+
+               Open-ended date ranges can be written with ".." in place of the end date. For example, "2015-11/.." indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated. Supersedes <a   href="http://schema.org/datasetTimeInterval">datasetTimeInterval</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/text">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/text">text</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The textual content of this CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/thumbnailUrl">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/thumbnailUrl">thumbnailUrl</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A thumbnail image relevant to the Thing.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/timeRequired">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/timeRequired">timeRequired</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Duration" /><a   href="http://schema.org/Duration">Duration</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Approximate or typical time it takes to work with or through this learning resource for the typical intended target audience, e.g. 'PT30M', 'PT1H25M'.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/translationOfWork">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a title="Defined in extension: bib.schema.org"  class="ext ext-bib"  href="http://bib.localhost:8080/translationOfWork">translationOfWork</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The work that this work has been translated from. e.g. 物种起源 is a translationOf “On the Origin of Species”<br/> Inverse property: <a title="Defined in extension: bib.schema.org"  class="ext ext-bib"  href="http://bib.localhost:8080/workTranslation">workTranslation</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/translator">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/translator">translator</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"></td><td class="prop-desc" property="rdfs:comment">Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/typicalAgeRange">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/typicalAgeRange">typicalAgeRange</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"></td><td class="prop-desc" property="rdfs:comment">The typical expected age range, e.g. '7-9', '11-'.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/version">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/version">version</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Number" /><a   href="http://schema.org/Number">Number</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The version of the CreativeWork embodied by a specified resource.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/video">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/video">video</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Clip" /><a   href="http://schema.org/Clip">Clip</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/VideoObject" /><a   href="http://schema.org/VideoObject">VideoObject</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">An embedded video object.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/workExample">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/workExample">workExample</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Example/instance/realization/derivation of the concept of this creative work. eg. The paperback edition, first edition, or eBook.<br/> Inverse property: <a   href="http://schema.org/exampleOfWork">exampleOfWork</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/workTranslation">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a title="Defined in extension: bib.schema.org"  class="ext ext-bib"  href="http://bib.localhost:8080/workTranslation">workTranslation</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A work that is a translation of the content of this work. e.g. 西遊記 has an English workTranslation “Journey to the West”,a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese  translation Tây du ký bình khảo.<br/> Inverse property: <a title="Defined in extension: bib.schema.org"  class="ext ext-bib"  href="http://bib.localhost:8080/translationOfWork">translationOfWork</a>.</td></tr><tr class="supertype">
+                    <th class="supertype-name" colspan="3">Properties from <a   href="http://schema.org/Thing">Thing</a></th>
+
+               </tr>
+
+               <tbody class="supertype">
+                 <tr typeof="rdfs:Property" resource="http://schema.org/additionalType">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/additionalType">additionalType</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax - the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those defined externally.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/alternateName">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/alternateName">alternateName</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An alias for the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/description">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/description">description</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A description of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/disambiguatingDescription">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/identifier">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/identifier">identifier</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The identifier property represents any kind of identifier for any kind of <a class="localLink" href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/image">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/image">image</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/ImageObject" /><a   href="http://schema.org/ImageObject">ImageObject</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An image of the item. This can be a <a class="localLink" href="http://schema.org/URL">URL</a> or a fully described <a class="localLink" href="http://schema.org/ImageObject">ImageObject</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/mainEntityOfPage">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/> Inverse property: <a   href="http://schema.org/mainEntity">mainEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/name">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/name">name</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The name of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/potentialAction">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/potentialAction">potentialAction</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/Action" /><a   href="http://schema.org/Action">Action</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sameAs">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/sameAs">sameAs</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/subjectOf">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/subjectOf">subjectOf</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Event" /><a   href="http://schema.org/Event">Event</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A CreativeWork or Event about this Thing..<br/> Inverse property: <a   href="http://schema.org/about">about</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/url">
+
+                     <th class="prop-nam" scope="row">
+
+               <code property="rdfs:label"><a   href="http://schema.org/url">url</a></code>
+                   </th>
+                <td class="prop-ect">
+               <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of the item.</td></tr>
+
+               </table>
+               </section>
+            </div>
+         </div>
+      </div>
+      {% include footer.html %}
+
+
+
+   </body>
+</html>

--- a/_devTypes/SequenceMatchingModel.html
+++ b/_devTypes/SequenceMatchingModel.html
@@ -35,7 +35,7 @@ external: #454547;
             <div id="main-content-wrapper" class="outer">
                <section id="main_content" class="inner">
                   {% include type_start.html %}
-                  <table class="definition-table">
+                  <table class="definition-table bsc_type">
         <thead>
   <tr><th>Property</th><th>Expected Type</th><th>Description</th>
   </tr>

--- a/_devTypes/SequenceMatchingModel.html
+++ b/_devTypes/SequenceMatchingModel.html
@@ -7,7 +7,7 @@ dateModified: 2019-06-21
 description: 'A model used to determine sequence matches such as domains in proteins.'
 gh_examples:
 gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20SequenceMatchingModel
-group: protein
+group: proteins
 hierarchy:
 - Thing
 - CreativeWork

--- a/_devTypes/SequenceRange.html
+++ b/_devTypes/SequenceRange.html
@@ -1,0 +1,281 @@
+---
+redirect_from:
+- "/SequenceRange"
+dateModified: 2019-06-21
+description:
+hierarchy:
+- Thing
+- BioChemEntity
+gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20SequenceRange
+group: proteins
+name: SequenceRange
+parent_type: BioChemEntity
+spec_type: Type
+status: revision #Revert to revision when working on the next version
+version: '0.1-DRAFT'
+
+bsc: #0B794B;
+pending : #0000CC;
+external: #454547;
+
+---
+
+
+<!DOCTYPE HTML>
+<html>
+   {% include head.html %}
+   <body>
+      {% include header.html %}
+      {% include navbar.html %}
+      <div class="page-content">
+        <div class="wrapper">
+           <div id="main-content-wrapper" class="outer">
+              <section id="main_content" class="inner">
+                {% include type_start.html %}
+                <table class="definition-table">
+        <thead>
+  <tr><th>Property</th><th>Expected Type</th><th>Description</th>
+  </tr>
+  </thead>
+
+<tr class="supertype">
+     <th class="supertype-name" colspan="3">Properties from <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/SequenceRange">SequenceRange</a></th>
+
+</tr>
+
+<tbody class="supertype">
+  <tr typeof="rdfs:Property" resource="http://schema.org/endUncertainty">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#endUncertainty">endUncertainty</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/SequenceRange"></td><td class="prop-desc" property="rdfs:comment">If the initial position is not known with reasonable certainty, specify here the uncertainty type as one of '&lt;' (any position before than rangeEnd), '&gt;' (any position after rangeEnd), '~' (around rangeEnd), '[#-#] (to indicate a range where rangeEnd could be located)'.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/rangeEnd">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#rangeEnd">rangeStart</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Integer" /><a   href="http://schema.org/Integer">Integer</a>&nbsp;<link property="domainIncludes" href="http://schema.org/SequenceRange"></td><td class="prop-desc" property="rdfs:comment">Final position of the range</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/rangeStart">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#rangeStart">rangeStart</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Integer" /><a   href="http://schema.org/Integer">Integer</a>&nbsp;<link property="domainIncludes" href="http://schema.org/SequenceRange"></td><td class="prop-desc" property="rdfs:comment">Initial position of the range.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/startUncertainty">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#startUncertainty">startUncertainty</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/SequenceRange"></td><td class="prop-desc" property="rdfs:comment">If the initial position is not known with reasonable certainty, specify here the uncertainty type as one of '&lt;' (any position before than rangeStart), '&gt;' (any position after rangeStart), '~' (around the rangeStart), '[#-#] (to indicate a range where rangeStart could be located)'.</td></tr><tr class="supertype">
+                     <th class="supertype-name" colspan="3">Properties from <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a></th>
+
+                </tr>
+
+                <tbody class="supertype">
+                  <tr typeof="rdfs:Property" resource="http://schema.org/associatedDisease">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#associatedDisease">associatedDisease</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/MedicalCondition" /><a   href="http://schema.org/MedicalCondition">MedicalCondition</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Disease associated to this BioChemEntity. Such disease can be a MedicalCondition or a URL. If you want to add an evidence supporting the association, please use PropertyValue.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/bioChemInteraction">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#bioChemInteraction">bioChemInteraction</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A BioChemEntity that is known to interact with this item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/bioChemSimilarity">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#bioChemSimilarity">bioChemSimilarity</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A similar molecular entity, e.g., obtained by fingerprint similarity algorithms.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/biologicalRole">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#biologicalRole">biologicalRole</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A role played by the molecular entity within a biological context.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasBioChemEntityPart">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasBioChemEntityPart">hasBioChemEntityPart</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Indicates a BioChemEntity that (in some sense) has this BioChemEntity as a part.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isPartOfBioChemEntity">isPartOfBioChemEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasMolecularFunction">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasMolecularFunction">hasMolecularFunction</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Molecular function performed by this BioChemEntity; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasRepresentation">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasRepresentation">hasRepresentation</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A common representation such as a protein sequence or chemical structure for this entity. For images use schema.org/image.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasSequenceAnnotation">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasSequenceAnnotation">hasSequenceAnnotation</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/SequenceAnnotation" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/SequenceAnnotation">SequenceAnnotation</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Pointer to a sequence annotation; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isEncodedByBioChemEntity">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isEncodedByBioChemEntity">isEncodedByBioChemEntity</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/DNA" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/DNA">DNA</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Gene" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/Gene">Gene</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/RNA" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/RNA">RNA</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Another BioChemEntity encoding by this one.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#encodesBioChemEntity">encodesBioChemEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isInvolvedInBiologicalProcess">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isInvolvedInBiologicalProcess">isInvolvedInBiologicalProcess</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Biological process this BioChemEntity is involved in; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isLocatedInSubcellularLocation">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isLocatedInSubcellularLocation">isLocatedInSubcellularLocation</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Subcellular location where this BioChemEntity is located; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isMatchedBy">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isMatchedBy">isMatchedBy</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/SequenceMatchingModel" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/SequenceMatchingModel">SequenceMatchingModel</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A model matching this BioChemEntity.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isPartOfBioChemEntity">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isPartOfBioChemEntity">isPartOfBioChemEntity</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Indicates a BioChemEntity that is (in some sense) a part of this BioChemEntity.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasBioChemEntityPart">hasBioChemEntityPart</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/taxonomicRange">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#taxonomicRange">taxonomicRange</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Taxon" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/Taxon">Taxon</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"><link property="domainIncludes" href="http://schema.org/Phenotype"></td><td class="prop-desc" property="rdfs:comment">The taxonomic grouping of the organism that expresses, encodes, or in someway related to the BioChemEntity.</td></tr><tr class="supertype">
+                     <th class="supertype-name" colspan="3">Properties from <a   href="http://schema.org/Thing">Thing</a></th>
+
+                </tr>
+
+                <tbody class="supertype">
+                  <tr typeof="rdfs:Property" resource="http://schema.org/additionalType">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/additionalType">additionalType</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax - the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those defined externally.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/alternateName">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/alternateName">alternateName</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An alias for the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/description">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/description">description</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A description of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/disambiguatingDescription">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/identifier">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/identifier">identifier</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The identifier property represents any kind of identifier for any kind of <a class="localLink" href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/image">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/image">image</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/ImageObject" /><a   href="http://schema.org/ImageObject">ImageObject</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An image of the item. This can be a <a class="localLink" href="http://schema.org/URL">URL</a> or a fully described <a class="localLink" href="http://schema.org/ImageObject">ImageObject</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/mainEntityOfPage">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/> Inverse property: <a   href="http://schema.org/mainEntity">mainEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/name">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/name">name</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The name of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/potentialAction">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/potentialAction">potentialAction</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Action" /><a   href="http://schema.org/Action">Action</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sameAs">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/sameAs">sameAs</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/subjectOf">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/subjectOf">subjectOf</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Event" /><a   href="http://schema.org/Event">Event</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A CreativeWork or Event about this Thing..<br/> Inverse property: <a   href="http://schema.org/about">about</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/url">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/url">url</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of the item.</td></tr>
+
+                </table>
+               </section>
+             </div>
+           </div>
+      </div>
+      {% include footer.html %}
+
+
+
+   </body>
+</html>

--- a/_devTypes/SequenceRange.html
+++ b/_devTypes/SequenceRange.html
@@ -32,7 +32,7 @@ external: #454547;
            <div id="main-content-wrapper" class="outer">
               <section id="main_content" class="inner">
                 {% include type_start.html %}
-                <table class="definition-table">
+                <table class="definition-table bsc_type">
         <thead>
   <tr><th>Property</th><th>Expected Type</th><th>Description</th>
   </tr>

--- a/_devTypes/Study.html
+++ b/_devTypes/Study.html
@@ -3,17 +3,19 @@ redirect_from:
 - "devTypes/Study/specification"
 - "devTypes/Study/specification/"
 - "/devTypes/Study/"
-dateModified: 2018-11-13
+- "/Study"
+dateModified: 2019-06-21
 description: "Study"
 hierarchy:
 - Thing
+- CreativeWork
 gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Study
 group: studies
 name: Study
-parent_type: Thing
+parent_type: CreativeWork
 spec_type: Type
 status: revision
-version: '0.1-DRAFT'
+version: '0.2-DRAFT'
 
 bsc: #0B794B;
 pending: #0000CC;
@@ -35,146 +37,776 @@ external: #454547;
               <section id="main_content" class="inner">
                 {% include type_start.html %}
 
-                <table class="bioschemas_properties bsc_type">
-                   <thead>
-                      <tr>
-                         <th>Property</th>
-                         <th>Expected Type</th>
-                         <th>Description</th>
-                      </tr>
-                   </thead>
-                   <tbody>
-                     <tr class="new_props_sdo">
-                        <td colspan="3">
-                           Properties from <a style="color: #0B794B;" href="/{{page.name}}">{{page.name}}</a> (pending schema.org integration).
-                        </td>
-                     </tr>
-                     <tr class="reu_props_sdo">
-                        <td colspan="3">Properties from <a href="http://schema.org/Thing">Thing</a></td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/additionalType">additionalType</a></th>
-                       <td>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax.
-                         This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax -
-                         the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those
-                         defined externally.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/alternateName">alternateName</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         An alias for the item.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/description">description</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         A descripton of the item.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/identifier">identifier</a></th>
-                       <td>
-                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-                         <a href="http://schema.org/Text">Text</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         The identifier property represents any kind of identifier for any kind of <a href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc.
-                         Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links.
-                         See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/image">image</a></th>
-                       <td>
-                         <a href="http://schema.org/ImageObject">ImageObject</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         An image of the item. This can be a <a href="http://schema.org/URL">URL</a> or a fully described <a href="http://schema.org/ImageObject">ImageObject</a>.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></th>
-                       <td>
-                         <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See
-                         <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/>
-                         Inverse property: <a href="http://schema.org/mainEntity">mainEntity</a>
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/name">name</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         The name of the item.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/potentialAction">potentialAction</a></th>
-                       <td>
-                         <a href="http://schema.org/Action">Action</a>
-                       </td>
-                       <td>
-                         Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/sameAs">sameAs</a></th>
-                       <td>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a style="color: #0000CC;" href="http://pending.schema.org/subjectOf">subjectOf</a></th>
-                       <td>
-                         <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
-                         <a href="http://schema.org/Event">Event</a>
-                       </td>
-                       <td>
-                         A CreativeWork or Event about this Thing..<br/>
-                         Inverse property: <a href="http://schema.org/about">about</a>.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/url">url</a></th>
-                       <td>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         URL of the item.
-                       </td>
-                     </tr>
-                   </tbody>
-                 </table>
+                <table class="definition-table bsc_type">
+                          <thead>
+                    <tr><th>Property</th><th>Expected Type</th><th>Description</th>
+                    </tr>
+                    </thead>
+
+                  <tr class="supertype">
+                       <th class="supertype-name" colspan="3">Properties from <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/Study">Study</a></th>
+
+                  </tr>
+
+                  <tbody class="supertype">
+                    <tr typeof="rdfs:Property" resource="http://schema.org/studyDomain">
+
+                        <th class="prop-nam" scope="row">
+
+                  <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#studyDomain">studyDomain</a></code>
+                      </th>
+                   <td class="prop-ect">
+                  <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Study"></td><td class="prop-desc" property="rdfs:comment">Define the domain of the study. For example, the domain could be astrophysics, functional genomics or earth science. Those domains can also have an ontology reference.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/studyProcess">
+
+                        <th class="prop-nam" scope="row">
+
+                  <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#studyProcess">studyProcess</a></code>
+                      </th>
+                   <td class="prop-ect">
+                  <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Study"></td><td class="prop-desc" property="rdfs:comment">A process performed as part of an experiment or wider study, i.e. intentionally designed. These processes can have ontology URL attached to.</td></tr><tr class="supertype">
+                     <th class="supertype-name" colspan="3">Properties from <a   href="http://schema.org/CreativeWork">CreativeWork</a></th>
+
+                </tr>
+
+                <tbody class="supertype">
+                  <tr typeof="rdfs:Property" resource="http://schema.org/about">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/about">about</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Thing" /><a   href="http://schema.org/Thing">Thing</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CommunicateAction"><link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"></td><td class="prop-desc" property="rdfs:comment">The subject matter of the content.<br/> Inverse property: <a   href="http://schema.org/subjectOf">subjectOf</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accessMode">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/accessMode">accessMode</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The human sensory perceptual system or cognitive faculty through which a person may process or perceive information. Expected values include: auditory, tactile, textual, visual, colorDependent, chartOnVisual, chemOnVisual, diagramOnVisual, mathOnVisual, musicOnVisual, textOnVisual.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accessModeSufficient">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/accessModeSufficient">accessModeSufficient</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A list of single or combined accessModes that are sufficient to understand all the intellectual content of a resource. Expected values include:  auditory, tactile, textual, visual.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accessibilityAPI">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/accessibilityAPI">accessibilityAPI</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates that the resource is compatible with the referenced accessibility API (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accessibilityControl">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/accessibilityControl">accessibilityControl</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Identifies input methods that are sufficient to fully control the described resource (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accessibilityFeature">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/accessibilityFeature">accessibilityFeature</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Content features of the resource, such as accessible media, alternatives and supported enhancements for accessibility (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accessibilityHazard">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/accessibilityHazard">accessibilityHazard</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A characteristic of the described resource that is physiologically dangerous to some users. Related to WCAG 2.0 guideline 2.3 (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists possible values</a>).</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accessibilitySummary">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/accessibilitySummary">accessibilitySummary</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A human-readable summary of specific accessibility features or deficiencies, consistent with the other accessibility metadata but expressing subtleties such as "short descriptions are present but long descriptions will be needed for non-visual users" or "short descriptions are present and no long descriptions are needed."</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/accountablePerson">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/accountablePerson">accountablePerson</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Specifies the Person that is legally accountable for the CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/aggregateRating">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/aggregateRating">aggregateRating</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/AggregateRating" /><a   href="http://schema.org/AggregateRating">AggregateRating</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Brand"><link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/Offer"><link property="domainIncludes" href="http://schema.org/Organization"><link property="domainIncludes" href="http://schema.org/Place"><link property="domainIncludes" href="http://schema.org/Product"><link property="domainIncludes" href="http://schema.org/Service"></td><td class="prop-desc" property="rdfs:comment">The overall rating, based on a collection of reviews or ratings, of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/alternativeHeadline">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/alternativeHeadline">alternativeHeadline</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A secondary title of the CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/associatedMedia">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/associatedMedia">associatedMedia</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/MediaObject" /><a   href="http://schema.org/MediaObject">MediaObject</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A media object that encodes this CreativeWork. This property is a synonym for encoding.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/audience">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/audience">audience</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Audience" /><a   href="http://schema.org/Audience">Audience</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/LodgingBusiness"><link property="domainIncludes" href="http://schema.org/PlayAction"><link property="domainIncludes" href="http://schema.org/Product"><link property="domainIncludes" href="http://schema.org/Service"></td><td class="prop-desc" property="rdfs:comment">An intended audience, i.e. a group for whom something was created. Supersedes <a   href="http://schema.org/serviceAudience">serviceAudience</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/audio">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/audio">audio</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/AudioObject" /><a   href="http://schema.org/AudioObject">AudioObject</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Clip" /><a   href="http://schema.org/Clip">Clip</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">An embedded audio object.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/author">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/author">author</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Rating"></td><td class="prop-desc" property="rdfs:comment">The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/award">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/award">award</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Organization"><link property="domainIncludes" href="http://schema.org/Person"><link property="domainIncludes" href="http://schema.org/Product"><link property="domainIncludes" href="http://schema.org/Service"></td><td class="prop-desc" property="rdfs:comment">An award won by or for this item. Supersedes <a   href="http://schema.org/awards">awards</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/character">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/character">character</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Fictional person connected with a creative work.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/citation">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/citation">citation</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A citation or reference to another creative work, such as another publication, web page, scholarly article, etc.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/comment">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/comment">comment</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Comment" /><a   href="http://schema.org/Comment">Comment</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/RsvpAction"></td><td class="prop-desc" property="rdfs:comment">Comments, typically from users.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/commentCount">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/commentCount">commentCount</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Integer" /><a   href="http://schema.org/Integer">Integer</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The number of comments this CreativeWork (e.g. Article, Question or Answer) has received. This is most applicable to works published in Web sites with commenting system; additional comments may exist elsewhere.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/contentLocation">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/contentLocation">contentLocation</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Place" /><a   href="http://schema.org/Place">Place</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The location depicted or described in the content. For example, the location in a photograph or painting.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/contentRating">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/contentRating">contentRating</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Rating" /><a   href="http://schema.org/Rating">Rating</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Official rating of a piece of content&#x2014;for example,'MPAA PG-13'.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/contentReferenceTime">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/contentReferenceTime">contentReferenceTime</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/DateTime" /><a   href="http://schema.org/DateTime">DateTime</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The specific time described by a creative work, for works (e.g. articles, video objects etc.) that emphasise a particular moment within an Event.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/contributor">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/contributor">contributor</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"></td><td class="prop-desc" property="rdfs:comment">A secondary contributor to the CreativeWork or Event.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/copyrightHolder">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/copyrightHolder">copyrightHolder</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The party holding the legal copyright to the CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/copyrightYear">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/copyrightYear">copyrightYear</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Number" /><a   href="http://schema.org/Number">Number</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The year during which the claimed copyright for the CreativeWork was first asserted.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/correction">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/correction">correction</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CorrectionComment" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/CorrectionComment">CorrectionComment</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates a correction to a <a class="localLink" href="http://schema.org/CreativeWork">CreativeWork</a>, either via a <a class="localLink" href="http://schema.org/CorrectionComment">CorrectionComment</a>, textually or in another document.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/creator">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/creator">creator</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/UserComments"></td><td class="prop-desc" property="rdfs:comment">The creator/author of this CreativeWork. This is the same as the Author property for CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/dateCreated">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/dateCreated">dateCreated</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Date" /><a   href="http://schema.org/Date">Date</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/DateTime" /><a   href="http://schema.org/DateTime">DateTime</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioSample"><link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/DataFeedItem"></td><td class="prop-desc" property="rdfs:comment">The date on which the CreativeWork was created or the item was added to a DataFeed.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/dateModified">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/dateModified">dateModified</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Date" /><a   href="http://schema.org/Date">Date</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/DateTime" /><a   href="http://schema.org/DateTime">DateTime</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/DataFeedItem"></td><td class="prop-desc" property="rdfs:comment">The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/datePublished">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/datePublished">datePublished</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Date" /><a   href="http://schema.org/Date">Date</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Date of first broadcast/publication.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/discussionUrl">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/discussionUrl">discussionUrl</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A link to the page containing the comments of the CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/editor">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/editor">editor</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Specifies the Person who edited the CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/educationalAlignment">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/educationalAlignment">educationalAlignment</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/AlignmentObject" /><a   href="http://schema.org/AlignmentObject">AlignmentObject</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">An alignment to an established educational framework.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/educationalUse">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/educationalUse">educationalUse</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The purpose of a work in the context of education; for example, 'assignment', 'group work'.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/encoding">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/encoding">encoding</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/MediaObject" /><a   href="http://schema.org/MediaObject">MediaObject</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A media object that encodes this CreativeWork. This property is a synonym for associatedMedia. Supersedes <a   href="http://schema.org/encodings">encodings</a>.<br/> Inverse property: <a   href="http://schema.org/encodesCreativeWork">encodesCreativeWork</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/encodingFormat">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/encodingFormat">encodingFormat</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/MediaObject"></td><td class="prop-desc" property="rdfs:comment">Media type typically expressed using a MIME format (see <a href="http://www.iana.org/assignments/media-types/media-types.xhtml">IANA site</a> and <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MDN reference</a>) e.g. application/zip for a SoftwareApplication binary, audio/mpeg for .mp3 etc.).<br/><br/>
+
+                In cases where a <a class="localLink" href="http://schema.org/CreativeWork">CreativeWork</a> has several media type representations, <a class="localLink" href="http://schema.org/encoding">encoding</a> can be used to indicate each <a class="localLink" href="http://schema.org/MediaObject">MediaObject</a> alongside particular <a class="localLink" href="http://schema.org/encodingFormat">encodingFormat</a> information.<br/><br/>
+
+                Unregistered or niche encoding and file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia/Wikidata entry. Supersedes <a   href="http://schema.org/fileFormat">fileFormat</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/exampleOfWork">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/exampleOfWork">exampleOfWork</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A creative work that this work is an example/instance/realization/derivation of.<br/> Inverse property: <a   href="http://schema.org/workExample">workExample</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/expires">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/expires">expires</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Date" /><a   href="http://schema.org/Date">Date</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Date the content expires and is no longer useful or available. For example a <a class="localLink" href="http://schema.org/VideoObject">VideoObject</a> or <a class="localLink" href="http://schema.org/NewsArticle">NewsArticle</a> whose availability or relevance is time-limited, or a <a class="localLink" href="http://schema.org/ClaimReview">ClaimReview</a> fact check whose publisher wants to indicate that it may no longer be relevant (or helpful to highlight) after some date.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/funder">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/funder">funder</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/MonetaryGrant"><link property="domainIncludes" href="http://schema.org/Organization"><link property="domainIncludes" href="http://schema.org/Person"></td><td class="prop-desc" property="rdfs:comment">A person or organization that supports (sponsors) something through some kind of financial contribution.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/genre">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/genre">genre</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BroadcastChannel"><link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/MusicGroup"></td><td class="prop-desc" property="rdfs:comment">Genre of the creative work, broadcast channel or group.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasPart">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/hasPart">hasPart</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates an item or CreativeWork that is part of this item, or CreativeWork (in some sense).<br/> Inverse property: <a   href="http://schema.org/isPartOf">isPartOf</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/headline">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/headline">headline</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Headline of the article.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/inLanguage">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/inLanguage">inLanguage</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Language" /><a   href="http://schema.org/Language">Language</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CommunicateAction"><link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/LinkRole"><link property="domainIncludes" href="http://schema.org/WriteAction"></td><td class="prop-desc" property="rdfs:comment">The language of the content or performance or used in an action. Please use one of the language codes from the <a href="http://tools.ietf.org/html/bcp47">IETF BCP 47 standard</a>. See also <a class="localLink" href="http://schema.org/availableLanguage">availableLanguage</a>. Supersedes <a   href="http://schema.org/language">language</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/interactionStatistic">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/interactionStatistic">interactionStatistic</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/InteractionCounter" /><a   href="http://schema.org/InteractionCounter">InteractionCounter</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used. Supersedes <a   href="http://schema.org/interactionCount">interactionCount</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/interactivityType">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/interactivityType">interactivityType</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The predominant mode of learning supported by the learning resource. Acceptable values are 'active', 'expositive', or 'mixed'.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isAccessibleForFree">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/isAccessibleForFree">isAccessibleForFree</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Boolean" /><a   href="http://schema.org/Boolean">Boolean</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/Place"><link property="domainIncludes" href="http://schema.org/PublicationEvent"></td><td class="prop-desc" property="rdfs:comment">A flag to signal that the item, event, or place is accessible for free. Supersedes <a   href="http://schema.org/free">free</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isBasedOn">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/isBasedOn">isBasedOn</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Product" /><a   href="http://schema.org/Product">Product</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A resource from which this work is derived or from which it is a modification or adaption. Supersedes <a   href="http://schema.org/isBasedOnUrl">isBasedOnUrl</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isBasisFor">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/isBasisFor">isBasisFor</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A resource that was (somehow) created using this resource as a basis for.<br/> Inverse property: <a   href="http://schema.org/isBasedOn">isBasedOn</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isFamilyFriendly">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/isFamilyFriendly">isFamilyFriendly</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Boolean" /><a   href="http://schema.org/Boolean">Boolean</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates whether this content is family friendly.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isPartOf">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/isPartOf">isPartOf</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates an item or CreativeWork that this item, or CreativeWork (in some sense), is part of.<br/> Inverse property: <a   href="http://schema.org/hasPart">hasPart</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/keywords">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/keywords">keywords</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/learningResourceType">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/learningResourceType">learningResourceType</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The predominant type or kind characterizing the learning resource. For example, 'presentation', 'handout'.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/license">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/license">license</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A license document that applies to this content, typically indicated by URL.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/locationCreated">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/locationCreated">locationCreated</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Place" /><a   href="http://schema.org/Place">Place</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioSample"><link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The location where the CreativeWork was created, which may not be the same as the location depicted in the CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/mainEntity">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/mainEntity">mainEntity</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Thing" /><a   href="http://schema.org/Thing">Thing</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates the primary entity described in some page or other CreativeWork.<br/> Inverse property: <a   href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/material">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/material">material</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Product" /><a   href="http://schema.org/Product">Product</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Product"></td><td class="prop-desc" property="rdfs:comment">A material that something is made from, e.g. leather, wool, cotton, paper.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/materialExtent">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/materialExtent">materialExtent</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/QuantitativeValue" /><a   href="http://schema.org/QuantitativeValue">QuantitativeValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The quantity of the materials being described or an expression of the physical space they occupy.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/mentions">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/mentions">mentions</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Thing" /><a   href="http://schema.org/Thing">Thing</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/offers">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/offers">offers</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Offer" /><a   href="http://schema.org/Offer">Offer</a>&nbsp;<link property="domainIncludes" href="http://schema.org/AggregateOffer"><link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/MenuItem"><link property="domainIncludes" href="http://schema.org/Product"><link property="domainIncludes" href="http://schema.org/Service"><link property="domainIncludes" href="http://schema.org/Trip"></td><td class="prop-desc" property="rdfs:comment">An offer to provide this item&#x2014;for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/position">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/position">position</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Integer" /><a   href="http://schema.org/Integer">Integer</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/ListItem"></td><td class="prop-desc" property="rdfs:comment">The position of an item in a series or sequence of items.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/producer">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/producer">producer</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.).</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/provider">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/provider">provider</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Invoice"><link property="domainIncludes" href="http://schema.org/ParcelDelivery"><link property="domainIncludes" href="http://schema.org/Reservation"><link property="domainIncludes" href="http://schema.org/Service"><link property="domainIncludes" href="http://schema.org/Trip"></td><td class="prop-desc" property="rdfs:comment">The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller. Supersedes <a   href="http://schema.org/carrier">carrier</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/publication">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/publication">publication</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/PublicationEvent" /><a   href="http://schema.org/PublicationEvent">PublicationEvent</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A publication event associated with the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/publisher">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/publisher">publisher</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The publisher of the creative work.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/publisherImprint">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bib.schema.org"  class="ext ext-bib"  href="http://bib.localhost:8080/publisherImprint">publisherImprint</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The publishing division which published the comic.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/publishingPrinciples">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/publishingPrinciples">publishingPrinciples</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Organization"><link property="domainIncludes" href="http://schema.org/Person"></td><td class="prop-desc" property="rdfs:comment">The publishingPrinciples property indicates (typically via <a class="localLink" href="http://schema.org/URL">URL</a>) a document describing the editorial principles of an <a class="localLink" href="http://schema.org/Organization">Organization</a> (or individual e.g. a <a class="localLink" href="http://schema.org/Person">Person</a> writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a <a class="localLink" href="http://schema.org/CreativeWork">CreativeWork</a> (e.g. <a class="localLink" href="http://schema.org/NewsArticle">NewsArticle</a>) the principles are those of the party primarily responsible for the creation of the <a class="localLink" href="http://schema.org/CreativeWork">CreativeWork</a>.<br/><br/>
+
+                While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a <a class="localLink" href="http://schema.org/funder">funder</a>) can be expressed using schema.org terminology.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/recordedAt">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/recordedAt">recordedAt</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Event" /><a   href="http://schema.org/Event">Event</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event.<br/> Inverse property: <a   href="http://schema.org/recordedIn">recordedIn</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/releasedEvent">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/releasedEvent">releasedEvent</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/PublicationEvent" /><a   href="http://schema.org/PublicationEvent">PublicationEvent</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The place and time the release was issued, expressed as a PublicationEvent.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/review">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/review">review</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Review" /><a   href="http://schema.org/Review">Review</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Brand"><link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/Offer"><link property="domainIncludes" href="http://schema.org/Organization"><link property="domainIncludes" href="http://schema.org/Place"><link property="domainIncludes" href="http://schema.org/Product"><link property="domainIncludes" href="http://schema.org/Service"></td><td class="prop-desc" property="rdfs:comment">A review of the item. Supersedes <a   href="http://schema.org/reviews">reviews</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/schemaVersion">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/schemaVersion">schemaVersion</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates (by URL or string) a particular version of a schema used in some CreativeWork. For example, a document could declare a schemaVersion using an URL such as http://schema.org/version/2.0/ if precise indication of schema version was required by some application.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sdDatePublished">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/sdDatePublished">sdDatePublished</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Date" /><a   href="http://schema.org/Date">Date</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates the date on which the current structured data was generated / published. Typically used alongside <a class="localLink" href="http://schema.org/sdPublisher">sdPublisher</a></td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sdLicense">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/sdLicense">sdLicense</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A license document that applies to this structured data, typically indicated by URL.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sdPublisher">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/sdPublisher">sdPublisher</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Indicates the party responsible for generating and publishing the current structured data markup, typically in cases where the structured data is derived automatically from existing published content but published on a different site. For example, student projects and open data initiatives often re-publish existing content with more explicitly structured metadata. The
+                <a class="localLink" href="http://schema.org/sdPublisher">sdPublisher</a> property helps make such practices more explicit.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sourceOrganization">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/sourceOrganization">sourceOrganization</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The Organization on whose behalf the creator was working.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/spatial">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/spatial">spatial</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Place" /><a   href="http://schema.org/Place">Place</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The "spatial" property can be used in cases when more specific properties
+                (e.g. <a class="localLink" href="http://schema.org/locationCreated">locationCreated</a>, <a class="localLink" href="http://schema.org/spatialCoverage">spatialCoverage</a>, <a class="localLink" href="http://schema.org/contentLocation">contentLocation</a>) are not known to be appropriate.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/spatialCoverage">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/spatialCoverage">spatialCoverage</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Place" /><a   href="http://schema.org/Place">Place</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The spatialCoverage of a CreativeWork indicates the place(s) which are the focus of the content. It is a subproperty of
+                      contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates
+                      areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sponsor">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/sponsor">sponsor</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"><link property="domainIncludes" href="http://schema.org/Grant"><link property="domainIncludes" href="http://schema.org/MedicalStudy"><link property="domainIncludes" href="http://schema.org/Organization"><link property="domainIncludes" href="http://schema.org/Person"></td><td class="prop-desc" property="rdfs:comment">A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/temporal">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/temporal">temporal</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/DateTime" /><a   href="http://schema.org/DateTime">DateTime</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The "temporal" property can be used in cases where more specific properties
+                (e.g. <a class="localLink" href="http://schema.org/temporalCoverage">temporalCoverage</a>, <a class="localLink" href="http://schema.org/dateCreated">dateCreated</a>, <a class="localLink" href="http://schema.org/dateModified">dateModified</a>, <a class="localLink" href="http://schema.org/datePublished">datePublished</a>) are not known to be appropriate.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/temporalCoverage">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/temporalCoverage">temporalCoverage</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/DateTime" /><a   href="http://schema.org/DateTime">DateTime</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The temporalCoverage of a CreativeWork indicates the period that the content applies to, i.e. that it describes, either as a DateTime or as a textual string indicating a time period in <a href="https://en.wikipedia.org/wiki/ISO_8601#Time_intervals">ISO 8601 time interval format</a>. In
+                      the case of a Dataset it will typically indicate the relevant time period in a precise notation (e.g. for a 2011 census dataset, the year 2011 would be written "2011/2012"). Other forms of content e.g. ScholarlyArticle, Book, TVSeries or TVEpisode may indicate their temporalCoverage in broader terms - textually or via well-known URL.
+                      Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945".<br/><br/>
+
+                Open-ended date ranges can be written with ".." in place of the end date. For example, "2015-11/.." indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated. Supersedes <a   href="http://schema.org/datasetTimeInterval">datasetTimeInterval</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/text">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/text">text</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The textual content of this CreativeWork.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/thumbnailUrl">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/thumbnailUrl">thumbnailUrl</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A thumbnail image relevant to the Thing.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/timeRequired">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/timeRequired">timeRequired</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Duration" /><a   href="http://schema.org/Duration">Duration</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Approximate or typical time it takes to work with or through this learning resource for the typical intended target audience, e.g. 'PT30M', 'PT1H25M'.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/translationOfWork">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bib.schema.org"  class="ext ext-bib"  href="http://bib.localhost:8080/translationOfWork">translationOfWork</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The work that this work has been translated from. e.g. 物种起源 is a translationOf “On the Origin of Species”<br/> Inverse property: <a title="Defined in extension: bib.schema.org"  class="ext ext-bib"  href="http://bib.localhost:8080/workTranslation">workTranslation</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/translator">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/translator">translator</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Organization" /><a   href="http://schema.org/Organization">Organization</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Person" /><a   href="http://schema.org/Person">Person</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"></td><td class="prop-desc" property="rdfs:comment">Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/typicalAgeRange">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/typicalAgeRange">typicalAgeRange</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"><link property="domainIncludes" href="http://schema.org/Event"></td><td class="prop-desc" property="rdfs:comment">The typical expected age range, e.g. '7-9', '11-'.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/version">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/version">version</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Number" /><a   href="http://schema.org/Number">Number</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">The version of the CreativeWork embodied by a specified resource.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/video">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/video">video</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Clip" /><a   href="http://schema.org/Clip">Clip</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/VideoObject" /><a   href="http://schema.org/VideoObject">VideoObject</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">An embedded video object.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/workExample">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/workExample">workExample</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">Example/instance/realization/derivation of the concept of this creative work. eg. The paperback edition, first edition, or eBook.<br/> Inverse property: <a   href="http://schema.org/exampleOfWork">exampleOfWork</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/workTranslation">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a title="Defined in extension: bib.schema.org"  class="ext ext-bib"  href="http://bib.localhost:8080/workTranslation">workTranslation</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp;<link property="domainIncludes" href="http://schema.org/CreativeWork"></td><td class="prop-desc" property="rdfs:comment">A work that is a translation of the content of this work. e.g. 西遊記 has an English workTranslation “Journey to the West”,a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese  translation Tây du ký bình khảo.<br/> Inverse property: <a title="Defined in extension: bib.schema.org"  class="ext ext-bib"  href="http://bib.localhost:8080/translationOfWork">translationOfWork</a>.</td></tr><tr class="supertype">
+                     <th class="supertype-name" colspan="3">Properties from <a   href="http://schema.org/Thing">Thing</a></th>
+
+                </tr>
+
+                <tbody class="supertype">
+                  <tr typeof="rdfs:Property" resource="http://schema.org/additionalType">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/additionalType">additionalType</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax - the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those defined externally.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/alternateName">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/alternateName">alternateName</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An alias for the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/description">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/description">description</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A description of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/disambiguatingDescription">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/identifier">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/identifier">identifier</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The identifier property represents any kind of identifier for any kind of <a class="localLink" href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/image">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/image">image</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/ImageObject" /><a   href="http://schema.org/ImageObject">ImageObject</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An image of the item. This can be a <a class="localLink" href="http://schema.org/URL">URL</a> or a fully described <a class="localLink" href="http://schema.org/ImageObject">ImageObject</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/mainEntityOfPage">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/> Inverse property: <a   href="http://schema.org/mainEntity">mainEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/name">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/name">name</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The name of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/potentialAction">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/potentialAction">potentialAction</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/Action" /><a   href="http://schema.org/Action">Action</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sameAs">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/sameAs">sameAs</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/subjectOf">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/subjectOf">subjectOf</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Event" /><a   href="http://schema.org/Event">Event</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A CreativeWork or Event about this Thing..<br/> Inverse property: <a   href="http://schema.org/about">about</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/url">
+
+                      <th class="prop-nam" scope="row">
+
+                <code property="rdfs:label"><a   href="http://schema.org/url">url</a></code>
+                    </th>
+                 <td class="prop-ect">
+                <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of the item.</td></tr>
+
+                </table>
                </section>
              </div>
            </div>

--- a/css/stylesheet.css
+++ b/css/stylesheet.css
@@ -1076,8 +1076,13 @@ table.bioschemas_spec_list td {
     max-width: 20em;
 }
 
+.definition-table.bsc_type td
+{
+  max-width: 40em;
+}
+
 .bioschemas_properties.bsc_type td,
-.definition-table td
+.definition-table.bsc_type th
 {
     max-width: none;
 }

--- a/css/stylesheet.css
+++ b/css/stylesheet.css
@@ -1003,7 +1003,8 @@ Specification Properties
 }
 
 table.bioschemas_properties,
-table.bioschemas_spec_list {
+table.bioschemas_spec_list,
+table.definition-table {
     -webkit-box-shadow: none;
     -moz-box-shadow: none;
     box-shadow: none;
@@ -1021,6 +1022,7 @@ table.bioschemas_spec_list {
 }
 
 .bioschemas_properties tr,
+.definition-table tr,
 table.bioschemas_spec_list tr {
     display: table-row;
     vertical-align: inherit;
@@ -1029,6 +1031,7 @@ table.bioschemas_spec_list tr {
 }
 
 .bioschemas_properties th,
+.definition-table th,
 table.bioschemas_spec_list th {
     padding-left: 5px;
     background: #C7CBCE;
@@ -1042,22 +1045,26 @@ table.bioschemas_spec_list th {
 }
 
 .bioschemas_properties tbody th,
+.definition-table tbody th,
 table.bioschemas_spec_list th {
     text-align: left;
     vertical-align: top;
 }
 
 .bioschemas_properties th:first-child,
+.definition-table th:first-child,
 table.bioschemas_spec_list th:first-child {
     border-top-left-radius: 0;
 }
 
 .bioschemas_properties th:last-child,
+.definition-table th:last-child,
 table.bioschemas_spec_list th:last-child {
     border-top-right-radius: 0;
 }
 
 .bioschemas_properties td,
+.definition-table td,
 table.bioschemas_spec_list td {
     border: 0;
     padding: 0.625em;
@@ -1069,7 +1076,9 @@ table.bioschemas_spec_list td {
     max-width: 20em;
 }
 
-.bioschemas_properties.bsc_type td {
+.bioschemas_properties.bsc_type td,
+.definition-table td
+{
     max-width: none;
 }
 
@@ -1082,7 +1091,8 @@ table.bioschemas_spec_list td {
 }
 
 .bioschemas_properties .new_props_sdo td a,
-.bioschemas_properties .new_props_sdo td a:link {
+.bioschemas_properties .new_props_sdo td a:link
+ {
     color: #0B794B;
 }
 
@@ -1099,6 +1109,7 @@ table.bioschemas_spec_list td {
 }
 
 .bioschemas_properties a,
+.definition-table a,
 table.bioschemas_spec_list a {
     color: #660000;
     text-decoration: none;
@@ -1115,7 +1126,9 @@ table.bioschemas_spec_list td a img {
     width: 3.7em;
 }
 
-.bioschemas_properties a:link {
+.bioschemas_properties a:link,
+.definition-table a:link
+{
     color: #990000;
     text-decoration: none;
     border-bottom: dotted 1px #990000;
@@ -1181,14 +1194,17 @@ input:checked+label {
 Style experiment
 *******************************************************************************/
 
-table.bioschemas_properties a.externalProp {
+table.bioschemas_properties a.externalProp,
+table.definition-table a.externalProp {
     color: #454547;
 }
 
-table.bioschemas_properties a.newBsc {
+table.bioschemas_properties a.newBsc,
+table.definition-table a.ext-bio  {
     color: #0B794B;
 }
 
-table.bioschemas_properties a.pending {
+table.bioschemas_properties a.pending,
+table.definition-table a.ext-pending {
     color: #0000CC;
 }

--- a/types/drafts.html
+++ b/types/drafts.html
@@ -13,8 +13,6 @@ redirect_from:
 <h2>Types</h2>
 <p>Schema.org describes ‘types’ of information, which then have ‘properties’. The types are things that we can talk about and the properties are the things that we can say about the type. We have found it necessary to propose some additional types to the Schema.org vocabulary to describe life sciences resources. These are specified below and are expected to be pushed up to Schema.org once they have stabalised.</p>
 
-<p><u>Note:</u> this list is currently incomplete. Other types are under consideration and will be added below. These include BioChemStructure, Enzyme, RNA, SequenceAnnotation, SequenceMatchingModel, and SequenceRange.</p>
-
 <table class="bioschemas_spec_list" style="width: 100%; margin-left: auto; margin-right: auto; text-align: center;">
     <thead>
         <tr>

--- a/types/drafts.html
+++ b/types/drafts.html
@@ -6,9 +6,9 @@ redirect_from:
 ---
 
 <h1>Draft Bioschemas Types</h1>
-<p>The types on this page are a work in progress. We would be delighted to receive your comments on these specifications
-    (<a href="mailto:public-bioschemas@w3.org" itemprop="email">public-bioschemas@w3.org</a>).</p>
-<p>The release candidate set of types can be found on the <a href="/types">types page</a>.</p>
+<p>The types on this page are a work in progress. We would be delighted to receive your comments on these specifications either through the mailing list
+    (<a href="mailto:public-bioschemas@w3.org" itemprop="email">public-bioschemas@w3.org</a>) or via our <a href="https://github.com/BioSchemas/specifications/issues">GitHub issue tracker</a>.</p>
+<p>The set of types that have reached release candidate status can be found on the <a href="/types">types page</a>.</p>
 
 <h2>Types</h2>
 <p>Schema.org describes ‘types’ of information, which then have ‘properties’. The types are things that we can talk about and the properties are the things that we can say about the type. We have found it necessary to propose some additional types to the Schema.org vocabulary to describe life sciences resources. These are specified below and are expected to be pushed up to Schema.org once they have stabalised.</p>


### PR DESCRIPTION
These commits take the latest revisions of the draft types that were not included in the first release to schema.org and includes them on the draft types page.

The text on the draft types page has been updated to reflect the inclusion of these types.