### PR TITLE
BEACONS ONLY attempt at new people pages

### DIFF
--- a/_groups/Beacons.md
+++ b/_groups/Beacons.md
@@ -27,10 +27,4 @@ draft_specifications:
   [
     'Beacon'
   ]
-
-members:
-  - SusheelVarma
-  - AndraWaagmeester
-  - MichaelBaudis
-  - RafaelJimenez
 ---

--- a/_groups/BeaconsPeople.md
+++ b/_groups/BeaconsPeople.md
@@ -1,0 +1,10 @@
+---
+collection: groups
+type: members
+name: Beacons
+members:
+- Susheel Varma, Elixir Hub
+- Andra Waagmeester
+- Michael Baudis, University of Zurich & Swiss Institute of Bioinformatics
+- Rafael C Jimenez, Elixir Hub
+---

--- a/_layouts/group-details.html
+++ b/_layouts/group-details.html
@@ -100,6 +100,11 @@
                   </ul>
                   <br/>
                   {% endif %}
+                  
+    
+                
+         
+
                   <h5>Group Leaders</h5>
                   <div id="leadTable">
                      {% for leader in page.lead %}
@@ -110,6 +115,19 @@
                   </div>
                   <br />
                   <h5>Group Members</h5>
+<!-- Not convinced this a good approach -->                  
+{% assign sorted_groups = site.groups | where:"type","members" | sort: 'name' %}
+{% for group in sorted_groups %}
+{% if page.name == group.name %}
+{% assign members = group.members | sort: 'name' %}
+{% for member in members %}
+<li>{{ member }} </li>
+{% endfor %}
+{% endif %}
+{% endfor %}					
+
+					            
+<!-- 
                   <div id="peopleTable">
                     {% for member-name in page.members %}
                     {% assign member-id = "/people/" | append: member-name %}
@@ -127,7 +145,7 @@
                     <p><a href="{{ member.url }}">{{ member.first-name }} {{ member.last-name }}</a></p>
                     {% endfor %}
                   </div>
-                  {% endif %}
+                  {% endif %}-->
                   {{ content }}
                </section>
             </div>

--- a/groups/index.html
+++ b/groups/index.html
@@ -12,7 +12,7 @@ title: BioSchemas Groups
 
 <p>The following groups, responsible for creating specifications within the project, are active within the Bioschemas community:</p>
 <ul>
-{% assign sorted_groups = site.groups | sort: 'name' %}
+{% assign sorted_groups = site.groups | where:"layout","group-details" | sort: 'name' %}
 {% for group in sorted_groups %}
 <li><a href="{{group.url}}">{{group.name}}</a> - {{group.abstract}}</li>
 {% endfor %}

--- a/people/index.html
+++ b/people/index.html
@@ -5,12 +5,28 @@ title: People
 
 <h1>People</h1>
 <div id="peopleTable">
+{% assign sorted_groups = site.groups | where:"type","members" | sort: 'name' %}
+{% for group in sorted_groups %}
+<h6>{{group.name}}</h6>
+
 <ul>
+
+{% assign members = group.members | sort: 'name' %}
+{% for member in members %}
+<li>{{ member }} </li>
+{% endfor %}
+
+
+<!-- 
     {% assign sorted_people = site.people | sort: 'last-name' %}
     {% for person in sorted_people %}
     <li><a href="{{ person.url }}">{{ person.first-name }} {{ person.last-name }}</a></li>
     {% endfor %}
+ -->
 </ul>
+{% endfor %}
+
+
 </div>
 
 <!-- change number columns based on device -->
@@ -24,7 +40,7 @@ title: People
     } else if(navigator.userAgent.match(/ipad/i)) {
         document.getElementById('peopleTable').style.columnCount = 1;                      
     } else {
-        document.getElementById('peopleTable').style.columnCount = 4;
+        document.getElementById('peopleTable').style.columnCount = 1;
     }
 </script>
 


### PR DESCRIPTION
Exploring options for people page. For BEACONS ONLY we have _groups/BeaconsPeople.md that contains group members (NOT LEADERS). This file is used to populate the group page and also the new people page:
* http://127.0.0.1:4000/groups/Beacons/
* http://127.0.0.1:4000/people/

I'm not convinced this is a better approach, see what you think. I see the following issues:
- you are still using md not something simpler like csv. The problem with csv is that it has to go in the _data folder and thus may be harder to find.
- rather than just editing 1 file (Beacons.md) the group leader now has to edit Beacons.md and BeaconsPeople.md.
- as there are no longer md files for each person there are no links to the person. All the info has to be displayed on the page.

Outstanding questions:
- what do we do with leaders? 
- what information do we want associated with each person. Currently I've kept it very simple (Name, Affiliation) but, depending on how complex you wish the md to be, we can add more info. There is no point in making it complicated as the group leaders won't add it and we can't really display it unless we have dedicated pages for each person.

Advantages
- by updating the people page from the list of people in each group these pages remain in sync and there is no need for extra work for us. It is up to the group leaders to maintain their lists.
