### PR TITLE
Live deploy add node cdr edd

### DIFF
--- a/_liveDeploys/liveDeploy.md
+++ b/_liveDeploys/liveDeploy.md
@@ -7,15 +7,6 @@ type: liveDeploy
 description: Services/sites implementing Bioschemas's markup
 list:
 -
-    name: Identifiers
-    highlight:
-    example_URL: http://identifiers.org/
-    resource_URL: http://identifiers.org/
-    schema_org: DataCatalog
-    bsc_profile: DataCatalog
-    bsc_ver: 0.1
-    comments: Could implement Dataset and DataRecord as well.
--
     name: Fairsharing
     highlight:
     example_URL: https://fairsharing.org/
@@ -42,6 +33,8 @@ list:
     bsc_profile: DataCatalog
     bsc_ver: 0.1
     comments: Could implement Dataset and DataRecord as well.
+    node: SE
+    type: CDR
 -
     name: EGA
     highlight:
@@ -51,6 +44,7 @@ list:
     bsc_profile: DataCatalog
     bsc_ver: 0.1
     comments:
+    node: EBI
 -
     name: Isaexplorer
     highlight:
@@ -78,6 +72,7 @@ list:
     bsc_profile: Dataset
     bsc_ver: 0.1
     comments:
+    node: EBI
 -
     name: MobiDB
     highlight:
@@ -87,6 +82,7 @@ list:
     bsc_profile: DataCatalog
     bsc_ver: 0.1
     comments:
+    node: IT
 -
     name: MobiDB
     highlight:
@@ -96,6 +92,7 @@ list:
     bsc_profile: Dataset
     bsc_ver: 0.2
     comments: Can implement DataRecord type.
+    node: IT
 -
     name: Biosamples
     highlight:
@@ -105,6 +102,8 @@ list:
     bsc_profile: DataCatalog
     bsc_ver: 0.1
     comments:
+    node: EBI    
+    type: EDD    
 -
     name: Biosamples
     highlight: 10 million+ pages
@@ -114,6 +113,8 @@ list:
     bsc_profile: Sample
     bsc_ver: 0.1
     comments:
+    node: EBI
+    type: EDD
 -
     name: DataMed
     highlight:
@@ -177,6 +178,7 @@ list:
     bsc_profile: Event
     bsc_ver: 0.1
     comments:    
+    node: UK
 -
     name: PDBe
     highlight: 140,000+ pages
@@ -186,6 +188,7 @@ list:
     bsc_profile: ProteinStructure
     bsc_ver: 0.1
     comments:
+    node: EBI
 -
     name: PDBe
     highlight: 214,000+ pages
@@ -195,6 +198,7 @@ list:
     bsc_profile: Protein
     bsc_ver: 0.1
     comments:    
+    node: EBI    
 -
     name: French Institute of Bioinformatics (IFB) Events
     highlight:
@@ -203,7 +207,8 @@ list:
     schema_org: Event
     bsc_profile: Event
     bsc_ver: 0.1
-    comments:     
+    comments:  
+    node: FR   
 -
     name: ELIXIR Portugal Events
     highlight:
@@ -213,6 +218,7 @@ list:
     bsc_profile: Event
     bsc_ver: 0.1
     comments:     
+    node: PT
 -
     name: SIB Events
     highlight:
@@ -222,6 +228,7 @@ list:
     bsc_profile: Event
     bsc_ver: 0.1
     comments:   
+    node: CH
 -
     name: ELIXIR Events
     highlight:
@@ -240,6 +247,7 @@ list:
     bsc_profile: Event
     bsc_ver: 0.1
     comments:
+    node: UK
 -
     name: HmmerWeb
     highlight: Result of searches are annotated (results last 1 week)
@@ -249,6 +257,7 @@ list:
     bsc_profile: Protein
     bsc_ver: 0.1
     comments:
+    node: EBI
 -
     name: HmmerWeb
     highlight: Result of searches are annotated (results last 1 week)
@@ -258,6 +267,7 @@ list:
     bsc_profile: ProteinStructure
     bsc_ver: 0.1
     comments:
+    node: EBI    
 -
     name: HmmerWeb
     highlight: Result of searches are annotated (results last 1 week)
@@ -266,7 +276,8 @@ list:
     schema_org:
     bsc_profile: ProteinAnnotation
     bsc_ver: 0.1
-    comments:         
+    comments:     
+    node: EBI        
 -
     name: Galaxy Project
     highlight:
@@ -284,6 +295,7 @@ list:
     bsc_profile: Dataset
     bsc_ver: 0.1
     comments:
+    node: EBI
 -
     name: CATH-Gene3D
     highlight:
@@ -293,15 +305,19 @@ list:
     bsc_profile: Dataset
     bsc_ver: 0.1
     comments:
