### PR TITLE
Old profile URL redirects

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,6 +3,8 @@ layout: default
 ---
 <h1>Page not found</h1>
 
-<p>It seems that you are trying to get to a page that does not exist. Please use the naviation bar above to navigate around the site.</p>
-
-<p>If you were looking for the latest version of our proposed types and properties for schema.org, these are now located at <a href="http://bio.sdo-bioschemas-227516.appspot.com/">http://bio.sdo-bioschemas-227516.appspot.com/</a>.</p>
+<p>It seems that you are trying to get to a page that does not exist. Please use the naviation bar above to navigate around the site. Some pages that you may be interest in are:</p>
+<ul>
+  <li><a href="/profiles">List of profiles</a></li>
+  <li><a href="/types">List of types</a></li>
+</ul>

--- a/_profiles/Beacon/0.2-DRAFT-2018_04_23.html
+++ b/_profiles/Beacon/0.2-DRAFT-2018_04_23.html
@@ -2,13 +2,14 @@
 redirect_from:
 - "devSpecs/Beacon/specification"
 - "devSpecs/Beacon/specification/"
+- "/specifications/drafts/Beacon"
 - "/devSpecs/Beacon/"
 - "/profiles/Beacon/"
 
 name: Beacon
 
-previous_version: 
-previous_release: 
+previous_version:
+previous_release:
 
 status: revision
 spec_type: Profile

--- a/_profiles/BioSample/0.1-DRAFT-2019_11_12.html
+++ b/_profiles/BioSample/0.1-DRAFT-2019_11_12.html
@@ -2,12 +2,13 @@
 redirect_from:
 - "devSpecs/BioSample/specification"
 - "devSpecs/BioSample/specification/"
+- "/specifications/drafts/BioSample"
 - '/profiles/BioSample/'
 
 name: BioSample
 
-previous_version: 
-previous_release: 
+previous_version:
+previous_release:
 
 status: revision
 spec_type: Profile

--- a/_profiles/ChemicalSubstance/0.3-DRAFT-2019_11_11.html
+++ b/_profiles/ChemicalSubstance/0.3-DRAFT-2019_11_11.html
@@ -3,12 +3,13 @@ redirect_from:
 - "devSpecs/ChemicalSubstance/specification"
 - "devSpecs/ChemicalSubstance/specification/"
 - "/devSpecs/ChemicalSubstance/"
+- "/specifications/drafts/ChemicalSubstance"
 - "/profiles/ChemicalSubstance/"
 
 name: ChemicalSubstance
 
 previous_version: '0.2-DRAFT-2019_06_11'
-previous_release: 
+previous_release:
 
 status: revision
 spec_type: Profile

--- a/_profiles/Course/0.7-DRAFT-2019_11_08.html
+++ b/_profiles/Course/0.7-DRAFT-2019_11_08.html
@@ -3,6 +3,7 @@ redirect_from:
 - "devSpecs/Course/specification"
 - "devSpecs/Course/specification/"
 - "/devSpecs/Course/"
+- "/specifications/drafts/Course"
 - '/profiles/Course/'
 
 name: Course

--- a/_profiles/CourseInstance/0.7-DRAFT-2019_11_08.html
+++ b/_profiles/CourseInstance/0.7-DRAFT-2019_11_08.html
@@ -3,6 +3,7 @@ redirect_from:
 - "devSpecs/CourseInstance/specification"
 - "devSpecs/CourseInstance/specification/"
 - "/devSpecs/CourseInstance/"
+- "/specifications/drafts/CourseInstance"
 - '/profiles/CourseInstance/'
 
 name: CourseInstance

--- a/_profiles/DataCatalog/0.3-RELEASE-2019_07_01.html
+++ b/_profiles/DataCatalog/0.3-RELEASE-2019_07_01.html
@@ -3,6 +3,8 @@ redirect_from:
 - "devSpecs/DataCatalog/specification"
 - "devSpecs/DataCatalog/specification/"
 - "/devSpecs/DataCatalog/"
+- "/specifications/drafts/DataCatalog"
+- "/specifications/DataCatalog"
 - "/profiles/DataCatalog/"
 
 name: DataCatalog

