### PR TITLE
Updated LabProtocol to 0.5_DRAFT

### DIFF
--- a/_data/profile_versions.yaml
+++ b/_data/profile_versions.yaml
@@ -80,7 +80,7 @@ Journal:
 
 LabProtocol:
     name: "LabProtocol"
-    latest_publication: "0.4-DRAFT-2020_07_23"
+    latest_publication: "0.5-DRAFT-2020_09_01"
     latest_release:
     status: "active"
 

--- a/_profiles/LabProtocol/0.5-DRAFT-2020_09_01.html
+++ b/_profiles/LabProtocol/0.5-DRAFT-2020_09_01.html
@@ -1,8 +1,14 @@
 ---
+redirect_from:
+- "devSpecs/LabProtocol/specification"
+- "devSpecs/LabProtocol/specification/"
+- "/devSpecs/LabProtocol/"
+- "/specifications/drafts/LabProtocol"
+- "/profiles/LabProtocol/"
 
 name: LabProtocol
 
-previous_version: '0.3-DRAFT-2019_06_14'
+previous_version: '0.4-DRAFT-2020_07_23'
 previous_release: 
 
 status: revision
@@ -13,28 +19,38 @@ cross_walk_url: https://docs.google.com/spreadsheets/d/1RWYIphvcBMHl8SLJl5-xRMZI
 gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20LabProtocol
 live_deploy: ''
 
-parent_type: CreativeWork
+parent_type: labProtocol
 hierarchy:
 - Thing
 - CreativeWork
+- LabProtocol
 
 # spec_info content generated using GOWeb
 # DO NOT MANUALLY EDIT THE CONTENT
 spec_info:
   title: LabProtocol
-  subtitle: Bioschemas profile describing a LabProtocol in Life Sciences
+  subtitle: Bioschemas profile describing a LabProtocol in Life Sciences. An experimental
+    LabProtocol is a sequence of tasks and operations executed to perform experimental
+    research in biological and biomedical areas.
   description: 'This LabProtocol profile specification presents the markup for describing
-    a LabProtocol.<h4>Summary of Changes</h4>    Changes since previous draft of the
-    LabProtocols profile:    <ul>      <li>''used'' added at the end to elements used
-    in the protocol, see <a href=''https://github.com/BioSchemas/specifications/issues/265''>issue
-    265</a></li>      <li>Protocols advantages, limitations, outcomes, purpose and
-    application were mixed up in the previous draft, they have been revised.</li>      <li>Short
-    examples have been added per properties, see <a href=''https://github.com/BioSchemas/specifications/issues/179''>issue
-    179</a>.</li>      <li>Links to the ontologies were revised.</li>      <li>Property
-    descriptions were revised.</li>      <li>Description property removed as we have now steps.</li>      
-    <li>Still pending: issue 331.</li>    </ul>'
-  version: '0.4-DRAFT-2020_07_23'
-  version_date: 20200723T141248
+    a LabProtocol type according to Bioschemas. An experimental LabProtocol is a sequence of tasks 
+    and operations executed to perform experimental research in biological and biomedical areas. 
+    <h4>Summary of Changes</h4>    Changes since previous draft of the
+    LabProtocols profile:    <ul>      <li>LabProtocol profile definition updated
+    to the one on the type, see <a href=''https://github.com/BioSchemas/specifications/issues/331''>issue
+    331</a></li>      <li>Description property added, see <a href=''https://github.com/BioSchemas/specifications/issues/436''>issue
+    436</a></li>      <li>Title added as minimum, see <a href=''https://github.com/BioSchemas/specifications/issues/438''>issue
+    438</a>.</li>      <li>Protocol advantage property description updated, see <a
+    href=''https://github.com/BioSchemas/specifications/issues/440''>issue 440</a></li>      <li>Time
+    properties updated (totalTime as it was plus performTime and prepTime as optional),
+    see <a href=''https://github.com/BioSchemas/specifications/issues/441''>issue
+    441</a></li>      <li>ReagentUsed property description updated, now using CHEBI
+    definition, also MolecularEntity and ChemicalSubstance to the range list added,
+    see <a href=''https://github.com/BioSchemas/specifications/issues/442''>issue
+    442</a></li>            <li>LabProtocol now used as the parent type for this profile, 
+      see <a href=''https://github.com/BioSchemas/specifications/issues/443''>issue 443</a></li>    </ul>'
+  version: 0.5-DRAFT
+  version_date: 20200901T154721
   official_type: http://bioschemas.org/LabProtocol
   full_example: https://github.com/BioSchemas/Specifications/tree/master/LabProtocol/examples
 mapping:
