### PR TITLE
Check for no use case declaration

### DIFF
--- a/_includes/profile_start.html
+++ b/_includes/profile_start.html
@@ -150,7 +150,7 @@
                {% endfor %}
             </td>
             <td class="spec_links">
-               {% if page.use_cases_url == '' %}
+               {% if page.use_cases_url == '' or page.use_cases_url == nil %}
                <a>
                <img src="/images/use_case_spec.png" alt="View BioSchemas {{ page.name }} Use Cases"  style="filter: grayscale(100%);">
                </a>

--- a/_includes/profile_table_rows.html
+++ b/_includes/profile_table_rows.html
@@ -14,7 +14,7 @@
             {% endfor %}
           </td>
           <td class="spec_links">
-            {% if spec.use_cases_url == '' %}
+            {% if spec.use_cases_url == '' or spec.use_cases_url == nil %}
             <a>
             <img src="/images/use_case_spec.png" alt="View BioSchemas {{ spec.spec_info.title }} Use Cases"  style="filter: grayscale(100%);">
             </a>


### PR DESCRIPTION
Found that the Workflows group had not defined a use case but the tables were all showing that they had a use case. 

Found a bug in the logic that decides whether to greyscale the use case link or not. It check for `''` but not for a nil value.

Corrected in all places where it occurs.