--- a/_profiles/DataRecord/0.2-DRAFT-2019_06_14.html
+++ b/_profiles/DataRecord/0.2-DRAFT-2019_06_14.html
@@ -3,6 +3,7 @@ redirect_from:
 - "devSpecs/DataRecord/specification"
 - "devSpecs/DataRecord/specification/"
 - "/devSpecs/DataRecord/"
+- "/specifications/drafts/DataRecord"
 - '/profiles/DataRecord/'
 
 name: DataRecord

--- a/_profiles/Dataset/0.3-RELEASE-2019_06_14.html
+++ b/_profiles/Dataset/0.3-RELEASE-2019_06_14.html
@@ -3,12 +3,14 @@ redirect_from:
  - "devSpecs/Dataset/specification"
  - "devSpecs/Dataset/specification/"
  - "/devSpecs/Dataset/"
+ - "/specifications/drafts/Dataset"
+ - "/specifications/Dataset"
  - '/profiles/Dataset/'
- 
+
 name: Dataset
 
 previous_version: '0.3-DRAFT-2018_11_12'
-previous_release: 
+previous_release:
 
 status: release #revision
 spec_type: Profile

--- a/_profiles/Event/0.2-DRAFT-2019_06_14.html
+++ b/_profiles/Event/0.2-DRAFT-2019_06_14.html
@@ -3,12 +3,13 @@ redirect_from:
 - "devSpecs/Event/specification"
 - "devSpecs/Event/specification/"
 - "/devSpecs/Event/"
+- "/specifications/drafts/Event"
 - "/profiles/Event/"
 
 name: Event
 
 previous_version: '0.1-DRAFT-2018_03_10'
-previous_release: 
+previous_release:
 
 status: revision
 spec_type: Profile

--- a/_profiles/Gene/0.4-RELEASE-2019_11_10.html
+++ b/_profiles/Gene/0.4-RELEASE-2019_11_10.html
@@ -3,6 +3,7 @@ redirect_from:
 - "devSpecs/Gene/specification"
 - "devSpecs/Gene/specification/"
 - "/devSpecs/Gene/"
+- "/specifications/Gene"
 - "/profiles/Gene/"
 
 name: Gene

--- a/_profiles/Gene/0.5-DRAFT-2019_06_14.html
+++ b/_profiles/Gene/0.5-DRAFT-2019_06_14.html
@@ -1,4 +1,7 @@
 ---
+redirect_from:
+- "/specifications/drafts/Gene"
+
 name: Gene
 
 previous_version: '0.4-RELEASE-2019_11_10'

--- a/_profiles/Journal/0.1-DRAFT-2019_11_21.html
+++ b/_profiles/Journal/0.1-DRAFT-2019_11_21.html
@@ -1,14 +1,15 @@
 ---
-redirect_from: 
+redirect_from:
 - "devSpecs/Journal/specification"
 - "devSpecs/Journal/specification/"
 - "/devSpecs/Journal/"
+- "/specifications/drafts/Journal"
 - "/profiles/Journal/"
 
 name: Journal
 
 previous_version: '0.1-DRAFT-2019_11_20'
-previous_release: 
+previous_release:
 
 status: revision
 spec_type: Profile
@@ -96,8 +97,8 @@ mapping:
   - PropertyValue
   - Text
   - URL
-  description: The identifier property represents any kind of identifier for any kind of Thing, 
-    such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, 
+  description: The identifier property represents any kind of identifier for any kind of Thing,
+    such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these,
     either as textual strings or as URL (URI) links. See background notes for more details.
   type: ""
   type_url: ""
@@ -110,8 +111,8 @@ mapping:
 - property: issn
   expected_types:
   - Text
-  description: The International Standard Serial Number (ISSN) that identifies this serial publication. 
-    You can repeat this property to identify different formats of, or the linking ISSN (ISSN-L) for, this 
+  description: The International Standard Serial Number (ISSN) that identifies this serial publication.
+    You can repeat this property to identify different formats of, or the linking ISSN (ISSN-L) for, this
     serial publication.
   type: ""
   type_url: ""
@@ -218,7 +219,7 @@ mapping:
     website.
   type: ""
   type_url: ""
-  bsc_description: Another possible URL for journals is the ISSN portal, for instance, the page 
+  bsc_description: Another possible URL for journals is the ISSN portal, for instance, the page
     https://portal.issn.org/resource/ISSN/2041-1480 corresponds to the Journal issn_p:2041-1480
   marginality: Optional
   cardinality: MANY