+    node: UK
+    type: CDR & EDD
 -
     name: CATH-Gene3D
-    highlight:
+    highlight: 
     example_URL: http://www.cathdb.info
     resource_URL: http://www.cathdb.info
     schema_org: DataCatalog
     bsc_profile: DataCatalog
     bsc_ver: 0.1
     comments:  
+    node: UK
+    type: CDR & EDD  
 -
     name: The Molecular INTeraction Database (MINT)
     highlight:
@@ -311,6 +327,8 @@ list:
     bsc_profile: DataCatalog
     bsc_ver: 0.1
     comments:    
+    node: IT
+    type: CDR
 -
     name: The Molecular INTeraction Database (MINT)
     highlight:
@@ -320,6 +338,8 @@ list:
     bsc_profile: Dataset
     bsc_ver: 0.1
     comments:        
+    node: IT    
+    type: CDR    
 -
     name: DEB Register
     highlight:
@@ -410,6 +430,8 @@ list:
     bsc_profile: Dataset
     bsc_ver: 0.2
     comments:
+    node: EBI    
+    type: CDR
 -
     name: ChEMBL
     highlight:
@@ -419,6 +441,7 @@ list:
     bsc_profile: MolecularEntity
     bsc_ver: 0.2-draft
     comments:
+    node: EBI
 -
     name: Alliance of Genome Resources
     highlight:
@@ -437,6 +460,7 @@ list:
     bsc_profile: DataCatalog
     bsc_ver: 0.1
     comments:  
+    node: CH
 -
     name: SWISS-MODEL Repository
     highlight: 12 Datasets
@@ -446,6 +470,7 @@ list:
     bsc_profile: Dataset
     bsc_ver: 0.2
     comments:  
+    node: CH 
 -
     name: SWISS-MODEL
     highlight:
@@ -455,6 +480,7 @@ list:
     bsc_profile: Tool
     bsc_ver: 0.1
     comments:  
+    node: CH    
 -
     name: ModelArchive
     highlight:
@@ -482,6 +508,7 @@ list:
     bsc_profile: DataCatalog
     bsc_ver: 0.1
     comments:
+    type: CDR & EDD
 -
     name: ENZYME - The Enzyme Data Bank
     highlight: 4450 datasets
@@ -518,6 +545,8 @@ list:
     bsc_profile: Dataset
     bsc_ver: 0.2
     comments:
+    node: EBI
+    type: CDR
 -
     name: Ensembl Genome Browser
     highlight:
@@ -527,6 +556,8 @@ list:
     bsc_profile: DataCatalog
     bsc_ver: 0.2
     comments:
+    node: EBI
+    type: CDR
 -
     name: ITSoneDB
     highlight:
@@ -536,6 +567,7 @@ list:
     bsc_profile: DataCatalog
     bsc_ver: 0.2
     comments:
+    node: IT
 -
     name: ITSOneDB Marine
     highlight:
@@ -545,6 +577,7 @@ list:
     bsc_profile: Dataset
     bsc_ver: 0.2
     comments:
+    node: IT
 -
     name: ITSoneDB Eukaryotic
     highlight:
@@ -554,6 +587,7 @@ list:
     bsc_profile: Dataset
     bsc_ver: 0.2
     comments:
+    node: IT
 -
     name: Global Biodiversity Information Facility
     highlight:

--- a/_liveDeploys/liveDeploy.md
+++ b/_liveDeploys/liveDeploy.md
@@ -113,7 +113,7 @@ list:
     bsc_ver: 0.1
     comments:
     node: EBI    
-    type: EDD    
+    type: DDR    
 -
     name: Biosamples
     highlight: 10 million+ pages
@@ -124,7 +124,7 @@ list:
     bsc_ver: 0.1
     comments:
     node: EBI
-    type: EDD
+    type: DDR
 -
     name: DataMed
     highlight:
@@ -316,7 +316,7 @@ list:
     bsc_ver: 0.1
     comments:
     node: UK
-    type: CDR & EDD
+    type: CDR & DDR
 -
     name: CATH-Gene3D
     highlight: 
@@ -327,7 +327,7 @@ list:
     bsc_ver: 0.1
     comments:  
     node: UK
-    type: CDR & EDD  
+    type: CDR & DDR  
 -
     name: The Molecular INTeraction Database (MINT)
     highlight:
@@ -518,7 +518,7 @@ list:
     bsc_profile: DataCatalog
     bsc_ver: 0.1
     comments:
-    type: CDR & EDD
+    type: CDR & DDR
 -
     name: ENZYME - The Enzyme Data Bank
     highlight: 4450 datasets

--- a/_liveDeploys/liveDeploy.md
+++ b/_liveDeploys/liveDeploy.md
@@ -7,6 +7,16 @@ type: liveDeploy
 description: Services/sites implementing Bioschemas's markup
 list:
 -
