### PR TITLE
updating LD: adding cosmic as DS + alliance genome as gene

### DIFF
--- a/_liveDeploys/liveDeploy.md
+++ b/_liveDeploys/liveDeploy.md
@@ -563,4 +563,22 @@ list:
     bsc_profile: Dataset
     bsc_ver: 0.2
     comments:
+-
+    name: COSMIC Gene at Sanger
+    highlight:
+    example_URL: http://cancer.sanger.ac.uk/cosmic/
+    resource_URL: http://cancer.sanger.ac.uk/cosmic/
+    schema_org: Dataset
+    bsc_profile: Dataset
+    bsc_ver: 
+    comments:    
+-
+    name: Alliance of Genome Resources
+    highlight: Provides MGI, FlyBase, RGD, WormBase, SGD and Zfin
+    example_URL: https://www.alliancegenome.org/gene/MGI:2442292
+    resource_URL: https://www.alliancegenome.org
+    schema_org: Gene
+    bsc_profile: Gene
+    bsc_ver: 0.5
+    comments:       
 ---


### PR DESCRIPTION
Tackling https://github.com/BioSchemas/specifications/issues/293#issuecomment-502840047

Comments:
1. COSMIC have the same markup on every page. In this they describe a Dataset that is not compliant with any of our versions. I've added it but without the version number.

2. 11 of the items in the list are OMICSDI republishing other sources and adding schema markup, eg, *ArrayExpress through OmicsDI*. All of these pages only have ItemPage; so ignoring

3. The other main provider is *Alliance of Genome Resources* (eg, *FlyBase through the Alliance of Genome Resources*) these all provide Gene, Organization, WebSite and Dataset. AoGR features 6 times in the list, but it really just 1 resource. None of the original publishers (eg FlyBase) seem to have any schema markup.
    * We already have AoGR with Dataset on the live deploy page.
    * I have added AoGR as a Gene, but I'm not sure about this as they are using Dataset to mean the actual data on the page. I.e., each page features one gene, and that gene is described in both Gene and Dataset. Have a look at [this](https://search.google.com/structured-data/testing-tool#url=https%3A%2F%2Fwww.alliancegenome.org%2Fgene%2FWB%3AWBGene00000001). Notice that Dataset is a superset of Gene. Dataset just adds @ id, keywords, version, license, includedInDataCatalog and creator. As each gene has its own Dataset, they must have nearly 100K Datasets!

4. I'm ignoring Kaggle as it is not a life science resource. However, if you wish I can find a health related dataset and use it. Perhaps [this](https://search.google.com/structured-data/testing-tool#url=https%3A%2F%2Fwww.kaggle.com%2Fronitf%2Fheart-disease-uci)? There are far more non life science datasets than life sciences ones, so it does seem a stretch claiming it.

5. Others we already have (eg MobiDB) or they have just schema.org.
