### PR TITLE
Live deploy improvements

### DIFF
--- a/_liveDeploys/liveDeploy.md
+++ b/_liveDeploys/liveDeploy.md
@@ -272,8 +272,8 @@ list:
 -
     name: HmmerWeb
     highlight: Result of searches are annotated (results last 1 week)
-    example_URL:
-    resource_URL: https://www.ebi.ac.uk/Tools/hmmer/search/phmmer
+    example_URL: https://www.ebi.ac.uk/Tools/hmmer/search/phmmer
+    resource_URL: https://www.ebi.ac.uk/Tools/hmmer/
     schema_org:
     bsc_profile: Protein
     bsc_ver: 0.1
@@ -282,8 +282,8 @@ list:
 -
     name: HmmerWeb
     highlight: Result of searches are annotated (results last 1 week)
-    example_URL:
-    resource_URL: https://www.ebi.ac.uk/Tools/hmmer/search/phmmer
+    example_URL: https://www.ebi.ac.uk/Tools/hmmer/search/phmmer
+    resource_URL: https://www.ebi.ac.uk/Tools/hmmer/
     schema_org:
     bsc_profile: ProteinStructure
     bsc_ver: 0.1
@@ -292,8 +292,8 @@ list:
 -
     name: HmmerWeb
     highlight: Result of searches are annotated (results last 1 week)
-    example_URL:
-    resource_URL: https://www.ebi.ac.uk/Tools/hmmer/search/phmmer
+    example_URL: https://www.ebi.ac.uk/Tools/hmmer/search/phmmer
+    resource_URL: https://www.ebi.ac.uk/Tools/hmmer/
     schema_org:
     bsc_profile: ProteinAnnotation
     bsc_ver: 0.1

--- a/_liveDeploys/liveDeploy.md
+++ b/_liveDeploys/liveDeploy.md
@@ -302,7 +302,7 @@ list:
 -
     name: Galaxy Project
     highlight:
-    URL: https://galaxyproject.org/events/
+    resource_URL: https://galaxyproject.org/events/
     schema_org: Event
     bsc_profile: Event
     bsc_ver: 0.1

--- a/_sass/_live-deploys.scss
+++ b/_sass/_live-deploys.scss
@@ -5,7 +5,8 @@
     }
     .live-deploy-table {
         text-align: center;
-        margin: 0 10% 0 10%;
+        margin: 0 1% 0 1%;
+        width: 90%;
     }
     .google-sdtt-button {
         position: relative;
@@ -72,7 +73,7 @@
             border-color: inherit;
             font-size: 100%;
             border-color: #fff;
-            border-width: 1em;            
+            border-width: 1em;
         }
         th {
             border-color: #fff;
@@ -87,7 +88,7 @@
             font-size: 100%;
         }
         td {
-            width: 100%;            
+            width: 100%;
             border: 0;
             padding: 0.625em;
             min-height: 1.25em;
@@ -115,7 +116,7 @@
         .structured-data-column {
             word-break: break-word;
             width:10em;
-            min-width: 10em;
+            min-width: 6em;
         }
         .profile-row {
             text-align: center;
@@ -159,19 +160,19 @@
         box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
         padding: 1em;
     }
-    
+
 	p.nodeText {
 		padding: 0;
 		margin: 0 10px 0;
 		font-size: 12px;
 		line-height : 14px;
-	}    
+	}
 
 	p.highlightsText {
 		font-style: italic;
 		padding: 0;
 		margin: 0 10px 0;
-		font-size: 12px;	
-		line-height : 14px;	
-	}	
+		font-size: 12px;
+		line-height : 14px;
+	}
 }

--- a/_sass/_live-deploys.scss
+++ b/_sass/_live-deploys.scss
@@ -118,6 +118,11 @@
             width:10em;
             min-width: 6em;
         }
