### PR TITLE
Updating release types to #321

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The website is deployed using [Jekyll](https://jekyllrb.com/).
 
 See [installation instructions](https://jekyllrb.com/docs/installation/) for full details of installing Jekyll. Below are a quick set of commands that should hopefully get you going:
 
-- Install Jekyll and Dependencies: ```gem install jekyll bundler jekyll-redirect-from```
+- Install Jekyll and Dependencies: ```gem install jekyll bundler jekyll-redirect-from``` and ```gem install jekyll-sitemap```
 - Clone the repository: ```git clone https://github.com/BioSchemas/bioschemas.github.io.git```
 - Run the website: ```jekyll serve```
 

--- a/_types/ChemicalSubstance.html
+++ b/_types/ChemicalSubstance.html
@@ -5,8 +5,8 @@ redirect_from:
 - "/ChemicalSubstance/"
 - "/ChemicalSubstance"
 - "/types/drafts/ChemicalSubstance/"
-dateModified: 2019-06-14
-description: "A chemical substance."
+dateModified: 2019-09-02
+description: "A chemical substance is 'a portion of matter of constant composition, composed of molecular entities of the same type or of different types' (source: <a href=\'https://www.ebi.ac.uk/chebi/searchId.do?chebiId=59999\'>ChEBI:59999</a>)."
 hierarchy:
 - Thing
 - BioChemEntity
@@ -16,7 +16,7 @@ name: ChemicalSubstance
 parent_type: BioChemEntity
 spec_type: Type
 status: release #Revert to revision when working on the next version
-version: '0.2-RC'
+version: '0.3-RC'
 
 bsc: #0B794B;
 pending: #0000CC;
@@ -38,311 +38,222 @@ external: #454547;
               <section id="main_content" class="inner">
                 {% include type_start.html %}
 
-                <table class="bioschemas_properties bsc_type">
-                   <thead>
-                      <tr>
-                         <th>Property</th>
-                         <th>Expected Type</th>
-                         <th>Description</th>
-                      </tr>
-                   </thead>
-                   <tbody>
-                     <tr class="new_props_sdo">
-                        <td colspan="3">
-                           Properties from <a style="color: #0B794B;" href="/{{page.name}}">{{page.name}}</a> ( schema.org integration).
-                        </td>
-                     </tr>
-                     <!-- ChemicalSubstance properties begin here -->
+                <table class="definition-table bsc_type">
+          <thead>
+    <tr><th>Property</th><th>Expected Type</th><th>Description</th>
+    </tr>
+    </thead>
 
-                    <tr id="chemicalRole">
-                      <th style="color: #0B794B;">chemicalRole</th>
-                      <td>
-                          <a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a>
-                      </td>
-                      <td>
-                          A role played by the molecular entity within a chemical context.
-                      </td>
-                    </tr>
-                    <tr id="molecularFormula">
-                      <th style="color: #0B794B;">molecularFormula</th>
-                      <td>
-                        <a href="http://schema.org/URL">Text</a>
-                      </td>
-                      <td>
-                        The empirical formula is the simplest whole number ratio of all the atoms in a molecule.
-                      </td>
-                    </tr>
-                    <tr id="potentialUse">
-                      <th style="color: #0B794B;">potentialUse</th>
-                      <td>
-                          <a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a>
-                      </td>
-                      <td>
-                          Intended use of the molecular entity by humans.
-                      </td>
-                    </tr>
+  <tr class="supertype">
+       <th class="supertype-name" colspan="3">Properties from <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/ChemicalSubstance">ChemicalSubstance</a></th>
 
+  </tr>
 
+  <tbody class="supertype">
+    <tr typeof="rdfs:Property" resource="http://schema.org/chemicalComposition">
 
+        <th class="prop-nam" scope="row">
 
-                    <!-- MolecularEntity properties ENDS here -->
-                     <tr class="reu_props_sdo">
-                        <td colspan="3">Properties from <a style="color: #0B794B;" href="/BioChemEntity">BioChemEntity</a> (pending schema.org integration).</td>
-                     </tr>
-                       <tr id="associatedDisease">
-                       <th style="color: #0B794B;">associatedDisease</th>
-                       <td>
-                         <a href="http://schema.org/MedicalCondition">MedicalCondition</a> or<br/>
-                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Disease associated to this BioChemEntity. Such a disease can be a MedicalCondition or a URL. If you want to add an evidence supporting the association, please use PropertyValue.
-                       </td>
-                     </tr>
-                     <tr id="bioChemInteraction">
-                       <th style="color: #0B794B;">bioChemInteraction</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/BioChemEntity">BioChemEntity</a>
-                       </td>
-                       <td>
-                        A BioChemEntity that is know to interact with this item.
-                       </td>
-                     </tr>
-                     <tr id="bioChemSimilarity">
-                       <th style="color: #0B794B;">bioChemSimilarity</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/BioChemEntity">BioChemEntity</a>
-                       </td>
-                       <td>
-                        A similar molecular entity, e.g., obtained by fingerprint similarity algorithm.
-                       </td>
-                     </tr>
-                     <tr id="biogicalRole">
-                       <th style="color: #0B794B;">biogicalRole</th>
-                       <td>
-                         <a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a>
-                       </td>
-                       <td>
-                        A role played by the molecular entity within a biological context.
-                       </td>
-                     </tr>
-                     <tr id="hasBioChemEntityPart">
-                       <th style="color: #0B794B;">hasBioChemEntityPart</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/BioChemEntity">BioChemEntity</a>
-                       </td>
-                       <td>
-                         Indicates a BioChemEntity that (in some sense) has this BioChemEntity as a part.<br/>
-                         Inverse property: <span style="color: #0B794B;">isPartOfBioChemEntity</span>
-                       </td>
-                     </tr>
-                      <tr id="hasMolecularFunction">
-                       <th style="color: #0B794B;">hasMolecularFunction</th>
-                       <td>
-                         <a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a> or<br/>
-                         <a href="http://schema.org/PropertyValue">PropertyValue</a>or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Molecular function performed by this BioChemEntity; please use PropertyValue if you want to include any evidence.
-                       </td>
-                     </tr>
-                     <tr id="hasRepresentation">
-                       <th style="color: #0B794B;">hasRepresentation</th>
-                       <td>
-                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-                         <a href="http://schema.org/Text">Text</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         A common representation such as a protein sequence or chemical structure for this entity. For images use schema.org/image.
-                       </td>
-                     </tr>
-                     <tr id="isEncodedByBioChemEntity">
-                       <th style="color: #0B794B;">isEncodedByBioChemEntity</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/Gene">Gene</a>
-                       </td>
-                       <td>
-                         Another BioChemEntity encoding this one. <br/>
-                         Inverse property: <span style="color: #0B794B;">encodesBioChemEntity.</span>
-                       </td>
-                     </tr>
-                     <tr id="isInvolvedInBiologicalProcess">
-                       <th style="color: #0B794B;">isInvolvedInBiologicalProcess</th>
-                       <td>
-							<a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a> or</b>
-							<a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-							<a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Biological process this BioChemEntity is involved in; please use PropertyValue if you want to include any evidence.
-                       </td>
-                     </tr>
-                     <tr id="isLocatedInSubcellularLocation">
-                       <th style="color: #0B794B;">isLocatedInSubcellularLocation</th>
-                       <td>
-							<a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a> or</b>
-							<a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-							<a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Subcellular location where this BioChemEntity is located; please use PropertyValue if you want to include any evidence.
-                       </td>
-                     </tr>
-                     <tr id="isPartOfBioChemEntity">
-                       <th style="color: #0B794B;">isPartOfBioChemEntity</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/BioChemEntity">BioChemEntity</a>
-                       </td>
-                       <td>
-                         Indicates a BioChemEntity that is (in some sense) a part of this BioChemEntity. <br/>
-                         Inverse property: <span style="color: #0B794B;">hasBioChemEntityPart</span>
-                       </td>
-                     </tr>
-                     <tr id="taxonomicRange">
-                       <th style="color: #0B794B;">taxonomicRange</th>
-                       <td>
-                       	 <a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a> or</b>
-                         <a style="color: #0B794B;" href="/types/drafts/Taxon">Taxon</a> or<br/>
-                         <a href="http://schema.org/Text">Text</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         The taxonomic grouping of the organism that expresses, encodes, or in someway related to the BioChemEntity.
-                       </td>
-                     </tr>
+  <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#chemicalComposition">chemicalComposition</a></code>
+      </th>
+   <td class="prop-ect">
+  <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/ChemicalSubstance"></td><td class="prop-desc" property="rdfs:comment">The chemical composition describes the identity and relative ratio of the chemical elements that make up the substance.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/chemicalRole">
 
+        <th class="prop-nam" scope="row">
 
+  <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#chemicalRole">chemicalRole</a></code>
+      </th>
+   <td class="prop-ect">
+  <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp;<link property="domainIncludes" href="http://schema.org/ChemicalSubstance"><link property="domainIncludes" href="http://schema.org/MolecularEntity"></td><td class="prop-desc" property="rdfs:comment">A role played by the BioChemEntity within a chemical context.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/potentialUse">
 
-					<!-- THING -->
-                     <tr class="reu_props_sdo">
-                        <td colspan="3">Properties from <a href="http://schema.org/Thing">Thing</a></td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/additionalType">additionalType</a></th>
-                       <td>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax.
-                         This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax -
-                         the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those
-                         defined externally.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/alternateName">alternateName</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         An alias for the item.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/description">description</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         A descripton of the item.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/identifier">identifier</a></th>
-                       <td>
-                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-                         <a href="http://schema.org/Text">Text</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         The identifier property represents any kind of identifier for any kind of <a href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc.
-                         Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links.
-                         See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/image">image</a></th>
-                       <td>
-                         <a href="http://schema.org/ImageObject">ImageObject</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         An image of the item. This can be a <a href="http://schema.org/URL">URL</a> or a fully described <a href="http://schema.org/ImageObject">ImageObject</a>.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></th>
-                       <td>
-                         <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See
-                         <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/>
-                         Inverse property: <a href="http://schema.org/mainEntity">mainEntity</a>
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/name">name</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         The name of the item.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/potentialAction">potentialAction</a></th>
-                       <td>
-                         <a href="http://schema.org/Action">Action</a>
-                       </td>
-                       <td>
-                         Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/sameAs">sameAs</a></th>
-                       <td>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/subjectOf">subjectOf</a></th>
-                       <td>
-                         <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
-                         <a href="http://schema.org/Event">Event</a>
-                       </td>
-                       <td>
-                         A CreativeWork or Event about this Thing..<br/>
-                         Inverse property: <a href="http://schema.org/about">about</a>.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/url">url</a></th>
-                       <td>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         URL of the item.
-                       </td>
-                     </tr>
-                   </tbody>
-                 </table>
+        <th class="prop-nam" scope="row">
+
+  <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#potentialUse">potentialUse</a></code>
+      </th>
+   <td class="prop-ect">
+  <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp;<link property="domainIncludes" href="http://schema.org/ChemicalSubstance"><link property="domainIncludes" href="http://schema.org/MolecularEntity"></td><td class="prop-desc" property="rdfs:comment">Intended use of the BioChemEntity by humans.</td></tr><tr class="supertype">
+       <th class="supertype-name" colspan="3">Properties from <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a></th>
+
+  </tr>
+
+  <tbody class="supertype">
+    <tr typeof="rdfs:Property" resource="http://schema.org/associatedDisease">
+
+        <th class="prop-nam" scope="row">
+
+  <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#associatedDisease">associatedDisease</a></code>
+      </th>
+   <td class="prop-ect">
+  <link  property="rangeIncludes" href="http://schema.org/MedicalCondition" /><a   href="http://schema.org/MedicalCondition">MedicalCondition</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Disease associated to this BioChemEntity. Such disease can be a MedicalCondition or a URL. If you want to add an evidence supporting the association, please use PropertyValue.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/bioChemInteraction">
+
+        <th class="prop-nam" scope="row">
+
+  <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#bioChemInteraction">bioChemInteraction</a></code>
+      </th>
+   <td class="prop-ect">
+  <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A BioChemEntity that is known to interact with this item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/bioChemSimilarity">
+
+        <th class="prop-nam" scope="row">
+
+  <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#bioChemSimilarity">bioChemSimilarity</a></code>
+      </th>
+   <td class="prop-ect">
+  <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A similar BioChemEntity, e.g., obtained by fingerprint similarity algorithms.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/biologicalRole">
+
+        <th class="prop-nam" scope="row">
+
+  <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#biologicalRole">biologicalRole</a></code>
+      </th>
+   <td class="prop-ect">
+  <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A role played by the BioChemEntity within a biological context.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasBioChemEntityPart">
+
+        <th class="prop-nam" scope="row">
+
+  <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasBioChemEntityPart">hasBioChemEntityPart</a></code>
+      </th>
+   <td class="prop-ect">
+  <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Indicates a BioChemEntity that (in some sense) has this BioChemEntity as a part.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isPartOfBioChemEntity">isPartOfBioChemEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasMolecularFunction">
+
+        <th class="prop-nam" scope="row">
+
+  <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasMolecularFunction">hasMolecularFunction</a></code>
+      </th>
+   <td class="prop-ect">
+  <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Molecular function performed by this BioChemEntity; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasRepresentation">
+
+        <th class="prop-nam" scope="row">
+
+  <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasRepresentation">hasRepresentation</a></code>
+      </th>
+   <td class="prop-ect">
+  <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A common representation such as a protein sequence or chemical structure for this entity. For images use schema.org/image.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isEncodedByBioChemEntity">
+
+        <th class="prop-nam" scope="row">
+
+  <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isEncodedByBioChemEntity">isEncodedByBioChemEntity</a></code>
+      </th>
+   <td class="prop-ect">
+  <link  property="rangeIncludes" href="http://schema.org/Gene" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/Gene">Gene</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Another BioChemEntity encoding by this one.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#encodesBioChemEntity">encodesBioChemEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isInvolvedInBiologicalProcess">
+
+        <th class="prop-nam" scope="row">
+
+  <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isInvolvedInBiologicalProcess">isInvolvedInBiologicalProcess</a></code>
+      </th>
+   <td class="prop-ect">
+  <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Biological process this BioChemEntity is involved in; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isLocatedInSubcellularLocation">
+
+        <th class="prop-nam" scope="row">
+
+  <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isLocatedInSubcellularLocation">isLocatedInSubcellularLocation</a></code>
+      </th>
+   <td class="prop-ect">
+  <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Subcellular location where this BioChemEntity is located; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isPartOfBioChemEntity">
+
+        <th class="prop-nam" scope="row">
+
+  <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isPartOfBioChemEntity">isPartOfBioChemEntity</a></code>
+      </th>
+   <td class="prop-ect">
+  <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Indicates a BioChemEntity that is (in some sense) a part of this BioChemEntity.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasBioChemEntityPart">hasBioChemEntityPart</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/taxonomicRange">
+
+        <th class="prop-nam" scope="row">
+
+  <code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#taxonomicRange">taxonomicRange</a></code>
+      </th>
+   <td class="prop-ect">
+  <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Taxon" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/Taxon">Taxon</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">The taxonomic grouping of the organism that expresses, encodes, or in someway related to the BioChemEntity.</td></tr><tr class="supertype">
+       <th class="supertype-name" colspan="3">Properties from <a   href="http://schema.org/Thing">Thing</a></th>
+
+  </tr>
+
+  <tbody class="supertype">
+    <tr typeof="rdfs:Property" resource="http://schema.org/additionalType">
+
+        <th class="prop-nam" scope="row">
+
+  <code property="rdfs:label"><a   href="http://schema.org/additionalType">additionalType</a></code>
+      </th>
+   <td class="prop-ect">
+  <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax - the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those defined externally.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/alternateName">
+
+        <th class="prop-nam" scope="row">
+
+  <code property="rdfs:label"><a   href="http://schema.org/alternateName">alternateName</a></code>
+      </th>
+   <td class="prop-ect">
+  <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An alias for the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/description">
+
+        <th class="prop-nam" scope="row">
+
+  <code property="rdfs:label"><a   href="http://schema.org/description">description</a></code>
+      </th>
+   <td class="prop-ect">
+  <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A description of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/disambiguatingDescription">
+
+        <th class="prop-nam" scope="row">
+
+  <code property="rdfs:label"><a   href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></code>
+      </th>
+   <td class="prop-ect">
+  <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/identifier">
+
+        <th class="prop-nam" scope="row">
+
+  <code property="rdfs:label"><a   href="http://schema.org/identifier">identifier</a></code>
+      </th>
+   <td class="prop-ect">
+  <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The identifier property represents any kind of identifier for any kind of <a class="localLink" href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/image">
+
+        <th class="prop-nam" scope="row">
+
+  <code property="rdfs:label"><a   href="http://schema.org/image">image</a></code>
+      </th>
+   <td class="prop-ect">
+  <link  property="rangeIncludes" href="http://schema.org/ImageObject" /><a   href="http://schema.org/ImageObject">ImageObject</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An image of the item. This can be a <a class="localLink" href="http://schema.org/URL">URL</a> or a fully described <a class="localLink" href="http://schema.org/ImageObject">ImageObject</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/mainEntityOfPage">
+
+        <th class="prop-nam" scope="row">
+
+  <code property="rdfs:label"><a   href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></code>
+      </th>
+   <td class="prop-ect">
+  <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/> Inverse property: <a   href="http://schema.org/mainEntity">mainEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/name">
+
+        <th class="prop-nam" scope="row">
+
+  <code property="rdfs:label"><a   href="http://schema.org/name">name</a></code>
+      </th>
+   <td class="prop-ect">
+  <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The name of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/potentialAction">
+
+        <th class="prop-nam" scope="row">
+
+  <code property="rdfs:label"><a   href="http://schema.org/potentialAction">potentialAction</a></code>
+      </th>
+   <td class="prop-ect">
+  <link  property="rangeIncludes" href="http://schema.org/Action" /><a   href="http://schema.org/Action">Action</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sameAs">
+
+        <th class="prop-nam" scope="row">
+
+  <code property="rdfs:label"><a   href="http://schema.org/sameAs">sameAs</a></code>
+      </th>
+   <td class="prop-ect">
+  <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/subjectOf">
+
+        <th class="prop-nam" scope="row">
+
+  <code property="rdfs:label"><a   href="http://schema.org/subjectOf">subjectOf</a></code>
+      </th>
+   <td class="prop-ect">
+  <link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Event" /><a   href="http://schema.org/Event">Event</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A CreativeWork or Event about this Thing.<br/> Inverse property: <a   href="http://schema.org/about">about</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/url">
+
+        <th class="prop-nam" scope="row">
+
+  <code property="rdfs:label"><a   href="http://schema.org/url">url</a></code>
+      </th>
+   <td class="prop-ect">
+  <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of the item.</td></tr>
+
+  </table>
                </section>
              </div>
            </div>

--- a/_types/Gene.html
+++ b/_types/Gene.html
@@ -5,8 +5,8 @@ redirect_from:
 - "/Gene/"
 - "/Gene"
 - "/types/drafts/Gene/"
-dateModified: 2019-06-14
-description: "A discrete unit of inheritance which affects one or more biological traits (Source: https://en.wikipedia.org/wiki/Gene). Examples include FOXP2 (Forkhead box protein P2), SCARNA21 (small Cajal body-specific RNA 21), A- (agouti genotype)."
+dateModified: 2019-09-02
+description: "A discrete unit of inheritance which affects one or more biological traits (Source: <a href=\'https://en.wikipedia.org/wiki/Gene\'>https://en.wikipedia.org/wiki/Gene</a>). Examples include FOXP2 (Forkhead box protein P2), SCARNA21 (small Cajal body-specific RNA 21), A- (agouti genotype)."
 hierarchy:
 - Thing
 - BioChemEntity
@@ -16,7 +16,7 @@ name: Gene
 parent_type: BioChemEntity
 spec_type: Type
 status: release #Revert to revision when working on the next version
-version: '0.2-RC'
+version: '0.3-RC'
 
 bsc: #0B794B;
 pending : #0000CC;
@@ -38,331 +38,236 @@ external: #454547;
               <section id="main_content" class="inner">
                 {% include type_start.html %}
 
-                <table class="bioschemas_properties bsc_type">
-                   <thead>
-                      <tr>
-                         <th>Property</th>
-                         <th>Expected Type</th>
-                         <th>Description</th>
-                      </tr>
-                   </thead>
-                   <tbody>
-                     <tr class="new_props_sdo">
-                        <td colspan="3">
-                           Properties from <a style="color: #0B794B;" href="/{{page.name}}">{{page.name}}</a> ( schema.org integration).
-                        </td>
-                     </tr>
-                     <tr id="alternativeOf">
-                       <th style="color: #0B794B;">alternativeOf</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/Gene">Gene</a>
-                       </td>
-                       <td>
-                         Another gene which is a variation of this one.
-                       </td>
-                     </tr>
-                     </tr>
-                     <tr id="encodesBioChemEntity">
-                       <th style="color: #0B794B;">encodesBioChemEntity</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/BioChemEntity">BioChemEntity</a>
-                       </td>
-                       <td>
-                         Another BioChemEntity encoded by this one.<br />
-						 Inverse property: <span style="color: #0B794B;">isEncodedByBioChemEntity</span>
-                       </td>
-                     </tr>
-                     <tr id="expressedIn">
-                       <th style="color: #0B794B;">expressedIn</th>
-                       <td>
-                         <a href="https://schema.org/AnatomicalStructure">AnatomicalStructure</a> or<br />
-                         <a href="https://schema.org/AnatomicalSystem">AnatomicalSystem</a> or<br />
-                         <a style="color: #0B794B;" href="/types/drafts/BioChemEntity">BioChemEntity</a> or<br />
-                         <a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a>
-                       </td>
-                       <td>
-							Tissue, organ, biological sample, etc in which activity of this gene has been observed experimentally. For example brain, digestive system.
-                       </td>
-                     </tr>
-                     <tr id="hasSequence">
-                       <th style="color: #0B794B;">hasSequence</th>
-                       <td>
-                         <a href="https://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-							Nucleotide or amino acid sequence.
-                       </td>
-                     </tr>
-                     <tr id="hasStatus">
-                       <th style="color: #0B794B;">hasStatus</th>
-                       <td>
-                         <a href="https://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-							One of pseudogene, dead, killed, live, predicted, suppressed.
-                       </td>
-                     </tr>
+                <table class="definition-table bsc_type">
+        <thead>
+  <tr><th>Property</th><th>Expected Type</th><th>Description</th>
+  </tr>
+  </thead>
 
+<tr class="supertype">
+     <th class="supertype-name" colspan="3">Properties from <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/Gene">Gene</a></th>
 
+</tr>
 
-                     <!-- BCE -->
-                     <tr class="reu_props_sdo">
-                        <td colspan="3">Properties from <a style="color: #0B794B;" href="/BioChemEntity">BioChemEntity</a> (pending schema.org integration).</td>
-                     </tr>
-                    <tr id="associatedDisease">
-                       <th style="color: #0B794B;">associatedDisease</th>
-                       <td>
-                         <a href="http://schema.org/MedicalCondition">MedicalCondition</a> or<br/>
-                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Disease associated to this BioChemEntity. Such a disease can be a MedicalCondition or a URL. If you want to add an evidence supporting the association, please use PropertyValue.
-                       </td>
-                     </tr>
-                     <tr id="bioChemInteraction">
-                       <th style="color: #0B794B;">bioChemInteraction</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/BioChemEntity">BioChemEntity</a>
-                       </td>
-                       <td>
-                        A BioChemEntity that is know to interact with this item.
-                       </td>
-                     </tr>
-                     <tr id="bioChemSimilarity">
-                       <th style="color: #0B794B;">bioChemSimilarity</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/BioChemEntity">BioChemEntity</a>
-                       </td>
-                       <td>
-                        A similar molecular entity, e.g., obtained by fingerprint similarity algorithm.
-                       </td>
-                     </tr>
-                     <tr id="biogicalRole">
-                       <th style="color: #0B794B;">biogicalRole</th>
-                       <td>
-                         <a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a>
-                       </td>
-                       <td>
-                        A role played by the molecular entity within a biological context.
-                       </td>
-                     </tr>
-                     <tr id="hasBioChemEntityPart">
-                       <th style="color: #0B794B;">hasBioChemEntityPart</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/BioChemEntity">BioChemEntity</a>
-                       </td>
-                       <td>
-                         Indicates a BioChemEntity that (in some sense) has this BioChemEntity as a part.<br/>
-                         Inverse property: <span style="color: #0B794B;">isPartOfBioChemEntity</span>
-                       </td>
-                     </tr>
-                      <tr id="hasMolecularFunction">
-                       <th style="color: #0B794B;">hasMolecularFunction</th>
-                       <td>
-                         <a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a> or<br/>
-                         <a href="http://schema.org/PropertyValue">PropertyValue</a>or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Molecular function performed by this BioChemEntity; please use PropertyValue if you want to include any evidence.
-                       </td>
-                     </tr>
-                     <tr id="hasRepresentation">
-                       <th style="color: #0B794B;">hasRepresentation</th>
-                       <td>
-                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-                         <a href="http://schema.org/Text">Text</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         A common representation such as a protein sequence or chemical structure for this entity. For images use schema.org/image.
-                       </td>
-                     </tr>
-                     <tr id="isEncodedByBioChemEntity">
-                       <th style="color: #0B794B;">isEncodedByBioChemEntity</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/Gene">Gene</a>
-                       </td>
-                       <td>
-                         Another BioChemEntity encoding this one. <br/>
-                         Inverse property: <span style="color: #0B794B;">encodesBioChemEntity</span>
-                       </td>
-                     </tr>
-                     <tr id="isInvolvedInBiologicalProcess">
-                       <th style="color: #0B794B;">isInvolvedInBiologicalProcess</th>
-                       <td>
-							<a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a> or</b>
-							<a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-							<a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Biological process this BioChemEntity is involved in; please use PropertyValue if you want to include any evidence.
-                       </td>
-                     </tr>
-                     <tr id="isLocatedInSubcellularLocation">
-                       <th style="color: #0B794B;">isLocatedInSubcellularLocation</th>
-                       <td>
-							<a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a> or</b>
-							<a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-							<a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Subcellular location where this BioChemEntity is located; please use PropertyValue if you want to include any evidence.
-                       </td>
-                     </tr>
-                     <tr id="isPartOfBioChemEntity">
-                       <th style="color: #0B794B;">isPartOfBioChemEntity</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/BioChemEntity">BioChemEntity</a>
-                       </td>
-                       <td>
-                         Indicates a BioChemEntity that is (in some sense) a part of this BioChemEntity. <br/>
-                         Inverse property: <span style="color: #0B794B;">hasBioChemEntityPart</span>
-                       </td>
-                     </tr>
-                     <tr id="taxonomicRange">
-                       <th style="color: #0B794B;">taxonomicRange</th>
-                       <td>
-                       	 <a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a> or</b>
-                         <a style="color: #0B794B;" href="/types/drafts/Taxon">Taxon</a> or<br/>
-                         <a href="http://schema.org/Text">Text</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         The taxonomic grouping of the organism that expresses, encodes, or in someway related to the BioChemEntity.
-                       </td>
-                     </tr>
+<tbody class="supertype">
+  <tr typeof="rdfs:Property" resource="http://schema.org/alternativeOf">
 
+      <th class="prop-nam" scope="row">
 
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#alternativeOf">alternativeOf</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Gene" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/Gene">Gene</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Gene"></td><td class="prop-desc" property="rdfs:comment">Another gene which is a variation of this one.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/encodesBioChemEntity">
 
-       				<!-- THING -->
-                     <tr class="reu_props_sdo">
-                        <td colspan="3">Properties from <a href="http://schema.org/Thing">Thing</a></td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/additionalType">additionalType</a></th>
-                       <td>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax.
-                         This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax -
-                         the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those
-                         defined externally.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/alternateName">alternateName</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         An alias for the item.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/description">description</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         A descripton of the item.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/identifier">identifier</a></th>
-                       <td>
-                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-                         <a href="http://schema.org/Text">Text</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         The identifier property represents any kind of identifier for any kind of <a href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc.
-                         Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links.
-                         See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/image">image</a></th>
-                       <td>
-                         <a href="http://schema.org/ImageObject">ImageObject</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         An image of the item. This can be a <a href="http://schema.org/URL">URL</a> or a fully described <a href="http://schema.org/ImageObject">ImageObject</a>.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></th>
-                       <td>
-                         <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See
-                         <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/>
-                         Inverse property: <a href="http://schema.org/mainEntity">mainEntity</a>
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/name">name</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         The name of the item.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/potentialAction">potentialAction</a></th>
-                       <td>
-                         <a href="http://schema.org/Action">Action</a>
-                       </td>
-                       <td>
-                         Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/sameAs">sameAs</a></th>
-                       <td>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/subjectOf">subjectOf</a></th>
-                       <td>
-                         <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
-                         <a href="http://schema.org/Event">Event</a>
-                       </td>
-                       <td>
-                         A CreativeWork or Event about this Thing..<br/>
-                         Inverse property: <a href="http://schema.org/about">about</a>.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/url">url</a></th>
-                       <td>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         URL of the item.
-                       </td>
-                     </tr>
-                   </tbody>
-                 </table>
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#encodesBioChemEntity">encodesBioChemEntity</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Gene"></td><td class="prop-desc" property="rdfs:comment">Another BioChemEntity encoded by this one.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isEncodedByBioChemEntity">isEncodedByBioChemEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/expressedIn">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#expressedIn">expressedIn</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/AnatomicalStructure" /><a   href="http://schema.org/AnatomicalStructure">AnatomicalStructure</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/AnatomicalSystem" /><a   href="http://schema.org/AnatomicalSystem">AnatomicalSystem</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Gene"></td><td class="prop-desc" property="rdfs:comment">Tissue, organ, biological sample, etc in which activity of this gene has been observed experimentally. For example brain, digestive system.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasBioPolymerSequence">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasBioPolymerSequence">hasBioPolymerSequence</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Gene"><link property="domainIncludes" href="http://schema.org/Protein"></td><td class="prop-desc" property="rdfs:comment">A symbolic representation of a BioChemEnity. For example, a nucleotide sequence of a Gene or an amino acid sequence of a Protein.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasStatus">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasStatus">hasStatus</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Gene"></td><td class="prop-desc" property="rdfs:comment">One of pseudogene, dead, killed, live, predicted, suppressed.</td></tr><tr class="supertype">
+     <th class="supertype-name" colspan="3">Properties from <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a></th>
+
+</tr>
+
+<tbody class="supertype">
+  <tr typeof="rdfs:Property" resource="http://schema.org/associatedDisease">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#associatedDisease">associatedDisease</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/MedicalCondition" /><a   href="http://schema.org/MedicalCondition">MedicalCondition</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Disease associated to this BioChemEntity. Such disease can be a MedicalCondition or a URL. If you want to add an evidence supporting the association, please use PropertyValue.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/bioChemInteraction">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#bioChemInteraction">bioChemInteraction</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A BioChemEntity that is known to interact with this item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/bioChemSimilarity">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#bioChemSimilarity">bioChemSimilarity</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A similar BioChemEntity, e.g., obtained by fingerprint similarity algorithms.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/biologicalRole">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#biologicalRole">biologicalRole</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A role played by the BioChemEntity within a biological context.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasBioChemEntityPart">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasBioChemEntityPart">hasBioChemEntityPart</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Indicates a BioChemEntity that (in some sense) has this BioChemEntity as a part.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isPartOfBioChemEntity">isPartOfBioChemEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasMolecularFunction">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasMolecularFunction">hasMolecularFunction</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Molecular function performed by this BioChemEntity; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasRepresentation">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasRepresentation">hasRepresentation</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A common representation such as a protein sequence or chemical structure for this entity. For images use schema.org/image.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isEncodedByBioChemEntity">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isEncodedByBioChemEntity">isEncodedByBioChemEntity</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Gene" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/Gene">Gene</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Another BioChemEntity encoding by this one.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#encodesBioChemEntity">encodesBioChemEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isInvolvedInBiologicalProcess">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isInvolvedInBiologicalProcess">isInvolvedInBiologicalProcess</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Biological process this BioChemEntity is involved in; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isLocatedInSubcellularLocation">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isLocatedInSubcellularLocation">isLocatedInSubcellularLocation</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Subcellular location where this BioChemEntity is located; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isPartOfBioChemEntity">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isPartOfBioChemEntity">isPartOfBioChemEntity</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Indicates a BioChemEntity that is (in some sense) a part of this BioChemEntity.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasBioChemEntityPart">hasBioChemEntityPart</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/taxonomicRange">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#taxonomicRange">taxonomicRange</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Taxon" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/Taxon">Taxon</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">The taxonomic grouping of the organism that expresses, encodes, or in someway related to the BioChemEntity.</td></tr><tr class="supertype">
+     <th class="supertype-name" colspan="3">Properties from <a   href="http://schema.org/Thing">Thing</a></th>
+
+</tr>
+
+<tbody class="supertype">
+  <tr typeof="rdfs:Property" resource="http://schema.org/additionalType">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/additionalType">additionalType</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax - the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those defined externally.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/alternateName">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/alternateName">alternateName</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An alias for the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/description">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/description">description</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A description of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/disambiguatingDescription">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/identifier">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/identifier">identifier</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The identifier property represents any kind of identifier for any kind of <a class="localLink" href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/image">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/image">image</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/ImageObject" /><a   href="http://schema.org/ImageObject">ImageObject</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An image of the item. This can be a <a class="localLink" href="http://schema.org/URL">URL</a> or a fully described <a class="localLink" href="http://schema.org/ImageObject">ImageObject</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/mainEntityOfPage">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/> Inverse property: <a   href="http://schema.org/mainEntity">mainEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/name">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/name">name</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The name of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/potentialAction">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/potentialAction">potentialAction</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Action" /><a   href="http://schema.org/Action">Action</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sameAs">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/sameAs">sameAs</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/subjectOf">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/subjectOf">subjectOf</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Event" /><a   href="http://schema.org/Event">Event</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A CreativeWork or Event about this Thing.<br/> Inverse property: <a   href="http://schema.org/about">about</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/url">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/url">url</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of the item.</td></tr>
+
+</table>
                </section>
              </div>
            </div>

--- a/_types/MolecularEntity.html
+++ b/_types/MolecularEntity.html
@@ -5,8 +5,8 @@ redirect_from:
 - "/MolecularEntity/"
 - "/MolecularEntity"
 - "/types/drafts/MolecularEntity/"
-dateModified: 2019-06-14
-description: "Any constitutionally or isotopically distinct atom, molecule, ion, ion pair, radical, radical ion, complex, conformer etc., identifiable as a separately distinguishable entity."
+dateModified: 2019-09-02
+description: "Any constitutionally or isotopically distinct atom, molecule, ion, ion pair, radical, radical ion, complex, conformer etc., identifiable as a separately distinguishable entity. (Source: <a href=\'https://www.ebi.ac.uk/chebi/searchId.do?chebiId=23367\'>ChEBI:23367</a>)"
 hierarchy:
 - Thing
 - BioChemEntity
@@ -16,7 +16,7 @@ name: MolecularEntity
 parent_type: BioChemEntity
 spec_type: Type
 status: release #Revert to revision when working on the next version
-version: '0.2-RC'
+version: '0.3-RC'
 
 bsc: #0B794B;
 pending: #0000CC;
@@ -38,368 +38,264 @@ external: #454547;
               <section id="main_content" class="inner">
                 {% include type_start.html %}
 
-                <table class="bioschemas_properties bsc_type">
-                   <thead>
-                      <tr>
-                         <th>Property</th>
-                         <th>Expected Type</th>
-                         <th>Description</th>
-                      </tr>
-                   </thead>
-                   <tbody>
-                     <tr class="new_props_sdo">
-                        <td colspan="3">
-                           Properties from <a style="color: #0B794B;" href="/{{page.name}}">{{page.name}}</a> (pending schema.org integration).
-                        </td>
-                     </tr>
-                     <!-- MolecularEntity properties begin here -->
-                    <tr id="chemicalRole">
-                      <th style="color: #0B794B;">chemicalRole</th>
-                      <td>
-                        <a style="color: #0000CC;" href="http://.schema.org/DefinedTerm">DefinedTerm</a>
-                      </td>
-                      <td>
-                        A role played by the molecular entity within a chemical contex.
-                      </td>
-                    </tr>
-                    <tr id="inChI">
-                      <th style="color: #0B794B;">inChI</th>
-                      <td>
-                        <a href="http://schema.org/Text">Text</a>
-                      </td>
-                      <td>
-                        Non-proprietary identifier for chemical substances that can be used in printed and electronic data sources thus
-                        enabling easier linking of diverse data compilations.
-                      </td>
-                    </tr>
-                    <tr id="inChIKey">
-                      <th style="color: #0B794B;">inChIKey</th>
-                      <td>
-                        <a href="http://schema.org/Text">Text</a>
-                      </td>
-                      <td>
-                        InChIKey is a hashed version of the full InChI (using the SHA-256 algorithm)
-                      </td>
-                    </tr>
-                    <tr id="iupacName">
-                      <th style="color: #0B794B;">iupacName</th>
-                      <td>
-                        <a href="http://schema.org/Text">Text</a>
-                      </td>
-                      <td>
-                        Systematic method of naming organic chemical compounds as recommended by the International Union of Pure and
-                        Applied Chemistry (IUPAC).
-                      </td>
-                    </tr>
-                    <tr id="molecularFormula">
-                      <th style="color: #0B794B;">molecularFormula</th>
-                      <td>
-                        <a href="http://schema.org/Test">Text</a>
-                      </td>
-                      <td>
-                        The empirical formula is the simplest whole number ratio of all the atoms in a molecule.
-                      </td>
-                    </tr>
-                    <tr id="molecularWeight">
-                      <th style="color: #0B794B;">molecularWeight</th>
-                      <td>
-                        <a href="http://schema.org/Mass">Mass</a>
-                      </td>
-                      <td>
-                        	This is the molecular weight of the entity being described, not of the parent. Units should be included in the form '&lt;Number&gt; &lt;Mass unit of measure&gt;', for example '0.01 mg'.
-                      </td>
-                    </tr>
-                    <tr id="monoisotopicMolecularWeight">
-                      <th style="color: #0B794B;">monoisotopicMolecularWeight</th>
-                      <td>
-                        <a href="http://schema.org/Mass">Mass</a>
-                      </td>
-                      <td>
-                          The monoisotopic mass is the sum of the masses of the atoms in a molecule using the unbound, ground-state, rest mass of the principal (most abundant) isotope for each element instead of the isotopic average mass. Please include the units the form '&lt;Number&gt; &lt;Mass unit of measure&gt;', for example '0.01 mg'.
-                      </td>
-                    </tr>
-                    <tr id="potentialUse">
-                      <th style="color: #0B794B;">potentialUse</th>
-                      <td>
-                          <a href="http://schema.org/DefinedTerm">DefinedTerm</a>
-                      </td>
-                      <td>
-                          Intended use of the molecular entity by humans.
-                      </td>
-                    </tr>
-                    <tr id="smiles">
-                      <th style="color: #0B794B;">smiles</th>
-                      <td>
-                        <a href="http://schema.org/Text">Text</a>
-                      </td>
-                      <td>
-                        A specification in form of a line notation for describing the structure of chemical species using short ASCII
-                        strings
-                      </td>
-                    </tr>
+                <table class="definition-table bsc_type">
+        <thead>
+  <tr><th>Property</th><th>Expected Type</th><th>Description</th>
+  </tr>
+  </thead>
 
+<tr class="supertype">
+     <th class="supertype-name" colspan="3">Properties from <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/MolecularEntity">MolecularEntity</a></th>
 
+</tr>
 
-                    <!-- MolecularEntity properties ENDS here -->
-                     <tr class="reu_props_sdo">
-                        <td colspan="3">Properties from <a style="color: #0B794B;" href="/BioChemEntity">BioChemEntity</a> (pending schema.org integration).</td>
-                     </tr>
-                       <tr id="associatedDisease">
-                       <th style="color: #0B794B;">associatedDisease</th>
-                       <td>
-                         <a href="http://schema.org/MedicalCondition">MedicalCondition</a> or<br/>
-                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Disease associated to this BioChemEntity. Such a disease can be a MedicalCondition or a URL. If you want to add an evidence supporting the association, please use PropertyValue.
-                       </td>
-                     </tr>
-                     <tr id="bioChemInteraction">
-                       <th style="color: #0B794B;">bioChemInteraction</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/BioChemEntity">BioChemEntity</a>
-                       </td>
-                       <td>
-                        A BioChemEntity that is know to interact with this item.
-                       </td>
-                     </tr>
-                     <tr id="bioChemSimilarity">
-                       <th style="color: #0B794B;">bioChemSimilarity</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/BioChemEntity">BioChemEntity</a>
-                       </td>
-                       <td>
-                        A similar molecular entity, e.g., obtained by fingerprint similarity algorithm.
-                       </td>
-                     </tr>
-                     <tr id="biogicalRole">
-                       <th style="color: #0B794B;">biogicalRole</th>
-                       <td>
-                         <a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a>
-                       </td>
-                       <td>
-                        A role played by the molecular entity within a biological context.
-                       </td>
-                     </tr>
-                     <tr id="hasBioChemEntityPart">
-                       <th style="color: #0B794B;">hasBioChemEntityPart</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/BioChemEntity">BioChemEntity</a>
-                       </td>
-                       <td>
-                         Indicates a BioChemEntity that (in some sense) has this BioChemEntity as a part.<br/>
-                         Inverse property: <span style="color: #0B794B;"> isPartOfBioChemEntity</span>
-                       </td>
-                     </tr>
-                      <tr id="hasMolecularFunction">
-                       <th style="color: #0B794B;">hasMolecularFunction</th>
-                       <td>
-                         <a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a> or<br/>
-                         <a href="http://schema.org/PropertyValue">PropertyValue</a>or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Molecular function performed by this BioChemEntity; please use PropertyValue if you want to include any evidence.
-                       </td>
-                     </tr>
-                     <tr id="hasRepresentation">
-                       <th style="color: #0B794B;">hasRepresentation</th>
-                       <td>
-                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-                         <a href="http://schema.org/Text">Text</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         A common representation such as a protein sequence or chemical structure for this entity. For images use schema.org/image.
-                       </td>
-                     </tr>
-                     <tr id="isEncodedByBioChemEntity">
-                       <th style="color: #0B794B;">isEncodedByBioChemEntity</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/Gene">Gene</a>
-                       </td>
-                       <td>
-                         Another BioChemEntity encoding this one. <br/>Inverse property: <span style="color: #0B794B;"> encodesBioChemEntity.</span>
-                       </td>
-                     </tr>
-                     <tr id="isInvolvedInBiologicalProcess">
-                       <th style="color: #0B794B;">isInvolvedInBiologicalProcess</th>
-                       <td>
-							<a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a> or</b>
-							<a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-							<a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Biological process this BioChemEntity is involved in; please use PropertyValue if you want to include any evidence.
-                       </td>
-                     </tr>
-                     <tr id="isLocatedInSubcellularLocation">
-                       <th style="color: #0B794B;">isLocatedInSubcellularLocation</th>
-                       <td>
-							<a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a> or</b>
-							<a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-							<a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Subcellular location where this BioChemEntity is located; please use PropertyValue if you want to include any evidence.
-                       </td>
-                     </tr>
-                     <tr id="isPartOfBioChemEntity">
-                       <th style="color: #0B794B;">isPartOfBioChemEntity</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/BioChemEntity">BioChemEntity</a>
-                       </td>
-                       <td>
-                         Indicates a BioChemEntity that is (in some sense) a part of this BioChemEntity. <br/>
-                         Inverse property: <span style="color: #0B794B;">hasBioChemEntityPart</span>
-                       </td>
-                     </tr>
-                     <tr id="taxonomicRange">
-                       <th style="color: #0B794B;">taxonomicRange</th>
-                       <td>
-                       	 <a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a> or</b>
-                         <a style="color: #0B794B;" href="/types/drafts/Taxon">Taxon</a> or<br/>
-                         <a href="http://schema.org/Text">Text</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         The taxonomic grouping of the organism that expresses, encodes, or in someway related to the BioChemEntity.
-                       </td>
-                     </tr>
+<tbody class="supertype">
+  <tr typeof="rdfs:Property" resource="http://schema.org/chemicalRole">
 
+      <th class="prop-nam" scope="row">
 
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#chemicalRole">chemicalRole</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp;<link property="domainIncludes" href="http://schema.org/ChemicalSubstance"><link property="domainIncludes" href="http://schema.org/MolecularEntity"></td><td class="prop-desc" property="rdfs:comment">A role played by the BioChemEntity within a chemical context.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/inChI">
 
+      <th class="prop-nam" scope="row">
 
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#inChI">inChI</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/MolecularEntity"></td><td class="prop-desc" property="rdfs:comment">Non-proprietary identifier for molecular entity that can be used in printed and electronic data sources thus enabling easier linking of diverse data compilations.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/inChIKey">
 
+      <th class="prop-nam" scope="row">
 
-                     <!-- THING -->
-                     <tr class="reu_props_sdo">
-                        <td colspan="3">Properties from <a href="http://schema.org/Thing">Thing</a></td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/additionalType">additionalType</a></th>
-                       <td>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax.
-                         This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax -
-                         the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those
-                         defined externally.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/alternateName">alternateName</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         An alias for the item.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/description">description</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         A descripton of the item.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/identifier">identifier</a></th>
-                       <td>
-                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-                         <a href="http://schema.org/Text">Text</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         The identifier property represents any kind of identifier for any kind of <a href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc.
-                         Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links.
-                         See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/image">image</a></th>
-                       <td>
-                         <a href="http://schema.org/ImageObject">ImageObject</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         An image of the item. This can be a <a href="http://schema.org/URL">URL</a> or a fully described <a href="http://schema.org/ImageObject">ImageObject</a>.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></th>
-                       <td>
-                         <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See
-                         <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/>
-                         Inverse property: <a href="http://schema.org/mainEntity">mainEntity</a>
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/name">name</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         The name of the item.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/potentialAction">potentialAction</a></th>
-                       <td>
-                         <a href="http://schema.org/Action">Action</a>
-                       </td>
-                       <td>
-                         Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/sameAs">sameAs</a></th>
-                       <td>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/subjectOf">subjectOf</a></th>
-                       <td>
-                         <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
-                         <a href="http://schema.org/Event">Event</a>
-                       </td>
-                       <td>
-                         A CreativeWork or Event about this Thing..<br/>
-                         Inverse property: <a href="http://schema.org/about">about</a>.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/url">url</a></th>
-                       <td>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         URL of the item.
-                       </td>
-                     </tr>
-                   </tbody>
-                 </table>
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#inChIKey">inChIKey</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/MolecularEntity"></td><td class="prop-desc" property="rdfs:comment">InChIKey is a hashed version of the full InChI (using the SHA-256 algorithm).</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/iupacName">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#iupacName">iupacName</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/MolecularEntity"></td><td class="prop-desc" property="rdfs:comment">Systematic method of naming chemical compounds as recommended by the International Union of Pure and Applied Chemistry (IUPAC).</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/molecularFormula">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#molecularFormula">molecularFormula</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/MolecularEntity"></td><td class="prop-desc" property="rdfs:comment">The empirical formula is the simplest whole number ratio of all the atoms in a molecule.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/molecularWeight">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#molecularWeight">molecularWeight</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/QuantitativeValue" /><a   href="http://schema.org/QuantitativeValue">QuantitativeValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/MolecularEntity"></td><td class="prop-desc" property="rdfs:comment">This is the molecular weight of the entity being described, not of the parent. Units should be included in the form '&lt;Number&gt; &lt;unit&gt;', for example '12 amu' or as '&lt;QuantitativeValue&gt;.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/monoisotopicMolecularWeight">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#monoisotopicMolecularWeight">monoisotopicMolecularWeight</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/QuantitativeValue" /><a   href="http://schema.org/QuantitativeValue">QuantitativeValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/MolecularEntity"></td><td class="prop-desc" property="rdfs:comment">The monoisotopic mass is the sum of the masses of the atoms in a molecule using the unbound, ground-state, rest mass of the principal (most abundant) isotope for each element instead of the isotopic average mass. Please include the units the form '&lt;Number&gt; &lt;unit&gt;', for example '770.230488 g/mol' or as '&lt;QuantitativeValue&gt;.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/potentialUse">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#potentialUse">potentialUse</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp;<link property="domainIncludes" href="http://schema.org/ChemicalSubstance"><link property="domainIncludes" href="http://schema.org/MolecularEntity"></td><td class="prop-desc" property="rdfs:comment">Intended use of the BioChemEntity by humans.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/smiles">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#smiles">smiles</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/MolecularEntity"></td><td class="prop-desc" property="rdfs:comment">A specification in form of a line notation for describing the structure of chemical species using short ASCII strings.</td></tr><tr class="supertype">
+     <th class="supertype-name" colspan="3">Properties from <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a></th>
+
+</tr>
+
+<tbody class="supertype">
+  <tr typeof="rdfs:Property" resource="http://schema.org/associatedDisease">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#associatedDisease">associatedDisease</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/MedicalCondition" /><a   href="http://schema.org/MedicalCondition">MedicalCondition</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Disease associated to this BioChemEntity. Such disease can be a MedicalCondition or a URL. If you want to add an evidence supporting the association, please use PropertyValue.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/bioChemInteraction">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#bioChemInteraction">bioChemInteraction</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A BioChemEntity that is known to interact with this item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/bioChemSimilarity">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#bioChemSimilarity">bioChemSimilarity</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A similar BioChemEntity, e.g., obtained by fingerprint similarity algorithms.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/biologicalRole">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#biologicalRole">biologicalRole</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A role played by the BioChemEntity within a biological context.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasBioChemEntityPart">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasBioChemEntityPart">hasBioChemEntityPart</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Indicates a BioChemEntity that (in some sense) has this BioChemEntity as a part.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isPartOfBioChemEntity">isPartOfBioChemEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasMolecularFunction">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasMolecularFunction">hasMolecularFunction</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Molecular function performed by this BioChemEntity; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasRepresentation">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasRepresentation">hasRepresentation</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A common representation such as a protein sequence or chemical structure for this entity. For images use schema.org/image.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isEncodedByBioChemEntity">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isEncodedByBioChemEntity">isEncodedByBioChemEntity</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Gene" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/Gene">Gene</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Another BioChemEntity encoding by this one.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#encodesBioChemEntity">encodesBioChemEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isInvolvedInBiologicalProcess">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isInvolvedInBiologicalProcess">isInvolvedInBiologicalProcess</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Biological process this BioChemEntity is involved in; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isLocatedInSubcellularLocation">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isLocatedInSubcellularLocation">isLocatedInSubcellularLocation</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Subcellular location where this BioChemEntity is located; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isPartOfBioChemEntity">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isPartOfBioChemEntity">isPartOfBioChemEntity</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Indicates a BioChemEntity that is (in some sense) a part of this BioChemEntity.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasBioChemEntityPart">hasBioChemEntityPart</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/taxonomicRange">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#taxonomicRange">taxonomicRange</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.org/DefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Taxon" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/Taxon">Taxon</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">The taxonomic grouping of the organism that expresses, encodes, or in someway related to the BioChemEntity.</td></tr><tr class="supertype">
+     <th class="supertype-name" colspan="3">Properties from <a   href="http://schema.org/Thing">Thing</a></th>
+
+</tr>
+
+<tbody class="supertype">
+  <tr typeof="rdfs:Property" resource="http://schema.org/additionalType">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/additionalType">additionalType</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax - the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those defined externally.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/alternateName">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/alternateName">alternateName</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An alias for the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/description">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/description">description</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A description of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/disambiguatingDescription">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/identifier">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/identifier">identifier</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.org/PropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The identifier property represents any kind of identifier for any kind of <a class="localLink" href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/image">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/image">image</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/ImageObject" /><a   href="http://schema.org/ImageObject">ImageObject</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An image of the item. This can be a <a class="localLink" href="http://schema.org/URL">URL</a> or a fully described <a class="localLink" href="http://schema.org/ImageObject">ImageObject</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/mainEntityOfPage">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/> Inverse property: <a   href="http://schema.org/mainEntity">mainEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/name">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/name">name</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.org/Text">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The name of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/potentialAction">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/potentialAction">potentialAction</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Action" /><a   href="http://schema.org/Action">Action</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sameAs">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/sameAs">sameAs</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/subjectOf">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/subjectOf">subjectOf</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.org/CreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Event" /><a   href="http://schema.org/Event">Event</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A CreativeWork or Event about this Thing.<br/> Inverse property: <a   href="http://schema.org/about">about</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/url">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.org/url">url</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.org/URL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of the item.</td></tr>
+
+</table>
                </section>
              </div>
            </div>

--- a/_types/Protein.html
+++ b/_types/Protein.html
@@ -5,7 +5,7 @@ redirect_from:
 - "/Protein/"
 - "/Protein"
 - "/types/drafts/Protein/"
-dateModified: 2019-06-14
+dateModified: 2019-09-02
 description: "Protein is here used in its widest possible definition, as classes of amino acid based molecules. Amyloid-beta Protein in human (UniProt P05067), eukaryota (e.g. an OrthoDB group) or even a single molecule that one can point to are all of type schema:Protein. A protein can thus be a subclass of another protein, e.g. schema:Protein as a UniProt record can have multiple isoforms inside it which would also be schema:Protein. They can be imagined, synthetic, hypothetical or naturally occurring."
 hierarchy:
 - Thing
@@ -16,7 +16,7 @@ name: Protein
 parent_type: BioChemEntity
 spec_type: Type
 status: release #Revert to revision when working on the next version
-version: '0.2-RC'
+version: '0.3-RC'
 
 bsc: #0B794B;
 pending: #0000CC;
@@ -38,291 +38,208 @@ external: #454547;
               <section id="main_content" class="inner">
                 {% include type_start.html %}
 
-                <table class="bioschemas_properties bsc_type">
-                   <thead>
-                      <tr>
-                         <th>Property</th>
-                         <th>Expected Type</th>
-                         <th>Description</th>
-                      </tr>
-                   </thead>
-                   <tbody>
-                     <tr class="new_props_sdo">
-                        <td colspan="3">
-                           Properties from <a style="color: #0B794B;" href="/{{page.name}}">{{page.name}}</a> (pending schema.org integration).
-                        </td>
-                     </tr>
-                     <tr id="hasSequence">
-                       <th style="color: #0B794B;">hasSequence</th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         	Nucleotide or amino acid sequence.
-                       </td>
-                     </tr>
+                <table class="definition-table bsc_type">
+        <thead>
+  <tr><th>Property</th><th>Expected Type</th><th>Description</th>
+  </tr>
+  </thead>
 
+<tr class="supertype">
+     <th class="supertype-name" colspan="3">Properties from <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/Protein">Protein</a></th>
 
+</tr>
 
+<tbody class="supertype">
+  <tr typeof="rdfs:Property" resource="http://schema.org/hasBioPolymerSequence">
 
+      <th class="prop-nam" scope="row">
 
-                     <!-- BCE -->
-                   <tr class="reu_props_sdo">
-                        <td colspan="3">Properties from <a style="color: #0B794B;" href="/BioChemEntity">BioChemEntity</a> (pending schema.org integration).</td>
-                     </tr>
-                       <tr id="associatedDisease">
-                       <th style="color: #0B794B;">associatedDisease</th>
-                       <td>
-                         <a href="http://schema.org/MedicalCondition">MedicalCondition</a> or<br/>
-                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Disease associated to this BioChemEntity. Such a disease can be a MedicalCondition or a URL. If you want to add an evidence supporting the association, please use PropertyValue.
-                       </td>
-                     </tr>
-                     <tr id="bioChemInteraction">
-                       <th style="color: #0B794B;">bioChemInteraction</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/BioChemEntity">BioChemEntity</a>
-                       </td>
-                       <td>
-                        A BioChemEntity that is know to interact with this item.
-                       </td>
-                     </tr>
-                     <tr id="bioChemSimilarity">
-                       <th style="color: #0B794B;">bioChemSimilarity</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/BioChemEntity">BioChemEntity</a>
-                       </td>
-                       <td>
-                        A similar molecular entity, e.g., obtained by fingerprint similarity algorithm.
-                       </td>
-                     </tr>
-                     <tr id="biogicalRole">
-                       <th style="color: #0B794B;">biogicalRole</th>
-                       <td>
-                         <a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a>
-                       </td>
-                       <td>
-                        A role played by the molecular entity within a biological context.
-                       </td>
-                     </tr>
-                     <tr id="hasBioChemEntityPart">
-                       <th style="color: #0B794B;">hasBioChemEntityPart</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/BioChemEntity">BioChemEntity</a>
-                       </td>
-                       <td>
-                         Indicates a BioChemEntity that (in some sense) has this BioChemEntity as a part.<br/>
-                         Inverse property: <span style="color: #0B794B;">isPartOfBioChemEntity</span>
-                       </td>
-                     </tr>
-                      <tr id="hasMolecularFunction">
-                       <th style="color: #0B794B;">hasMolecularFunction</th>
-                       <td>
-                         <a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a> or<br/>
-                         <a href="http://schema.org/PropertyValue">PropertyValue</a>or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Molecular function performed by this BioChemEntity; please use PropertyValue if you want to include any evidence.
-                       </td>
-                     </tr>
-                     <tr id="hasRepresentation">
-                       <th style="color: #0B794B;">hasRepresentation</th>
-                       <td>
-                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-                         <a href="http://schema.org/Text">Text</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         A common representation such as a protein sequence or chemical structure for this entity. For images use schema.org/image.
-                       </td>
-                     </tr>
-                     <tr id="isEncodedByBioChemEntity">
-                       <th style="color: #0B794B;">isEncodedByBioChemEntity</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/Gene">Gene</a>
-                       </td>
-                       <td>
-                         Another BioChemEntity encoding this one. <br/>
-                         Inverse property: <span style="color: #0B794B;">encodesBioChemEntity.</span>
-                       </td>
-                     </tr>
-                     <tr id="isInvolvedInBiologicalProcess">
-                       <th style="color: #0B794B;">isInvolvedInBiologicalProcess</th>
-                       <td>
-							<a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a> or</b>
-							<a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-							<a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Biological process this BioChemEntity is involved in; please use PropertyValue if you want to include any evidence.
-                       </td>
-                     </tr>
-                     <tr id="isLocatedInSubcellularLocation">
-                       <th style="color: #0B794B;">isLocatedInSubcellularLocation</th>
-                       <td>
-							<a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a> or</b>
-							<a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-							<a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Subcellular location where this BioChemEntity is located; please use PropertyValue if you want to include any evidence.
-                       </td>
-                     </tr>
-                     <tr id="isPartOfBioChemEntity">
-                       <th style="color: #0B794B;">isPartOfBioChemEntity</th>
-                       <td>
-                         <a style="color: #0B794B;" href="/types/drafts/BioChemEntity">BioChemEntity</a>
-                       </td>
-                       <td>
-                         Indicates a BioChemEntity that is (in some sense) a part of this BioChemEntity. <br/>
-                         Inverse property: <span style="color: #0B794B;">hasBioChemEntityPart</span>
-                       </td>
-                     </tr>
-                     <tr id="taxonomicRange">
-                       <th style="color: #0B794B;">taxonomicRange</th>
-                       <td>
-                       	 <a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a> or</b>
-                         <a style="color: #0B794B;" href="/types/drafts/Taxon">Taxon</a> or<br/>
-                         <a href="http://schema.org/Text">Text</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         The taxonomic grouping of the organism that expresses, encodes, or in someway related to the BioChemEntity.
-                       </td>
-                     </tr>
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasBioPolymerSequence">hasBioPolymerSequence</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.orgText">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Gene"><link property="domainIncludes" href="http://schema.org/Protein"></td><td class="prop-desc" property="rdfs:comment">A symbolic representation of a BioChemEnity. For example, a nucleotide sequence of a Gene or an amino acid sequence of a Protein.</td></tr><tr class="supertype">
+     <th class="supertype-name" colspan="3">Properties from <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a></th>
 
+</tr>
 
-  						<!-- THING -->
-                     <tr class="reu_props_sdo">
-                        <td colspan="3">Properties from <a href="http://schema.org/Thing">Thing</a></td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/additionalType">additionalType</a></th>
-                       <td>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax.
-                         This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax -
-                         the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those
-                         defined externally.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/alternateName">alternateName</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         An alias for the item.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/description">description</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         A descripton of the item.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/disambiguatingDescription">disambiguatingDescription</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/identifier">identifier</a></th>
-                       <td>
-                         <a href="http://schema.org/PropertyValue">PropertyValue</a> or<br/>
-                         <a href="http://schema.org/Text">Text</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         The identifier property represents any kind of identifier for any kind of <a href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc.
-                         Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links.
-                         See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/image">image</a></th>
-                       <td>
-                         <a href="http://schema.org/ImageObject">ImageObject</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         An image of the item. This can be a <a href="http://schema.org/URL">URL</a> or a fully described <a href="http://schema.org/ImageObject">ImageObject</a>.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/mainEntityOfPage">mainEntityOfPage</a></th>
-                       <td>
-                         <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See
-                         <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/>
-                         Inverse property: <a href="http://schema.org/mainEntity">mainEntity</a>
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/name">name</a></th>
-                       <td>
-                         <a href="http://schema.org/Text">Text</a>
-                       </td>
-                       <td>
-                         The name of the item.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/potentialAction">potentialAction</a></th>
-                       <td>
-                         <a href="http://schema.org/Action">Action</a>
-                       </td>
-                       <td>
-                         Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/sameAs">sameAs</a></th>
-                       <td>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/subjectOf">subjectOf</a></th>
-                       <td>
-                         <a href="http://schema.org/CreativeWork">CreativeWork</a> or<br/>
-                         <a href="http://schema.org/Event">Event</a>
-                       </td>
-                       <td>
-                         A CreativeWork or Event about this Thing..<br/>
-                         Inverse property: <a href="http://schema.org/about">about</a>.
-                       </td>
-                     </tr>
-                     <tr>
-                       <th><a href="http://schema.org/url">url</a></th>
-                       <td>
-                         <a href="http://schema.org/URL">URL</a>
-                       </td>
-                       <td>
-                         URL of the item.
-                       </td>
-                     </tr>
-                   </tbody>
-                 </table>
+<tbody class="supertype">
+  <tr typeof="rdfs:Property" resource="http://schema.org/associatedDisease">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#associatedDisease">associatedDisease</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/MedicalCondition" /><a   href="http://schema.orgMedicalCondition">MedicalCondition</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.orgPropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.orgURL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Disease associated to this BioChemEntity. Such disease can be a MedicalCondition or a URL. If you want to add an evidence supporting the association, please use PropertyValue.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/bioChemInteraction">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#bioChemInteraction">bioChemInteraction</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A BioChemEntity that is known to interact with this item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/bioChemSimilarity">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#bioChemSimilarity">bioChemSimilarity</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A similar BioChemEntity, e.g., obtained by fingerprint similarity algorithms.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/biologicalRole">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#biologicalRole">biologicalRole</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.orgDefinedTerm">DefinedTerm</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A role played by the BioChemEntity within a biological context.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasBioChemEntityPart">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasBioChemEntityPart">hasBioChemEntityPart</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Indicates a BioChemEntity that (in some sense) has this BioChemEntity as a part.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isPartOfBioChemEntity">isPartOfBioChemEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasMolecularFunction">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasMolecularFunction">hasMolecularFunction</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.orgDefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.orgPropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.orgURL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Molecular function performed by this BioChemEntity; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/hasRepresentation">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasRepresentation">hasRepresentation</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.orgPropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.orgText">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.orgURL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">A common representation such as a protein sequence or chemical structure for this entity. For images use schema.org/image.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isEncodedByBioChemEntity">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isEncodedByBioChemEntity">isEncodedByBioChemEntity</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Gene" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/Gene">Gene</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Another BioChemEntity encoding by this one.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#encodesBioChemEntity">encodesBioChemEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isInvolvedInBiologicalProcess">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isInvolvedInBiologicalProcess">isInvolvedInBiologicalProcess</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.orgDefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.orgPropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.orgURL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Biological process this BioChemEntity is involved in; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isLocatedInSubcellularLocation">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isLocatedInSubcellularLocation">isLocatedInSubcellularLocation</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.orgDefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.orgPropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.orgURL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Subcellular location where this BioChemEntity is located; please use PropertyValue if you want to include any evidence.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/isPartOfBioChemEntity">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#isPartOfBioChemEntity">isPartOfBioChemEntity</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/BioChemEntity" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/BioChemEntity">BioChemEntity</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">Indicates a BioChemEntity that is (in some sense) a part of this BioChemEntity.<br/> Inverse property: <a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#hasBioChemEntityPart">hasBioChemEntityPart</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/taxonomicRange">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="#taxonomicRange">taxonomicRange</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/DefinedTerm" /><a title="Defined in extension: pending.schema.org"  class="ext ext-pending"  href="http://pending.schema.orgDefinedTerm">DefinedTerm</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Taxon" /><a title="Defined in extension: bio.schema.org"  class="ext ext-bio"  href="/Taxon">Taxon</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.orgText">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.orgURL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/BioChemEntity"></td><td class="prop-desc" property="rdfs:comment">The taxonomic grouping of the organism that expresses, encodes, or in someway related to the BioChemEntity.</td></tr><tr class="supertype">
+     <th class="supertype-name" colspan="3">Properties from <a   href="http://schema.orgThing">Thing</a></th>
+
+</tr>
+
+<tbody class="supertype">
+  <tr typeof="rdfs:Property" resource="http://schema.org/additionalType">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.orgadditionalType">additionalType</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.orgURL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax - the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those defined externally.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/alternateName">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.orgalternateName">alternateName</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.orgText">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An alias for the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/description">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.orgdescription">description</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.orgText">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A description of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/disambiguatingDescription">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.orgdisambiguatingDescription">disambiguatingDescription</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.orgText">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/identifier">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.orgidentifier">identifier</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/PropertyValue" /><a   href="http://schema.orgPropertyValue">PropertyValue</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.orgText">Text</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.orgURL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The identifier property represents any kind of identifier for any kind of <a class="localLink" href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See <a href="http://schema.org/docs/datamodel.html#identifierBg">background notes</a> for more details.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/image">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.orgimage">image</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/ImageObject" /><a   href="http://schema.orgImageObject">ImageObject</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.orgURL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">An image of the item. This can be a <a class="localLink" href="http://schema.org/URL">URL</a> or a fully described <a class="localLink" href="http://schema.org/ImageObject">ImageObject</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/mainEntityOfPage">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.orgmainEntityOfPage">mainEntityOfPage</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.orgCreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.orgURL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See <a href="http://schema.org/docs/datamodel.html#mainEntityBackground">background notes</a> for details.<br/> Inverse property: <a   href="http://schema.orgmainEntity">mainEntity</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/name">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.orgname">name</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Text" /><a   href="http://schema.orgText">Text</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">The name of the item.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/potentialAction">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.orgpotentialAction">potentialAction</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/Action" /><a   href="http://schema.orgAction">Action</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/sameAs">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.orgsameAs">sameAs</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.orgURL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/subjectOf">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.orgsubjectOf">subjectOf</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/CreativeWork" /><a   href="http://schema.orgCreativeWork">CreativeWork</a>&nbsp; or <br/> <link  property="rangeIncludes" href="http://schema.org/Event" /><a   href="http://schema.orgEvent">Event</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">A CreativeWork or Event about this Thing.<br/> Inverse property: <a   href="http://schema.orgabout">about</a>.</td></tr><tr typeof="rdfs:Property" resource="http://schema.org/url">
+
+      <th class="prop-nam" scope="row">
+
+<code property="rdfs:label"><a   href="http://schema.orgurl">url</a></code>
+    </th>
+ <td class="prop-ect">
+<link  property="rangeIncludes" href="http://schema.org/URL" /><a   href="http://schema.orgURL">URL</a>&nbsp;<link property="domainIncludes" href="http://schema.org/Thing"></td><td class="prop-desc" property="rdfs:comment">URL of the item.</td></tr>
+
+</table>
                </section>
              </div>
            </div>


### PR DESCRIPTION
Updating the release candidate types on the website so that they are inline with the latest versions on the appspot site.

This includes renaming `hasSequence` to `hasBioPolymerSequence` as discussed in https://github.com/BioSchemas/specifications/issues/321 and dependent on pull request https://github.com/BioSchemas/schemaorg/pull/3 being approved.

If https://github.com/BioSchemas/schemaorg/pull/3 is not approved, then `hasBioPolymerSequence` should be reverted back to `hasSequence`. All other changes should be maintained.

Note that there are more changes than you would expect showing up in the git diff. This is due to following the process outlined on the [wiki](https://github.com/BioSchemas/specifications/wiki/Copying-Schema.org-Type-Proposals-to-the-Bioschemas-Website) being followed rather than a more manual copy and paste.