--- a/_profiles/LabProtocol/0.3-DRAFT-2019_06_14.html
+++ b/_profiles/LabProtocol/0.3-DRAFT-2019_06_14.html
@@ -3,12 +3,13 @@ redirect_from:
 - "devSpecs/LabProtocol/specification"
 - "devSpecs/LabProtocol/specification/"
 - "/devSpecs/LabProtocol/"
+- "/specifications/drafts/LabProtocol"
 - "/profiles/LabProtocol/"
 
 name: LabProtocol
 
 previous_version: '0.2-DRAFT-2018_03_09'
-previous_release: 
+previous_release:
 
 status: revision
 spec_type: Profile

--- a/_profiles/MolecularEntity/0.4-DRAFT-2019_11_11.html
+++ b/_profiles/MolecularEntity/0.4-DRAFT-2019_11_11.html
@@ -3,6 +3,7 @@ redirect_from:
 - "devSpecs/MolecularEntity/specification"
 - "devSpecs/MolecularEntity/specification/"
 - "/devSpecs/MolecularEntity/"
+- "/specifications/drafts/MolecularEntity"
 - "/profiles/MolecularEntity/"
 
 name: MolecularEntity

--- a/_profiles/Organization/0.2-DRAFT-2019_07_19.html
+++ b/_profiles/Organization/0.2-DRAFT-2019_07_19.html
@@ -3,12 +3,13 @@ redirect_from:
 - "devSpecs/Organization/specification"
 - "devSpecs/Organization/specification/"
 - "/devSpecs/Organization/"
+- "/specifications/drafts/Organization"
 - "/profiles/Organization/"
 
 name: Organization
 
 previous_version: 0.2-DRAFT-2019_07_17
-previous_release: 
+previous_release:
 
 status: revision
 spec_type: Profile

--- a/_profiles/Person/0.2-DRAFT-2019_07_19.html
+++ b/_profiles/Person/0.2-DRAFT-2019_07_19.html
@@ -3,12 +3,13 @@ redirect_from:
 - "devSpecs/Person/specification"
 - "devSpecs/Person/specification/"
 - "/devSpecs/Person/"
+- "/specifications/drafts/Person"
 - "/profiles/Person/"
 
 name: Person
 
 previous_version: 0.1-DRAFT-2018_03_14
-previous_release: 
+previous_release:
 
 status: revision
 spec_type: Profile

--- a/_profiles/Phenotype/0.1-DRAFT-2018_11_15.html
+++ b/_profiles/Phenotype/0.1-DRAFT-2018_11_15.html
@@ -1,14 +1,15 @@
 ---
-redirect_from: 
+redirect_from:
 - "devSpecs/Phenotype/specification"
 - "devSpecs/Phenotype/specification/"
 - "/devSpecs/Phenotype/"
+- "/specifications/drafts/Phenotype"
 - "/profiles/Phenotype/"
 
 name: Phenotype
 
-previous_version: 
-previous_release: 
+previous_version:
+previous_release:
 
 status: revision
 spec_type: Profile

--- a/_profiles/Protein/0.6-RELEASE-2018_11_10.html
+++ b/_profiles/Protein/0.6-RELEASE-2018_11_10.html
@@ -3,13 +3,14 @@ redirect_from:
 - "devSpecs/Protein/specification"
 - "devSpecs/Protein/specification/"
 - "/devSpecs/Protein/"
+- "/specifications/Protein"
 - "/profiles/Protein/"
 
 
 name: Protein
 
 previous_version: 0.6-DRAFT-2018_11_10
-previous_release: 
+previous_release:
 
 status: release # Change to revision if you are working on an update
 spec_type: Profile

--- a/_profiles/Protein/0.9-DRAFT-2019_08_20.html
+++ b/_profiles/Protein/0.9-DRAFT-2019_08_20.html
@@ -1,8 +1,11 @@
 ---
+redirect_from:
+- "/specifications/drafts/Protein"
+
 name: Protein
 
 previous_version: 0.8-DRAFT-2019_05_08
-previous_release: 
+previous_release:
 
 
 status: revision # Change to revision if you are working on an update