@@ -149,6 +165,36 @@ mapping:
       "@type": "LabProtocol",
       "datePublished": "2014-10-01T19:30"
     }
+- property: description
+  expected_types:
+  - Text
+  description: A description of the item.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: ONE
+  controlled_vocab: ""
+  example: |-
+    {
+      "@type": "LabProtocol",
+      "description": "Quick overview of this lab protocol. Step 1: Use a solvent resistant maker... Step2: Record weight"
+    }
+- property: headline
+  expected_types:
+  - Text
+  description: Headline of the article.
+  type: ""
+  type_url: ""
+  bsc_description: Main title of the LabProtocol
+  marginality: Minimum
+  cardinality: ONE
+  controlled_vocab: ""
+  example: |-
+    {
+      "@type": "LabProtocol",
+      "headline": "Nanopore community protocol"
+    }
 - property: identifier
   expected_types:
   - PropertyValue
@@ -193,7 +239,7 @@ mapping:
 - property: isPartOf
   expected_types:
   - CreativeWork
-  - Trip
+  - URL
   description: 'Indicates an item or CreativeWork that this item, or CreativeWork
     (in some sense), is part of. Inverse property: hasPart.'
   type: ""
@@ -260,12 +306,45 @@ mapping:
       "@type": "LabProtocol",
       "URL": "https://creativecommons.org/licenses/by/4.0/"
     }
+- property: performTime
+  expected_types:
+  - Duration
+  description: The length of time it takes to perform instructions or a direction
+    (not including time to prepare the supplies), in ISO 8601 duration format.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: ONE
+  controlled_vocab: ""
+  example: |-
+    {
+      "@type": "LabProtocol",
+      "performTime": "10:00:00"
+    }
+- property: prepTime
+  expected_types:
+  - Duration
+  description: The length of time it takes to prepare the items to be used in instructions
+    or a direction, in ISO 8601 duration format.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: ONE
+  controlled_vocab: ""
+  example: |-
+    {
+      "@type": "LabProtocol",
+      "prepTime": "5:00:00"
+    }
 - property: protocolAdvantage
   expected_types:
   - CreativeWork
   - Text
-  description: Situations where the Protocol has been successfully employed (see more
-    information <a href="http://vocab.linkeddata.es/SMARTProtocols/myDocumentation_SPdoc_18Abril2017/index_SPdoc_V4.0.html#AdvantageOfTheProtocol">here</a>)
+  description: Situations where the Protocol has been successfully employed including
+    advantageous elements (e.g. better yield, shorter running time) (see more information
+    <a href="http://vocab.linkeddata.es/SMARTProtocols/myDocumentation_SPdoc_18Abril2017/index_SPdoc_V4.0.html#AdvantageOfTheProtocol">here</a>)
   type: bioschemas
   type_url: ""
   bsc_description: ""
@@ -351,11 +430,15 @@ mapping:
 - property: reagentUsed
   expected_types:
   - BioChemEntity
+  - MolecularEntity
+  - ChemicalSubstance
   - DefinedTerm
   - Text
   - URL
   description: Reagents used in the protocol. ChEBI and PubChem entities can be used
-    whenever available. Commercial names are also acceptable
+    whenever available. Commercial names are also acceptable. A reagent is defined
+    as 'A substance used in a chemical reaction to detect, measure, examine, or produce
+    other substances' in <a href='https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:33893'>CHEBI:33893</a>
   type: bioschemas
   type_url: ""
   bsc_description: ""
@@ -422,6 +505,7 @@ mapping:
       "@type": "LabProtocol",
       "totalTime": "15:00:00"
     }
+
 
 
 ---


### PR DESCRIPTION
Changes since previous draft of the LabProtocols profile:

- LabProtocol profile definition updated to the one on the type, see issue [331](https://github.com/BioSchemas/specifications/issues/331)
- Description property added, see issue [436](https://github.com/BioSchemas/specifications/issues/436)
- Title added as minimum, see issue [438](https://github.com/BioSchemas/specifications/issues/438)
- Protocol advantage property description updated, see issue [440](https://github.com/BioSchemas/specifications/issues/440)
- Time properties updated (totalTime as it was plus performTime and prepTime as optional), see issue [441](https://github.com/BioSchemas/specifications/issues/441)
- ReagentUsed property description updated, now using CHEBI definition, also MolecularEntity and ChemicalSubstance to the range list added, see issue [442](https://github.com/BioSchemas/specifications/issues/442)
- LabProtocol now used as the parent type for this profile, see issue [443](https://github.com/BioSchemas/specifications/issues/443)