### PR TITLE
Simplify joining page

### DIFF
--- a/howtojoin/index.html
+++ b/howtojoin/index.html
@@ -11,7 +11,7 @@ title: How To Join
     <p><span itemprop="name">Bioschemas</span> is an open community and welcomes any organization or individual to join this community effort. If you want to be involved in Bioschemas, please
       <ul>
         <li><a href="mailto:public-bioschemas-request@w3.org?subject=subscribe">Subscribe</a> to the mailing list <i class="fas fa-envelope"></i></li>
-        <li>Get involved in discussions on <a href="https://github.com/BioSchemas/">GitHub</a> <i class="fab fa-github"></i></li>
+        <li>Get involved in discussions on <a href="https://github.com/BioSchemas/specifications/issues">GitHub</a> <i class="fab fa-github"></i></li>
         <!-- <li>Join our <a href="https://join.slack.com/t/bioschemas/shared_invite/enQtNDExMjk1OTg3MzE1LTQ2OWNjZGEwMGZjNjZhNGJjNmRlMTE5ZTI0NGViMjlhNmM5MzVmMmI1YWY1NGQ1M2I3MTAxY2JlNjQ4ZDc3MmI">Slack workspace</a> <i class="fab fa-slack"></i></li> -->
       </ul>
     </p>

--- a/howtojoin/index.html
+++ b/howtojoin/index.html
@@ -10,9 +10,9 @@ title: How To Join
 
     <p><span itemprop="name">Bioschemas</span> is an open community and welcomes any organization or individual to join this community effort. If you want to be involved in Bioschemas, please
       <ul>
-        <li><a href="https://www.w3.org/community/bioschemas/join">Join</a> the W3C Bioschemas Community Group (detailed instructions <a href="#w3c">below</a>), this will also subscribe you to the <a href="http://lists.w3.org/Archives/Public/public-bioschemas/">mailing list</a> <i class="fas fa-envelope"></i></li>
+        <li><a href="mailto:public-bioschemas-request@w3.org?subject=subscribe">Subscribe</a> to the mailing list <i class="fas fa-envelope"></i></li>
         <li>Get involved in discussions on <a href="https://github.com/BioSchemas/">GitHub</a> <i class="fab fa-github"></i></li>
-        <li>Join our <a href="https://join.slack.com/t/bioschemas/shared_invite/enQtNDExMjk1OTg3MzE1LTQ2OWNjZGEwMGZjNjZhNGJjNmRlMTE5ZTI0NGViMjlhNmM5MzVmMmI1YWY1NGQ1M2I3MTAxY2JlNjQ4ZDc3MmI">Slack workspace</a> <i class="fab fa-slack"></i></li>
+        <!-- <li>Join our <a href="https://join.slack.com/t/bioschemas/shared_invite/enQtNDExMjk1OTg3MzE1LTQ2OWNjZGEwMGZjNjZhNGJjNmRlMTE5ZTI0NGViMjlhNmM5MzVmMmI1YWY1NGQ1M2I3MTAxY2JlNjQ4ZDc3MmI">Slack workspace</a> <i class="fab fa-slack"></i></li> -->
       </ul>
     </p>
 

--- a/howtojoin/index.html
+++ b/howtojoin/index.html
@@ -16,22 +16,22 @@ title: How To Join
       </ul>
     </p>
 
-    If you are having problems joining the W3C Community Group, e.g. needing/awaiting authorisation from someone in your organisation, you can directly <a href="mailto:public-bioschemas-request@w3.org?subject=subscribe">subscribe to the mailing list</a>.
     <p>See the <a href="/people">people</a> page to see who is involved.</p>
-
-    <h2 id="w3c">W3C Community Group</h2>
-
-    <p>Joining a W3C Community Group requires a <a href="https://www.w3.org/accounts/request">W3C participant account</a>, there is no need to be part of a membership organisation. Complete all sections of the form and then make the appropriate employment declaration on the second page. You may join the group as individuals or as an affiliate to an organisation in which case your employer gets to sign a Contributor License Agreement which sets licensing obligations for specifications created by the Community Group.</p>
-
-    <p>Once you have received the confirmation email for your account you should be able to log in and <a href="https://www.w3.org/community/bioschemas/join">join</a> the Bioschemas Community Group.</p>
-
-    <p>More detailed step-by-step instructions are available <a href="https://docs.google.com/document/d/1uTTtZs88oQWSjQ2ZDipT4qbHtdl6IVTRMSpkbuiLc54/edit?usp=sharing">here</a>.</p>
 
     <h2>Mailing List</h2>
 
     <p>The Bioschemas mailing list is our main communication channel and is hosted by the <a href="https://www.w3.org/community/bioschemas/">W3C Bioschemas Community Group</a>. There is no requirement for a W3C account to <a href="mailto:public-bioschemas-request@w3.org?subject=subscribe">subscribe</a> to the mailing list. However, we would encourage you to join the W3C Community Group.</p>
 
     <p>All messages to the mailing list are available through a <a href="http://lists.w3.org/Archives/Public/public-bioschemas/">public archive</a>.</p>
+
+    <h3 id="w3c">W3C Community Group</h3>
+
+    <p>Joining a W3C Community Group requires a <a href="https://www.w3.org/accounts/request">W3C participant account</a>, there is no need to be part of a membership organisation. To join the community group, complete all sections of the <a href="https://www.w3.org/accounts/request">form</a> and then make the appropriate employment declaration on the second page. You may join the group as an individual or as an affiliate to an organisation in which case your employer gets to sign a Contributor License Agreement which sets licensing obligations for specifications created by the Community Group.</p>
+
+    <p>Once you have received the confirmation email for your account you should be able to log in and <a href="https://www.w3.org/community/bioschemas/join">join</a> the Bioschemas Community Group.</p>
+
+    <p>More detailed step-by-step instructions are available <a href="https://docs.google.com/document/d/1uTTtZs88oQWSjQ2ZDipT4qbHtdl6IVTRMSpkbuiLc54/edit?usp=sharing">here</a>.</p>
+
 
     <h2>GitHub</h2>
 

--- a/howtojoin/index.html
+++ b/howtojoin/index.html
@@ -17,6 +17,7 @@ title: How To Join
     </p>
 
     If you are having problems joining the W3C Community Group, e.g. needing/awaiting authorisation from someone in your organisation, you can directly <a href="mailto:public-bioschemas-request@w3.org?subject=subscribe">subscribe to the mailing list</a>.
+    <p>See the <a href="/people">people</a> page to see who is involved.</p>
 
     <h2 id="w3c">W3C Community Group</h2>
 


### PR DESCRIPTION
Implemented actions discussed in last management group call.
Made joining the mailing list the focus of the joining instructions, not joining the W3C group.

Have left simplifying the people management for another task.