### PR TITLE
Redirect governance to Governance repo

### DIFF
--- a/community/governance.html
+++ b/community/governance.html
@@ -1,18 +1,5 @@
 ---
 layout: default
-title: Community
+title: Governance
+redirect_to: https://github.com/BioSchemas/governance/blob/master/governance.md
 ---
-
-<div class="outer" itemscope itemtype="http://schema.org/Organization">
-    <meta itemprop="logo" content="http://bioschemas.org/images/square_logo2.png"/>
-    <meta itemprop="url" content="http://bioschemas.org"/>
-    <meta itemprop="name" content="BioSchemas Community"/>
-    <meta itemprop="email" content="enquiries@bioschemas.org"/>
-
-
-    <h1>Governance</h1>
-    <p>The governance process for the development of specifications in the Bioschemas community is depicted in the figure below. The community can iterate on the development of a profile. Once a new stable version is available, this can be passed to the <a href="/community#leadership">leadership team</a> for approval. Once approved it will appear as the next stable release with a unique version number.</p>
-
-    <a href="/images/governance.jpg"><img src="/images/governance.jpg" alt="Goverance process for developing profiles in the Bioschemas community." /></a>
-
-</div>


### PR DESCRIPTION
Old governance page now redirects to latest governance document