### PR TITLE
Update links to latest version

### DIFF
--- a/_data/profile_versions.yaml
+++ b/_data/profile_versions.yaml
@@ -68,7 +68,7 @@ Journal:
 
 LabProtocol:
     name: "LabProtocol"
-    latest_publication: "0.3-DRAFT-2019_06_14"
+    latest_publication: "0.4-DRAFT-2020_07_23"
     latest_release:
     status: "active"
 

--- a/_profiles/LabProtocol/0.4-DRAFT-2020_07_23.html
+++ b/_profiles/LabProtocol/0.4-DRAFT-2020_07_23.html
@@ -24,13 +24,13 @@ spec_info:
   subtitle: Bioschemas profile describing a LabProtocol in Life Sciences
   description: 'This LabProtocol profile specification presents the markup for describing
     a LabProtocol.<h4>Summary of Changes</h4>    Changes since previous draft of the
-    LabProtocols profile:    <ul>      <li>used added at the end to elements used
+    LabProtocols profile:    <ul>      <li>''used'' added at the end to elements used
     in the protocol, see <a href=''https://github.com/BioSchemas/specifications/issues/265''>issue
     265</a></li>      <li>Protocols advantages, limitations, outcomes, purpose and
-    application where mixed up in the previous draft, they have being revised.</li>      <li>Short
+    application were mixed up in the previous draft, they have been revised.</li>      <li>Short
     examples have been added per properties, see <a href=''https://github.com/BioSchemas/specifications/issues/179''>issue
     179</a>.</li>      <li>Links to the ontologies were revised.</li>      <li>Property
-    descriptions were revised.</li>      <li>Description propery removed as we have now steps.</li>      
+    descriptions were revised.</li>      <li>Description property removed as we have now steps.</li>      
     <li>Still pending: issue 331.</li>    </ul>'
   version: '0.4-DRAFT-2020_07_23'
   version_date: 20200723T141248

--- a/_profiles/LabProtocol/0.4-DRAFT-2020_07_23.html
+++ b/_profiles/LabProtocol/0.4-DRAFT-2020_07_23.html
@@ -1,7 +1,7 @@
 ---
 name: LabProtocol
 
-previous_version: 
+previous_version: '0.3-DRAFT-2019_06_14'
 previous_release: 
 
 status: revision
@@ -32,7 +32,7 @@ spec_info:
     179</a>.</li>      <li>Links to the ontologies were revised.</li>      <li>Property
     descriptions were revised.</li>      <li>Description propery removed as we have now steps.</li>      
     <li>Still pending: issue 331.</li>    </ul>'
-  version: 0.4-DRAFT
+  version: '0.4-DRAFT-2020_07_23'
   version_date: 20200723T141248
   official_type: http://bioschemas.org/LabProtocol
   full_example: https://github.com/BioSchemas/Specifications/tree/master/LabProtocol/examples


### PR DESCRIPTION
Updates links to latest LabProtocol profile version (the PR https://github.com/BioSchemas/bioschemas.github.io/pull/307 only updated the YAML profile but not the links)