@@ -93,7 +96,7 @@ mapping:
       "@type": "Protein",
       "@id" : "http://purl.uniprot.org/uniprot/P05067",
       "bioChemInteraction": [
-        { "@id": "http://purl.uniprot.org/uniprot/Q306T3" }, 
+        { "@id": "http://purl.uniprot.org/uniprot/Q306T3" },
         { "@id": "http://purl.uniprot.org/uniprot/Q02410" }
       ]
     }
@@ -108,13 +111,13 @@ mapping:
   marginality: Optional
   cardinality: MANY
   controlled_vocab: ""
-  example: 
+  example:
     {
       "@type": "Protein",
       "@id": "http://purl.uniprot.org/uniprot/P05067",
       "bioChemSimilarity": [
         { "@id" : "http://purl.uniprot.org/uniprot/O97584" },
-        { "@id" : "http://purl.uniprot.org/uniparc/UPI0000110448" } 
+        { "@id" : "http://purl.uniprot.org/uniparc/UPI0000110448" }
       ]
     }
 - property: description
@@ -178,7 +181,7 @@ mapping:
   bsc_description: '**Bioschemas Protein**: This property could be used, for instance,
     to register a sequence protein as it is a representation of the protein. If you
     want to better define the nature of the representation, use a PropertyValue where, for instance,
-    the property *name* is Sequence, the *value* are protein sequences, and the *referenceValue* 
+    the property *name* is Sequence, the *value* are protein sequences, and the *referenceValue*
     id the canonical sequence.'
   marginality: Recommended
   cardinality: MANY
@@ -189,7 +192,7 @@ mapping:
       "@id": "http://purl.uniprot.org/uniprot/P05067",
       "hasRepresentation": "MLPGLALLLLAAWTARALEVPTDGNAGLLAEPQIAMFCGR..."
     }