+        .profile-column {
+            word-break: break-word;
+            width:11em;
+            min-width: 11em;
+        }
         .profile-row {
             text-align: center;
             font-weight: bold;

--- a/liveDeploys/elixir.html
+++ b/liveDeploys/elixir.html
@@ -18,7 +18,7 @@ description: |-
     <div class="container-flow">
         <div class="row">
 
-            <div class="col-md-8">
+            <div class="col-md-10">
     <section class="live-deploy-table">
     	<h5>Elixir resources using Bioschema's markup</h5>
         <ul style='text-align: left;'>
@@ -29,28 +29,30 @@ description: |-
             <thead>
                 <tr>
                     <th>Name</th>
-                    <th>Profile</th>
+                    <th class="profile-column">Profile</th>
                     <th>Profile Version</th>
+                    <th class="structured-data-column">Page</th>
                     <th class="structured-data-column">Structured Data Testing Tool</th>
+                    <th class="structured-data-column">Rich Snippet Tool</th>
                 </tr>
             </thead>
       		<tbody>
             {% assign groups = liveDeploys.list | group_by: 'node' | where_exp: "name", "name != nil" | sort: 'name' %}
             {% for group in groups %}
             {% assign group_index = forloop.index %}
-            {% if group_index == 1%}            
- 
+            {% if group_index == 1%}
+
             {% else %}
             <tr class="profile-row collapsed" style="cursor: pointer;" data-toggle="collapse" data-target=".collapse{{group.name}}" aria-expanded="false" aria-controls="collapse{{group.name}}">
-                <td colspan="4">
+                <td colspan="6">
                     <div class="repo-count"><strong>{{group.items | size}}</strong></div>
-                   
-                    {{group.name}}<br>                   
+
+                    {{group.name}}<br>
                     <div class="plus-icon"><i class="fas fa-plus fa-lg"></i></div>
                 </td>
-            </tr>              
-            {% endif %}   
-            
+            </tr>
+            {% endif %}
+
             {% assign live_sorted_list = group.items | sort: 'node' | uniq %}
             {% assign live_sorted_list = group.items | sort: 'name' | uniq %}
             {% for live in live_sorted_list %}
@@ -59,13 +61,13 @@ description: |-
         	<tr>
                 <td class="deploy-name-column hidden-row">
                 	{% if group_index == 1%}
-            
+
                     {% else %}
                     <div class="collapse collapse{{group.name}} ">
                     {% endif %}
                         <a href="{{live.resource_URL}}" target="_blank">{{live.name}}</a>
                         {% if live.type != nil %}
-                        <p class="nodeText"><em>type</em>: {{live.type}}<p>                   	
+                        <p class="nodeText"><em>type</em>: {{live.type}}<p>
                         {% endif %}
                     </div>
                 </td>
@@ -77,7 +79,7 @@ description: |-
                     {% endif %}
                     {{live.bsc_profile}}
                     </div>
-                </td>                
+                </td>
                 <td class="profile-version hidden-row">
 	                {% if group_index == 1%}
 
@@ -89,22 +91,50 @@ description: |-
                 </td>
                 <td class="structured-data-column hidden-row">
                     {% if live.example_URL != nil %}
-                    {% if group_index == 1%}                    
+                    {% if group_index == 1%}
 
                     {% else %}
                     <div class="collapse collapse{{group.name}}">
                     {% endif %}
                     <div class="google-sdtt-button">
-                        <span class="tooltiptext">Visualise on GTest tool</span>
-                        <a href="https://search.google.com/structured-data/testing-tool#url={{live.example_URL}}" class="btn btn-bioschema btn-block" target="_blank">visualise</a>
+                        <span class="tooltiptext">View example page</span>
+                        <a href="{{live.example_URL}}" class="btn btn-bioschema btn-block" target="_blank">view</a>
+                    </div>
+                    </div>
+                    {% endif %}
+                </td>
+                <td class="structured-data-column hidden-row">
+                    {% if live.example_URL != nil %}
+                    {% if group_index == 1%}
+
+                    {% else %}
+                    <div class="collapse collapse{{group.name}}">
+                    {% endif %}
+                    <div class="google-sdtt-button">
+                        <span class="tooltiptext">Visualise on structured data testing tool</span>
+                        <a href="https://search.google.com/structured-data/testing-tool?url={{live.example_URL}}" class="btn btn-bioschema btn-block" target="_blank">view</a>
+                    </div>
+                    </div>
+                    {% endif %}
+                </td>
+                <td class="structured-data-column hidden-row">
+                    {% if live.example_URL != nil %}
+                    {% if group_index == 1%}
+
+                    {% else %}
+                    <div class="collapse collapse{{group.name}}">
+                    {% endif %}
+                    <div class="google-sdtt-button">
+                        <span class="tooltiptext">Visualise on Rich Snippet tool</span>
+                        <a href="https://search.google.com/test/rich-results?url={{live.example_URL}}" class="btn btn-bioschema btn-block" target="_blank">view</a>
                     </div>
                     </div>
                     {% endif %}
                 </td>
             </tr>
-            
-            	 		
-			{% endif %}        
+
+
+			{% endif %}
             {% endfor %}
             {% endfor %}
       		</tbody>

--- a/liveDeploys/elixir.html
+++ b/liveDeploys/elixir.html
@@ -15,10 +15,7 @@ description: |-
     <p>{{page.description | markdownify}}</p>
     <br>
  	{% assign liveDeploys = site.liveDeploys | where:"name", 'Live Deploys' | first %}
-    <div class="container-flow">
-        <div class="row">
 
-            <div class="col-md-10">
     <section class="live-deploy-table">
     	<h5>Elixir resources using Bioschema's markup</h5>
         <ul style='text-align: left;'>
@@ -30,7 +27,7 @@ description: |-
                 <tr>
                     <th>Name</th>
                     <th class="profile-column">Profile</th>
-                    <th>Profile Version</th>
+                    <th class="structured-data-column">Profile Version</th>
                     <th class="structured-data-column">Page</th>
                     <th class="structured-data-column">Structured Data Testing Tool</th>
                     <th class="structured-data-column">Rich Snippet Tool</th>
@@ -141,11 +138,8 @@ description: |-
         </table>
 
     </section>
-  </div>
-  </div>
     <blockquote>
         <h6>Note:</h6>
         As we do not maintain the websites listed above we can not guarantee the list is up to date, the sites are live and feature appropriate content or the links work.
         <p>Help us keep it updated: <a href="/howtojoin/">Join</a> the community and/or create a pull request on the <a href="https://github.com/BioSchemas/bioschemas.github.io">bioschemas github</a> community project.</p>
     </blockquote>
-</div>

--- a/liveDeploys/index.html
+++ b/liveDeploys/index.html
@@ -52,7 +52,11 @@ description: |-
             <tr>
                 <td class="deploy-name-column hidden-row">
                     <div class="collapse collapse{{profile.name}} ">
+                      {% if live.resource_URL != nil %}
                         <a href="{{live.resource_URL}}" target="_blank">{{live.name}}</a>
+                      {% else %}
+                        {{live.name}}
+                      {% endif %}
                         {% if live.highlight != nil %}
                         	<p class="highlightsText">{{live.highlight}}</p>
                         {% endif %}

--- a/liveDeploys/index.html
+++ b/liveDeploys/index.html
@@ -15,7 +15,6 @@ description: |-
     <p>{{page.description | markdownify}}</p>
     <br>
     {% assign liveDeploys = site.liveDeploys | where:"name", 'Live Deploys' | first %}
-    {% assign candidates = site.liveDeploys | where:"name", 'Candidates' | first %}
     <div class="container-flow">
         <div class="row">
 

--- a/liveDeploys/index.html
+++ b/liveDeploys/index.html
@@ -26,8 +26,8 @@ description: |-
             <thead>
                 <tr>
                     <th>Name</th>
-                    <th>Profile Version</th>
-                    <th>Page</th>
+                    <th class="structured-data-column">Profile Version</th>
+                    <th class="structured-data-column">Page</th>
                     <th class="structured-data-column">Structured Data Testing Tool</th>
                     <th class="structured-data-column">Rich Snippet Tool</th>
                 </tr>

--- a/liveDeploys/index.html
+++ b/liveDeploys/index.html
@@ -28,7 +28,9 @@ description: |-
                 <tr>
                     <th>Name</th>
                     <th>Profile Version</th>
+                    <th>Page</th>
                     <th class="structured-data-column">Structured Data Testing Tool</th>
+                    <th class="structured-data-column">Rich Snippet Tool</th>
                 </tr>
             </thead>
             <tbody>
@@ -36,7 +38,7 @@ description: |-
             {% for profile in profiles %}
             {% assign profile_index = forloop.index %}
             <tr class="profile-row collapsed" style="cursor: pointer;" data-toggle="collapse" data-target=".collapse{{profile.name}}" aria-expanded="false" aria-controls="collapse{{profile.name}}">
-                <td colspan="3">
+                <td colspan="5">
                     <div class="repo-count"><strong>{{profile.items | size}}</strong></div>
                     {% if profile.name == "LabProtocol" or profile.name == "DataRecord" or profile.name == "BioChemEntity" %}
                     <a href="/types/{{profile.name}}" target="_blank">{{profile.name}}</a><br>
@@ -66,8 +68,28 @@ description: |-
                     {% if live.example_URL != nil %}
                     <div class="collapse collapse{{profile.name}}">
                     <div class="google-sdtt-button">
-                        <span class="tooltiptext">Visualise on GTest tool</span>
-                        <a href="https://search.google.com/structured-data/testing-tool#url={{live.example_URL}}" class="btn btn-bioschema btn-block" target="_blank">visualise</a>
+                        <span class="tooltiptext">View example page</span>
+                        <a href="{{live.example_URL}}" class="btn btn-bioschema btn-block" target="_blank">view</a>
+                    </div>
+                    </div>
+                    {% endif %}
+                </td>
+                <td class="structured-data-column hidden-row">
+                    {% if live.example_URL != nil %}
+                    <div class="collapse collapse{{profile.name}}">
+                    <div class="google-sdtt-button">
+                        <span class="tooltiptext">Visualise on structured data testing tool</span>
+                        <a href="https://search.google.com/structured-data/testing-tool?url={{live.example_URL}}" class="btn btn-bioschema btn-block" target="_blank">view</a>
+                    </div>
+                    </div>
+                    {% endif %}
+                </td>
+                <td class="structured-data-column hidden-row">
+                    {% if live.example_URL != nil %}
+                    <div class="collapse collapse{{profile.name}}">
+                    <div class="google-sdtt-button">
+                        <span class="tooltiptext">Visualise on Rich Snippet tool</span>
+                        <a href="https://search.google.com/test/rich-results?url={{live.example_URL}}" class="btn btn-bioschema btn-block" target="_blank">view</a>
                     </div>
                     </div>
                     {% endif %}


### PR DESCRIPTION
Adding feature requested in [issue 358](https://github.com/BioSchemas/specifications/issues/358) and made various improvements to the table.

Live deploy list now includes link to example page as deployed, structured data testing tool, and rich snippet generation tool. In the future we can add a Bioschemas valdator as well.

This PR also fixes the problem with the table width jumping around.