### PR TITLE
Removed 'DRAFT' from display of some release candidate types

### DIFF
--- a/_types/BioSample.html
+++ b/_types/BioSample.html
@@ -15,7 +15,7 @@ group: samples
 name: BioSample
 parent_type: BioChemEntity
 spec_type: Type
-status: revision
+status: release #Revert to revision when working on the next version
 version: '0.1-RC'
 
 bsc: #0B794B;

--- a/_types/ChemicalSubstance.html
+++ b/_types/ChemicalSubstance.html
@@ -15,7 +15,7 @@ group: chemicals
 name: ChemicalSubstance
 parent_type: BioChemEntity
 spec_type: Type
-status: revision
+status: release #Revert to revision when working on the next version
 version: '0.2-RC'
 
 bsc: #0B794B;

--- a/_types/MolecularEntity.html
+++ b/_types/MolecularEntity.html
@@ -15,7 +15,7 @@ group: chemicals
 name: MolecularEntity
 parent_type: BioChemEntity
 spec_type: Type
-status: revision
+status: release #Revert to revision when working on the next version
 version: '0.2-RC'
 
 bsc: #0B794B;

--- a/_types/Taxon.html
+++ b/_types/Taxon.html
@@ -14,7 +14,7 @@ group: biodiversity
 name: Taxon
 parent_type: Thing
 spec_type: Type
-status: revision
+status: release #Revert to revision when working on the next version
 version: '0.3-RC'
 
 bsc: #0B794B;


### PR DESCRIPTION
Some release candidate types were still set in draft mode. This PR ensures that they are all in release status.