### PR TITLE
SynBioHub should be listed as UK resource

### DIFF
--- a/_liveDeploys/liveDeploy.md
+++ b/_liveDeploys/liveDeploy.md
@@ -634,6 +634,7 @@ list:
     bsc_profile: DataCatalog
     bsc_ver: 0.3
     comments:     
+    node: UK
 -
     name: SynBioHub
     highlight: 
@@ -643,6 +644,7 @@ list:
     bsc_profile: Dataset
     bsc_ver: 0.3
     comments:  
+    node: UK
 -
     name: SynBioHub
     highlight: 
@@ -652,6 +654,7 @@ list:
     bsc_profile: DataRecord
     bsc_ver: 0.2-DRAFT
     comments:          
+    node: UK       
 -
     name: SynBioHub
     highlight: 
@@ -661,4 +664,5 @@ list:
     bsc_profile: BioChemEntity
     bsc_ver: 0.7-RC
     comments:    
+    node: UK
 ---

--- a/liveDeploys/elixir.html
+++ b/liveDeploys/elixir.html
@@ -52,6 +52,7 @@ description: |-
             {% endif %}   
             
             {% assign live_sorted_list = group.items | sort: 'node' | uniq %}
+            {% assign live_sorted_list = group.items | sort: 'name' | uniq %}
             {% for live in live_sorted_list %}
             {% if live.node != nil %}
 


### PR DESCRIPTION
Added SynBioHub to the list of UK node resources.

Noticed that node resources are not sorted by name. Corrected this.