+    name: Identifiers
+    highlight:
+    example_URL: https://ebi.identifiers.org/
+    resource_URL: https://ebi.identifiers.org/
+    schema_org: DataCatalog
+    bsc_profile: DataCatalog
+    bsc_ver: 0.1
+    node: EBI    
+    comments: 
+-
     name: Fairsharing
     highlight:
     example_URL: https://fairsharing.org/

--- a/_sass/_live-deploys.scss
+++ b/_sass/_live-deploys.scss
@@ -163,7 +163,7 @@
 	p.nodeText {
 		padding: 0;
 		margin: 0 10px 0;
-		font-size: 10px;
+		font-size: 12px;
 		line-height : 14px;
 	}    
 
@@ -171,7 +171,7 @@
 		font-style: italic;
 		padding: 0;
 		margin: 0 10px 0;
-		font-size: 10px;	
+		font-size: 12px;	
 		line-height : 14px;	
 	}	
 }

--- a/_sass/_live-deploys.scss
+++ b/_sass/_live-deploys.scss
@@ -159,4 +159,19 @@
         box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
         padding: 1em;
     }
+    
+	p.nodeText {
+		padding: 0;
+		margin: 0 10px 0;
+		font-size: 10px;
+		line-height : 14px;
+	}    
+
+	p.highlightsText {
+		font-style: italic;
+		padding: 0;
+		margin: 0 10px 0;
+		font-size: 10px;	
+		line-height : 14px;	
+	}	
 }

--- a/liveDeploys/elixir.html
+++ b/liveDeploys/elixir.html
@@ -32,11 +32,11 @@ description: |-
                 </tr>
             </thead>
       		<tbody>
-            {% assign groups = liveDeploys.list | group_by: 'node' | sort: 'name' %}
+            {% assign groups = liveDeploys.list | group_by: 'node' | where_exp: "name", "name != nil" | sort: 'name' %}
             {% for group in groups %}
+	        <p>{{ forloop.index}} *** {{group.name }}</p>
             {% assign group_index = forloop.index %}
-            {% if group_index == 1%}
-            <!-- do not show resources with no node; need better way of doing this - can't get where to work in above assign statement -->
+            {% if group_index == 1%}            
             {% elsif group_index == 2%}
             <tr class="profile-row" style="cursor: pointer;" data-toggle="collapse" data-target=".collapse{{group.name}}" aria-expanded="true" aria-controls="collapse{{group.name}}">
                 <td colspan="3">
@@ -45,6 +45,7 @@ description: |-
                     <div class="plus-icon"><i class="fas fa-minus fa-lg"></i></div>
                 </td>
             </tr>
+ 
             {% else %}
             <tr class="profile-row collapsed" style="cursor: pointer;" data-toggle="collapse" data-target=".collapse{{group.name}}" aria-expanded="false" aria-controls="collapse{{group.name}}">
                 <td colspan="3">
@@ -62,7 +63,9 @@ description: |-
 
         	<tr>
                 <td class="deploy-name-column hidden-row">
-                    {% if profile_index == 1%}
+                	{% if group_index == 1%}
+                
+                    {% elsif group_index == 2%}
                     <div class="collapse show collapse{{group.name}} ">
                     {% else %}
                     <div class="collapse collapse{{group.name}} ">
@@ -72,7 +75,8 @@ description: |-
                     </div>
                 </td>
                 <td class="profile-version hidden-row">
-                    {% if profile_index == 1%}
+	                {% if group_index == 1%}
+                    {% elsif group_index == 2%}
                     <div class="collapse show collapse{{group.name}}">
                     {% else %}
                     <div class="collapse collapse{{group.name}}">
@@ -82,7 +86,9 @@ description: |-
                 </td>
                 <td class="structured-data-column hidden-row">
                     {% if live.example_URL != nil %}
-                    {% if profile_index == 1%}
+                    {% if group_index == 1%}
+                    
+                    {% elsif group_index == 2%}
                     <div class="collapse show collapse{{group.name}}">
                     {% else %}
                     <div class="collapse collapse{{group.name}}">

--- a/liveDeploys/elixir.html
+++ b/liveDeploys/elixir.html
@@ -35,14 +35,6 @@ description: |-
             {% for group in groups %}
             {% assign group_index = forloop.index %}
             {% if group_index == 1%}            
-            {% elsif group_index == 2%}
-            <tr class="profile-row" style="cursor: pointer;" data-toggle="collapse" data-target=".collapse{{group.name}}" aria-expanded="true" aria-controls="collapse{{group.name}}">
-                <td colspan="4">
-                    <div class="repo-count"><strong>{{group.items | size}}</strong></div>
-                    {{group.name}}<br>
-                    <div class="plus-icon"><i class="fas fa-minus fa-lg"></i></div>
-                </td>
-            </tr>
  
             {% else %}
             <tr class="profile-row collapsed" style="cursor: pointer;" data-toggle="collapse" data-target=".collapse{{group.name}}" aria-expanded="false" aria-controls="collapse{{group.name}}">
