### PR TITLE
Updated NMNHParis live deploy entry

### DIFF
--- a/_liveDeploys/liveDeploy.md
+++ b/_liveDeploys/liveDeploy.md
@@ -713,9 +713,19 @@ list:
     resource_URL: https://inpn.mnhn.fr/
     schema_org: Taxon
     bsc_profile: Taxon
-    bsc_ver: 0.4-DRAFT
+    bsc_ver: 0.7-DRAFT
     comments:    
     node:
+-
+    name: National Museum of Natural History of Paris
+    highlight: 180,000+ species have been annotated
+    example_URL: https://inpn.mnhn.fr/espece/cd_nom/60878/
+    resource_URL: https://inpn.mnhn.fr/
+    schema_org: TaxonName
+    bsc_profile: TaxonName
+    bsc_ver: 0.1-DRAFT
+    comments:    
+    node:    
 -
     name: FlyMine
     highlight:


### PR DESCRIPTION
National Museum of Natural History in Paris has updated the deployment to use the Taxon 0.7-DRAFT and TaxonName 0.1-DRAFT profiles. This PR updates the live deploy list to reflect this.