-    
+
     {
       "@type": "Protein",
       "@id": "http://purl.uniprot.org/uniprot/P05067",
@@ -339,7 +342,7 @@ mapping:
   example: |-
     {
       "@type": "Protein",
-      "@id" : "http://purl.uniprot.org/uniprot/P05519",   
+      "@id" : "http://purl.uniprot.org/uniprot/P05519",
       "mainEntityOfPage": {
         "@type": "WebPage",
         "@id": "https://www.uniprot.org/uniprot/P05519"

--- a/_profiles/ProteinAnnotation/0.4-DRAFT-2018_02_25.html
+++ b/_profiles/ProteinAnnotation/0.4-DRAFT-2018_02_25.html
@@ -3,12 +3,13 @@ redirect_from:
 - "devSpecs/ProteinAnnotation/specification"
 - "devSpecs/ProteinAnnotation/specification/"
 - "/devSpecs/ProteinAnnotation/"
+- "/specifications/drafts/ProteinAnnotation"
 - "/profiles/ProteinAnnotation/"
 
 name: ProteinAnnotation
 
-previous_version: 
-previous_release: 
+previous_version:
+previous_release:
 
 status: revision
 spec_type: Profile

--- a/_profiles/ProteinStructure/0.5-DRAFT-2018_08_15.html
+++ b/_profiles/ProteinStructure/0.5-DRAFT-2018_08_15.html
@@ -1,13 +1,14 @@
 ---
-redirect_from: 
+redirect_from:
 - "devSpecs/ProteinStructure/specification"
 - "devSpecs/ProteinStructure/specification/"
 - "/devSpecs/ProteinStructure/"
+- "/specifications/drafts/ProteinStructure"
 - "/profiles/ProteinStructure/"
 
 name: ProteinStructure
 
-previous_version: 
+previous_version:
 previous_release:
 
 status: revision

--- a/_profiles/PublicationIssue/0.1-DRAFT-2019_02_08.html
+++ b/_profiles/PublicationIssue/0.1-DRAFT-2019_02_08.html
@@ -1,14 +1,15 @@
 ---
-redirect_from: 
+redirect_from:
 - "devSpecs/PublicationIssue/specification"
 - "devSpecs/PublicationIssue/specification/"
 - "/devSpecs/PublicationIssue/"
+- "/specifications/drafts/PublicationIssue"
 - "/profiles/PublicationIssue/"
 
 name: PublicationIssue
 
 previous_version: 0.1-DRAFT-2019_01_31
-previous_release: 
+previous_release:
 
 
 status: revision

--- a/_profiles/PublicationVolume/0.1-DRAFT-2019_02_15.html
+++ b/_profiles/PublicationVolume/0.1-DRAFT-2019_02_15.html
@@ -1,14 +1,15 @@
 ---
-redirect_from: 
+redirect_from:
 - "devSpecs/PublicationVolume/specification"
 - "devSpecs/PublicationVolume/specification/"
 - "/devSpecs/PublicationVolume/"
+- "/specifications/drafts/PublicationVolume"
 - "/profiles/PublicationVolume/"
 
 name: PublicationVolume
 
 previous_version: '0.1-DRAFT-2019_02_14'
-previous_release: 
+previous_release:
 
 status: revision
 spec_type: Profile

--- a/_profiles/RNA/0.1-DRAFT-2019_11_15.html
+++ b/_profiles/RNA/0.1-DRAFT-2019_11_15.html
@@ -3,12 +3,13 @@ redirect_from:
 - "devSpecs/RNA/specification"
 - "devSpecs/RNA/specification/"
 - "/devSpecs/RNA/"
+- "/specifications/drafts/RNA"
 - "/profiles/RNA/"
 
 name: RNA
 
 previous_version:
-previous_release: 
+previous_release:
 
 status: revision # Change to revision if you are working on an update
 spec_type: Profile

--- a/_profiles/Sample/0.2-RELEASE-2018_11_10.html
+++ b/_profiles/Sample/0.2-RELEASE-2018_11_10.html
@@ -1,14 +1,16 @@
 ---
-redirect_from: 
+redirect_from:
 - "devSpecs/Sample/specification"
 - "devSpecs/Sample/specification/"
 - "/devSpecs/Sample/"
+- "/specifications/drafts/Sample"
+- "/specifications/Sample"
 - "/profiles/Sample/"
 
 name: Sample
 
 previous_version: 0.2-DRAFT-2018_11_10
-previous_release: 
+previous_release:
 
 
 status: release # Change to revision if you are working on an update

--- a/_profiles/ScholarlyArticle/0.1-DRAFT-2019_03_15.html
+++ b/_profiles/ScholarlyArticle/0.1-DRAFT-2019_03_15.html
@@ -1,14 +1,15 @@
 ---
-redirect_from: 
+redirect_from:
 - "devSpecs/ScholarlyArticle/specification"
 - "devSpecs/ScholarlyArticle/specification/"
 - "/devSpecs/ScholarlyArticle/"
+- "/specifications/drafts/ScholarlyArticle"
 - "/profiles/ScholarlyArticle/"
 
 name: ScholarlyArticle
 
 previous_version: 0.1-DRAFT-2019_02_14
-previous_release: 
+previous_release:
 
 status: revision
 spec_type: Profile

--- a/_profiles/SemanticAnnotation/0.1-DRAFT-2019_11_19.html
+++ b/_profiles/SemanticAnnotation/0.1-DRAFT-2019_11_19.html
@@ -1,14 +1,15 @@
 ---
-redirect_from: 
+redirect_from:
 - "devSpecs/SemanticAnnotation/specification"
 - "devSpecs/SemanticAnnotation/specification/"
 - "/devSpecs/SemanticAnnotation/"
+- "/specifications/drafts/SemanticAnnotation"
 - "/profiles/SemanticAnnotation/"
 
 name: SemanticAnnotation
 
 previous_version: 0.1-DRAFT-2019_02_08
-previous_release: 
+previous_release:
 
 status: revision
 spec_type: Profile
@@ -28,7 +29,7 @@ spec_info:
   subtitle: Bioschemas profile, based on Biotea model, describing a semantic annotation
     associated to a piece of text in a ScholarlyArticle in Life Sciences.
   description: A SemanticAnnotation currently corresponds to an expression identified
-    in a ScholarlyArticle and associated to an ontology term. It could apply as well to documents 
+    in a ScholarlyArticle and associated to an ontology term. It could apply as well to documents
     other than ScholarlyArticle, for instant patents and so.
   version: 0.1-DRAFT-2019_11_19
   version_date: 20190208T104450
@@ -170,7 +171,7 @@ mapping:
      Inverse property: mainEntityOfPage.
   type: ""
   type_url: ""
-  bsc_description: DefinedTerm(s), i.e., ontology terms, associated to this annotation. Use DefinedTermSet if multiple related 
+  bsc_description: DefinedTerm(s), i.e., ontology terms, associated to this annotation. Use DefinedTermSet if multiple related
    terms should be seen as a whole, for instance MeSH descriptors accompanied by MeSH qualifiers .
    On the DefinedTerm, use additionalType to link to a Unified Medical Language System (UMLS) semantic
     type (TUI) or group, and sameAs to link to the corresponding concept unique identifier

--- a/_profiles/Study/0.1-DRAFT-2018_11_15.html
+++ b/_profiles/Study/0.1-DRAFT-2018_11_15.html
@@ -3,12 +3,13 @@ redirect_from:
 - "devSpecs/Study/specification"
 - "devSpecs/Study/specification/"
 - "/devSpecs/Study/"
+- "/specifications/drafts/Study"
 - "/profiles/Study/"
 
 name: Study
 
 previous_version:
-previous_release: 
+previous_release:
 
 status: revision
 spec_type: Profile

--- a/_profiles/Taxon/0.3-RELEASE-2018_11_10.html
+++ b/_profiles/Taxon/0.3-RELEASE-2018_11_10.html
@@ -3,6 +3,7 @@ redirect_from:
 - "devSpecs/Taxon/specification"
 - "devSpecs/Taxon/specification/"
 - "/devSpecs/Taxon/"
+- "/specifications/Taxon"
 - "/profiles/Taxon/"
 
 name: Taxon

--- a/_profiles/Taxon/0.4-DRAFT-2019_06_24.html
+++ b/_profiles/Taxon/0.4-DRAFT-2019_06_24.html
@@ -1,4 +1,7 @@
 ---
+redirect_from:
+- "/specifications/drafts/Taxon"
+
 name: Taxon
 
 previous_version: 0.4-DRAFT-2019_06_19

--- a/_profiles/Tool/0.4-DRAFT-2019_07_19.html
+++ b/_profiles/Tool/0.4-DRAFT-2019_07_19.html
@@ -1,14 +1,15 @@
 ---
-redirect_from: 
+redirect_from:
 - "devSpecs/Tool/specification"
 - "devSpecs/Tool/specification/"
 - "/devSpecs/Tool/"
+- "/specifications/drafts/Tool"
 - "/profiles/Tool/"
 
 name: Tool
 
 previous_version: 0.3-DRAFT-2019_07_18
-previous_release: 
+previous_release:
 
 status: revision
 spec_type: Profile

--- a/_profiles/TrainingMaterial/0.7-DRAFT-2019_11_08.html
+++ b/_profiles/TrainingMaterial/0.7-DRAFT-2019_11_08.html
@@ -3,6 +3,7 @@ redirect_from:
 - "devSpecs/TrainingMaterial/specification"
 - "devSpecs/TrainingMaterial/specification/"
 - "/devSpecs/TrainingMaterial/"
+- "/specifications/drafts/TrainingMaterial"
 - "/profiles/TrainingMaterial/"
 
 name: TrainingMaterial

--- a/_profiles/Workflow/0.2-DRAFT-2019_11_29.html
+++ b/_profiles/Workflow/0.2-DRAFT-2019_11_29.html
@@ -1,19 +1,20 @@
 ---
-redirect_from: 
+redirect_from:
 - "devSpecs/Workflow/specification"
 - "devSpecs/Workflow/specification/"
 - "/devSpecs/Workflow/"
+- "/specifications/drafts/Workflow"
 - "/profiles/Workflow/"
 
 name: Workflow
 
-previous_version: 
-previous_release: 
+previous_version:
+previous_release:
 
 status: revision
 spec_type: Profile
 group: workflow
-use_cases_url: 
+use_cases_url:
 cross_walk_url: https://docs.google.com/spreadsheets/d/1Z3eQrj5Gbs3WGVd1cXUzpL6X1v8Y8cWg-oe2nKzXgzo/edit
 gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Workflow
 live_deploy: ''


### PR DESCRIPTION
Added redirects for old specification URLs to new locations

This means that URLs like `https://bioschemas.org/specifications/drafts/Course/` should redirect to the latest draft of the Course profile