@@ -62,9 +54,7 @@ description: |-
         	<tr>
                 <td class="deploy-name-column hidden-row">
                 	{% if group_index == 1%}
-                
-                    {% elsif group_index == 2%}
-                    <div class="collapse show collapse{{group.name}} ">
+            
                     {% else %}
                     <div class="collapse collapse{{group.name}} ">
                     {% endif %}
@@ -76,8 +66,7 @@ description: |-
                 </td>
                 <td class="profile hidden-row">
 	                {% if group_index == 1%}
-                    {% elsif group_index == 2%}
-                    <div class="collapse show collapse{{group.name}}">
+
                     {% else %}
                     <div class="collapse collapse{{group.name}}">
                     {% endif %}
@@ -86,8 +75,7 @@ description: |-
                 </td>                
                 <td class="profile-version hidden-row">
 	                {% if group_index == 1%}
-                    {% elsif group_index == 2%}
-                    <div class="collapse show collapse{{group.name}}">
+
                     {% else %}
                     <div class="collapse collapse{{group.name}}">
                     {% endif %}
@@ -96,10 +84,8 @@ description: |-
                 </td>
                 <td class="structured-data-column hidden-row">
                     {% if live.example_URL != nil %}
-                    {% if group_index == 1%}
-                    
-                    {% elsif group_index == 2%}
-                    <div class="collapse show collapse{{group.name}}">
+                    {% if group_index == 1%}                    
+
                     {% else %}
                     <div class="collapse collapse{{group.name}}">
                     {% endif %}

--- a/liveDeploys/elixir.html
+++ b/liveDeploys/elixir.html
@@ -21,12 +21,11 @@ description: |-
             <div class="col-md-8">
     <section class="live-deploy-table">
     	<h5>Elixir resources using Bioschema's markup</h5>
-        <!-- <h5>{{liveDeploys.description}}</h5> -->
-        <!-- <p><strong>{{elixirLD.list | size}}</strong> Elixir resources using Bioschemas.</p> -->
         <table>
             <thead>
                 <tr>
                     <th>Name</th>
+                    <th>Profile</th>
                     <th>Profile Version</th>
                     <th class="structured-data-column">Structured Data Testing Tool</th>
                 </tr>
@@ -34,12 +33,11 @@ description: |-
       		<tbody>
             {% assign groups = liveDeploys.list | group_by: 'node' | where_exp: "name", "name != nil" | sort: 'name' %}
             {% for group in groups %}
-	        <p>{{ forloop.index}} *** {{group.name }}</p>
             {% assign group_index = forloop.index %}
             {% if group_index == 1%}            
             {% elsif group_index == 2%}
             <tr class="profile-row" style="cursor: pointer;" data-toggle="collapse" data-target=".collapse{{group.name}}" aria-expanded="true" aria-controls="collapse{{group.name}}">
-                <td colspan="3">
+                <td colspan="4">
                     <div class="repo-count"><strong>{{group.items | size}}</strong></div>
                     {{group.name}}<br>
                     <div class="plus-icon"><i class="fas fa-minus fa-lg"></i></div>
@@ -48,7 +46,7 @@ description: |-
  
             {% else %}
             <tr class="profile-row collapsed" style="cursor: pointer;" data-toggle="collapse" data-target=".collapse{{group.name}}" aria-expanded="false" aria-controls="collapse{{group.name}}">
-                <td colspan="3">
+                <td colspan="4">
                     <div class="repo-count"><strong>{{group.items | size}}</strong></div>
                    
                     {{group.name}}<br>                   
@@ -71,9 +69,21 @@ description: |-
                     <div class="collapse collapse{{group.name}} ">
                     {% endif %}
                         <a href="{{live.resource_URL}}" target="_blank">{{live.name}}</a>
-                        <p class="nodeText"><em>profile</em>: {{live.bsc_profile}} {% if live.type != nil %}  <em>type</em>: {{live.type}} {% endif %}<p>                   	
+                        {% if live.type != nil %}
+                        <p class="nodeText"><em>type</em>: {{live.type}}<p>                   	
+                        {% endif %}
                     </div>
                 </td>
+                <td class="profile hidden-row">
+	                {% if group_index == 1%}
+                    {% elsif group_index == 2%}
+                    <div class="collapse show collapse{{group.name}}">
+                    {% else %}
+                    <div class="collapse collapse{{group.name}}">
+                    {% endif %}
+                    {{live.bsc_profile}}
+                    </div>
+                </td>                
                 <td class="profile-version hidden-row">
 	                {% if group_index == 1%}
                     {% elsif group_index == 2%}

