### PR TITLE
Fix Issue 381

### DIFF
--- a/_includes/profile_table_rows.html
+++ b/_includes/profile_table_rows.html
@@ -1,7 +1,7 @@
       <tr>
           {% assign date_time = spec.spec_info.version_date %}
-          <th><a href="/profiles/{{spec.name}}" title="{{ spec.spec_info.subtitle }}">{{ spec.spec_info.title }}</a><br />(v{{spec.spec_info.version}})<br />{{ date_time | date_to_long_string }}
-          
+          <th><a href="/profiles/{{spec.name}}/{{spec.spec_info.version}}" title="{{ spec.spec_info.subtitle }}">{{ spec.spec_info.title }}</a><br />(v{{spec.spec_info.version}})<br />{{ date_time | date_to_long_string }}
+
           	{% if site.data.profile_versions[spec.name].status == "deprecated" %}
           	<p>deprecated on: {{site.data.profile_versions[spec.name].deprecated_date }}<p>
           	{% endif %}

--- a/types/index.html
+++ b/types/index.html
@@ -113,7 +113,7 @@ redirect_from:
       {% if site.data.type_versions[spec.name].latest_publication != nill %}
 	  {% if spec.version == site.data.type_versions[spec.name].latest_publication %}
     <tr>
-        <th><a href="/types/{{spec.name}}" title="{{spec.subtitle}}">{{ spec.name }}</a><br />(v{{spec.version}})<br />{{spec.dateModified}}</th>
+        <th><a href="/types/{{spec.name}}/{{spec.version}}" title="{{spec.subtitle}}">{{ spec.name }}</a><br />(v{{spec.version}})<br />{{spec.dateModified}}</th>
         <td>
         {% assign group = site.groups | where:"identifier", spec.group | first %}
         <a href="{{group.url}}">{{group.name}}</a>


### PR DESCRIPTION
This PR fixes https://github.com/BioSchemas/specifications/issues/381 whereby the draft profiles on the [profiles page](https://bioschemas.org/profiles) link to the latest release rather than the latest draft.

I've also ensured that the logic is applied to the types page as well.