--- a/liveDeploys/elixir.html
+++ b/liveDeploys/elixir.html
@@ -1,0 +1,114 @@
+---
+layout: default
+title: Live Deploys
+description: |-
+    Below we list the ELIXIR services/sites that use [Bioschemas](https://bioschemas.org) markup to describe what they are offering. We provide a direct link to the site and also a link to Google's [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool) visualisation of the site's markup.
+    The link to Google’s SDTT shows one example from the site; however, many more may exist. For example, Biosamples have marked up all of their content (currently over 10 million samples).
+    Please remember that Google sets minimum requirements for [schema.org](https://schema.org) markup, which may conflict with those of [Bioschemas](https://bioschemas.org). As such, Google's [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool) may provide warnings or errors when the markup is perfectly compliant with both [schema.org](http://schema.org) and [Bioschemas](http://bioschemas.org).
+    If your Bioschemas compliant site is not listed below, please email us at [enquiries@bioschemas.org](mailto:enquiries@bioschemas.org).
+    
+    To view the full live deploys page, with non-ELIXIR resources includes, [click here](../liveDeploys).
+---
+<div class="live-deploys">
+
+    <h1>Live deploys</h1>
+    <p>{{page.description | markdownify}}</p>
+    <br>
+ 	{% assign liveDeploys = site.liveDeploys | where:"name", 'Live Deploys' | first %}
+    <div class="container-flow">
+        <div class="row">
+
+            <div class="col-md-8">
+    <section class="live-deploy-table">
+    	<h5>Elixir resources using Bioschema's markup</h5>
+        <!-- <h5>{{liveDeploys.description}}</h5> -->
+        <!-- <p><strong>{{elixirLD.list | size}}</strong> Elixir resources using Bioschemas.</p> -->
+        <table>
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Profile Version</th>
+                    <th class="structured-data-column">Structured Data Testing Tool</th>
+                </tr>
+            </thead>
+      		<tbody>
+            {% assign groups = liveDeploys.list | group_by: 'node' | sort: 'name' %}
+            {% for group in groups %}
+            {% assign group_index = forloop.index %}
+            {% if group_index == 1%}
+            <!-- do not show resources with no node; need better way of doing this - can't get where to work in above assign statement -->
+            {% elsif group_index == 2%}
+            <tr class="profile-row" style="cursor: pointer;" data-toggle="collapse" data-target=".collapse{{group.name}}" aria-expanded="true" aria-controls="collapse{{group.name}}">
+                <td colspan="3">
+                    <div class="repo-count"><strong>{{group.items | size}}</strong></div>
+                    {{group.name}}<br>
+                    <div class="plus-icon"><i class="fas fa-minus fa-lg"></i></div>
+                </td>
+            </tr>
+            {% else %}
+            <tr class="profile-row collapsed" style="cursor: pointer;" data-toggle="collapse" data-target=".collapse{{group.name}}" aria-expanded="false" aria-controls="collapse{{group.name}}">
+                <td colspan="3">
+                    <div class="repo-count"><strong>{{group.items | size}}</strong></div>
+                   
+                    {{group.name}}<br>                   
+                    <div class="plus-icon"><i class="fas fa-plus fa-lg"></i></div>
+                </td>
+            </tr>              
+            {% endif %}   
+            
+            {% assign live_sorted_list = group.items | sort: 'node' | uniq %}
+            {% for live in live_sorted_list %}
+            {% if live.node != nil %}
+
+        	<tr>
+                <td class="deploy-name-column hidden-row">
+                    {% if profile_index == 1%}
+                    <div class="collapse show collapse{{group.name}} ">
+                    {% else %}
+                    <div class="collapse collapse{{group.name}} ">
+                    {% endif %}
+                        <a href="{{live.resource_URL}}" target="_blank">{{live.name}}</a>
+                        <p class="nodeText"><em>profile</em>: {{live.bsc_profile}} {% if live.type != nil %}  <em>type</em>: {{live.type}} {% endif %}<p>                   	
+                    </div>
+                </td>
+                <td class="profile-version hidden-row">
+                    {% if profile_index == 1%}
+                    <div class="collapse show collapse{{group.name}}">
+                    {% else %}
+                    <div class="collapse collapse{{group.name}}">
+                    {% endif %}
+                    {{live.bsc_ver}}
+                    </div>
+                </td>
+                <td class="structured-data-column hidden-row">
+                    {% if live.example_URL != nil %}
+                    {% if profile_index == 1%}
+                    <div class="collapse show collapse{{group.name}}">
+                    {% else %}
+                    <div class="collapse collapse{{group.name}}">
+                    {% endif %}
+                    <div class="google-sdtt-button">
+                        <span class="tooltiptext">Visualise on GTest tool</span>
+                        <a href="https://search.google.com/structured-data/testing-tool#url={{live.example_URL}}" class="btn btn-bioschema btn-block" target="_blank">visualise</a>
+                    </div>
+                    </div>
+                    {% endif %}
+                </td>
+            </tr>
+            
+            	 		
+			{% endif %}        
+            {% endfor %}
+            {% endfor %}
+      		</tbody>
+        </table>
+
+    </section>
+  </div>
+  </div>
+    <blockquote>
+        <h6>Note:</h6>
+        As we do not maintain the websites listed above we can not guarantee the list is up to date, the sites are live and feature appropriate content or the links work.
+        <p>Help us keep it updated: <a href="/howtojoin/">Join</a> the community and/or create a pull request on the <a href="https://github.com/BioSchemas/bioschemas.github.io">bioschemas github</a> community project.</p>
+    </blockquote>
+</div>

--- a/liveDeploys/elixir.html
+++ b/liveDeploys/elixir.html
@@ -2,16 +2,16 @@
 layout: default
 title: Live Deploys
 description: |-
-    Below we list the ELIXIR services/sites that use [Bioschemas](https://bioschemas.org) markup to describe what they are offering. We provide a direct link to the site and also a link to Google's [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool) visualisation of the site's markup.
+    Below we list the ELIXIR services/sites that use [Bioschemas](https://bioschemas.org) markup to describe what they are offering. We provide a direct link to the site and also a link to Google's Structured Data Testing Tool ([SDTT](https://search.google.com/structured-data/testing-tool)) visualisation of the site's markup.
     The link to Google’s SDTT shows one example from the site; however, many more may exist. For example, Biosamples have marked up all of their content (currently over 10 million samples).
-    Please remember that Google sets minimum requirements for [schema.org](https://schema.org) markup, which may conflict with those of [Bioschemas](https://bioschemas.org). As such, Google's [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool) may provide warnings or errors when the markup is perfectly compliant with both [schema.org](http://schema.org) and [Bioschemas](http://bioschemas.org).
+    Please remember that Google sets minimum requirements for [schema.org](https://schema.org) markup, which may differ with those of [Bioschemas](https://bioschemas.org). As such, Google's [SDTT](https://search.google.com/structured-data/testing-tool) may provide warnings or errors when the markup is perfectly compliant with both [schema.org](http://schema.org) and [Bioschemas](http://bioschemas.org).
     If your Bioschemas compliant site is not listed below, please email us at [enquiries@bioschemas.org](mailto:enquiries@bioschemas.org).
-    
-    To view the full live deploys page, with non-ELIXIR resources includes, [click here](../liveDeploys).
+
+    To view the full list of Bioschemas deployments [click here](/liveDeploys).
 ---
 <div class="live-deploys">
 
-    <h1>Live deploys</h1>
+    <h1>ELIXIR Live deploys</h1>
     <p>{{page.description | markdownify}}</p>
     <br>
  	{% assign liveDeploys = site.liveDeploys | where:"name", 'Live Deploys' | first %}

--- a/liveDeploys/elixir.html
+++ b/liveDeploys/elixir.html
@@ -21,6 +21,10 @@ description: |-
             <div class="col-md-8">
     <section class="live-deploy-table">
     	<h5>Elixir resources using Bioschema's markup</h5>
+        <ul style='text-align: left;'>
+          <li>CDR: <a href="https://elixir-europe.org/platforms/data/core-data-resources">ELIXIR Core Data Resource</a></li>
+          <li>DDR: <a href="https://elixir-europe.org/platforms/data/elixir-deposition-databases">ELIXIR Deposition Database Resource</a></li>
+        </ul>
         <table>
             <thead>
                 <tr>

--- a/liveDeploys/index.html
+++ b/liveDeploys/index.html
@@ -2,7 +2,7 @@
 layout: default
 title: Live Deploys
 description: |-
-    Below we list the services/sites that use [Bioschemas](http://bioschemas.org) markup to describe what they are offering. We provide a direct link to the site and also a link to Google's Structured Data Testing Tool ([SDTT])(https://search.google.com/structured-data/testing-tool) visualisation of the site's markup.
+    Below we list the services/sites that use [Bioschemas](http://bioschemas.org) markup to describe what they are offering. We provide a direct link to the site and also a link to Google's Structured Data Testing Tool ([SDTT](https://search.google.com/structured-data/testing-tool)) visualisation of the site's markup.
     The link to Google’s SDTT shows one example from the site; however, many more may exist. For example, Biosamples have marked up all of their content (currently over 10 million samples).
     Please remember that Google sets minimum requirements for [schema.org](http://schema.org) markup, which may differ with those of [Bioschemas](http://bioschemas.org). As such, Google's [SDTT](https://search.google.com/structured-data/testing-tool) may provide warnings or errors when the markup is perfectly compliant with both [schema.org](http://schema.org) and [Bioschemas](http://bioschemas.org).
     If your Bioschemas compliant site is not listed below, please email us at [enquiries@bioschemas.org](mailto:enquiries@bioschemas.org).

--- a/liveDeploys/index.html
+++ b/liveDeploys/index.html
@@ -2,11 +2,11 @@
 layout: default
 title: Live Deploys
 description: |-
-    Below we list the services/sites that use [Bioschemas](http://bioschemas.org) markup to describe what they are offering. We provide a direct link to the site and also a link to Google's [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool) visualisation of the site's markup.
+    Below we list the services/sites that use [Bioschemas](http://bioschemas.org) markup to describe what they are offering. We provide a direct link to the site and also a link to Google's Structured Data Testing Tool ([SDTT])(https://search.google.com/structured-data/testing-tool) visualisation of the site's markup.
     The link to Google’s SDTT shows one example from the site; however, many more may exist. For example, Biosamples have marked up all of their content (currently over 10 million samples).
-    Please remember that Google sets minimum requirements for [schema.org](http://schema.org) markup, which may conflict with those of [Bioschemas](http://bioschemas.org). As such, Google's [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool) may provide warnings or errors when the markup is perfectly compliant with both [schema.org](http://schema.org) and [Bioschemas](http://bioschemas.org).
+    Please remember that Google sets minimum requirements for [schema.org](http://schema.org) markup, which may differ with those of [Bioschemas](http://bioschemas.org). As such, Google's [SDTT](https://search.google.com/structured-data/testing-tool) may provide warnings or errors when the markup is perfectly compliant with both [schema.org](http://schema.org) and [Bioschemas](http://bioschemas.org).
     If your Bioschemas compliant site is not listed below, please email us at [enquiries@bioschemas.org](mailto:enquiries@bioschemas.org).
-    
+
     To view an ELIXIR only list of live deploys [click here](./elixir).
 ---
 <div class="live-deploys">

--- a/liveDeploys/index.html
+++ b/liveDeploys/index.html
@@ -6,6 +6,8 @@ description: |-
     The link to Google’s SDTT shows one example from the site; however, many more may exist. For example, Biosamples have marked up all of their content (currently over 10 million samples).
     Please remember that Google sets minimum requirements for [schema.org](http://schema.org) markup, which may conflict with those of [Bioschemas](http://bioschemas.org). As such, Google's [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool) may provide warnings or errors when the markup is perfectly compliant with both [schema.org](http://schema.org) and [Bioschemas](http://bioschemas.org).
     If your Bioschemas compliant site is not listed below, please email us at [enquiries@bioschemas.org](mailto:enquiries@bioschemas.org).
+    
+    To view an ELIXIR only list of live deploys [click here](./elixir).
 ---
 <div class="live-deploys">
 
@@ -70,15 +72,6 @@ description: |-
                         <a href="{{live.resource_URL}}" target="_blank">{{live.name}}</a>
                         {% if live.highlight != nil %}
                         	<p class="highlightsText">{{live.highlight}}</p>
-                        {% endif %}
-                        {% if live.node != nil %}
-                           	{% if live.type != nil %}
-	                         	<p class="nodeText">node: {{live.node}} type: {{live.type}}</p>
-	                    	{% else %}
-	                    		<p class="nodeText">node: {{live.node}}</p>
-	                    	{% endif %}
-	                    {% elsif live.type != nil %}
-	                    	<p class="nodeText"> type: {{live.type}}</p>
                         {% endif %}
                     </div>
                 </td>

--- a/liveDeploys/index.html
+++ b/liveDeploys/index.html
@@ -3,7 +3,7 @@ layout: default
 title: Live Deploys
 description: |-
     Below we list the services/sites that use [Bioschemas](http://bioschemas.org) markup to describe what they are offering. We provide a direct link to the site and also a link to Google's [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool) visualisation of the site's markup.
-    The link to Google’s SDTT shows one example from the site; however, many more may exist. For example, Biosamples have marked up all of their content (currently over 5 million samples).
+    The link to Google’s SDTT shows one example from the site; however, many more may exist. For example, Biosamples have marked up all of their content (currently over 10 million samples).
     Please remember that Google sets minimum requirements for [schema.org](http://schema.org) markup, which may conflict with those of [Bioschemas](http://bioschemas.org). As such, Google's [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool) may provide warnings or errors when the markup is perfectly compliant with both [schema.org](http://schema.org) and [Bioschemas](http://bioschemas.org).
     If your Bioschemas compliant site is not listed below, please email us at [enquiries@bioschemas.org](mailto:enquiries@bioschemas.org).
 ---
@@ -63,12 +63,23 @@ description: |-
             <tr>
                 <td class="deploy-name-column hidden-row">
                     {% if profile_index == 1%}
-                    <div class="collapse show collapse{{profile.name}}">
+                    <div class="collapse show collapse{{profile.name}} ">
                     {% else %}
-                    <div class="collapse collapse{{profile.name}}">
+                    <div class="collapse collapse{{profile.name}} ">
                     {% endif %}
                         <a href="{{live.resource_URL}}" target="_blank">{{live.name}}</a>
-                        <p>{{live.highlight}}</p>
+                        {% if live.highlight != nil %}
+                        	<p class="highlightsText">{{live.highlight}}</p>
+                        {% endif %}
+                        {% if live.node != nil %}
+                           	{% if live.type != nil %}
+	                         	<p class="nodeText">node: {{live.node}} type: {{live.type}}</p>
+	                    	{% else %}
+	                    		<p class="nodeText">node: {{live.node}}</p>
+	                    	{% endif %}
+	                    {% elsif live.type != nil %}
+	                    	<p class="nodeText"> type: {{live.type}}</p>
+                        {% endif %}
                     </div>
                 </td>
                 <td class="profile-version hidden-row">

--- a/liveDeploys/index.html
+++ b/liveDeploys/index.html
@@ -35,19 +35,6 @@ description: |-
             {% assign profiles = liveDeploys.list | group_by: 'bsc_profile' | sort: 'name' %}
             {% for profile in profiles %}
             {% assign profile_index = forloop.index %}
-            {% if profile_index == 1%}
-            <tr class="profile-row" style="cursor: pointer;" data-toggle="collapse" data-target=".collapse{{profile.name}}" aria-expanded="true" aria-controls="collapse{{profile.name}}">
-                <td colspan="3">
-                    <div class="repo-count"><strong>{{profile.items | size}}</strong></div>
-                    {% if profile.name == "LabProtocol" or profile.name == "DataRecord" or profile.name == "BioChemEntity" %}
-                    <a href="/types/{{profile.name}}" target="_blank">{{profile.name}}</a><br>
-                    {% else %}
-                    <a href="/specifications/{{profile.name}}" target="_blank">{{profile.name}}</a><br>
-                    {% endif %}
-                    <div class="plus-icon"><i class="fas fa-minus fa-lg"></i></div>
-                </td>
-            </tr>
-            {% else %}
             <tr class="profile-row collapsed" style="cursor: pointer;" data-toggle="collapse" data-target=".collapse{{profile.name}}" aria-expanded="false" aria-controls="collapse{{profile.name}}">
                 <td colspan="3">
                     <div class="repo-count"><strong>{{profile.items | size}}</strong></div>
@@ -59,16 +46,11 @@ description: |-
                     <div class="plus-icon"><i class="fas fa-plus fa-lg"></i></div>
                 </td>
             </tr>
-            {% endif %}
             {% assign live_sorted_list = profile.items | sort: 'name' %}
             {% for live in live_sorted_list %}
             <tr>
                 <td class="deploy-name-column hidden-row">
-                    {% if profile_index == 1%}
-                    <div class="collapse show collapse{{profile.name}} ">
-                    {% else %}
                     <div class="collapse collapse{{profile.name}} ">
-                    {% endif %}
                         <a href="{{live.resource_URL}}" target="_blank">{{live.name}}</a>
                         {% if live.highlight != nil %}
                         	<p class="highlightsText">{{live.highlight}}</p>
@@ -76,21 +58,13 @@ description: |-
                     </div>
                 </td>
                 <td class="profile-version hidden-row">
-                    {% if profile_index == 1%}
-                    <div class="collapse show collapse{{profile.name}}">
-                    {% else %}
                     <div class="collapse collapse{{profile.name}}">
-                    {% endif %}
                     {{live.bsc_ver}}
                     </div>
                 </td>
                 <td class="structured-data-column hidden-row">
                     {% if live.example_URL != nil %}
-                    {% if profile_index == 1%}
-                    <div class="collapse show collapse{{profile.name}}">
-                    {% else %}
                     <div class="collapse collapse{{profile.name}}">
-                    {% endif %}
                     <div class="google-sdtt-button">
                         <span class="tooltiptext">Visualise on GTest tool</span>
                         <a href="https://search.google.com/structured-data/testing-tool#url={{live.example_URL}}" class="btn btn-bioschema btn-block" target="_blank">visualise</a>


### PR DESCRIPTION
Changes:
* Removed identifiers.org as it no longer has markup on homepage.
* Increased biosamples pages from 5 million to over 10
* added node info & CDR/EDD info
* changed stylesheet to ?improve? presentation of highlights & node/CDR info

@AlasdairGray not a fan of the way is this presented. What do you think?