### PR TITLE
Convert all uses of BioSchemas to Bioschemas

### DIFF
--- a/GSoC/index.html
+++ b/GSoC/index.html
@@ -99,7 +99,7 @@ This web page gives an overview of project ideas we are offering to students who
 <h4>Difficulty</h4>
 <ul><li>Hard</li></ul>
 <h4>References</h4>
-<ul><li><a href="https://github.com/BioSchemas/bioschemas-nutch-indexer">https://github.com/BioSchemas/bioschemas-nutch-indexer</a></li></ul></ul>
+<ul><li><a href="https://github.com/Bioschemas/bioschemas-nutch-indexer">https://github.com/Bioschemas/bioschemas-nutch-indexer</a></li></ul></ul>
 
 <h3>Map2Model</h3>
 <p>Automating the generation and publication of Bioschema's specifications from best practise guidelines.</p>
@@ -121,7 +121,7 @@ This web page gives an overview of project ideas we are offering to students who
 <h4>Rate difficulty</h4>
 <ul><li>Medium</li></ul></ul>
 <h4>References</h4>
-<ul><li><a href="https://github.com/BioSchemas/map2model">https://github.com/BioSchemas/map2model</a> </li>
+<ul><li><a href="https://github.com/Bioschemas/map2model">https://github.com/Bioschemas/map2model</a> </li>
 <li><a href="http://bioschemas.org/specifications/">http://bioschemas.org/specifications/</a></li></ul>
 
 <h3>Markup Builder</h3>
@@ -174,7 +174,7 @@ Extend the existing system such that:
 <h3>Bioschemas4JATS</h3>
 <p>How could we have infoboxes describing the content of a scientific publication? </p>
 <h4>Description</h4>
-<p>The Journal Article Tag Suite (JATS) is an XML format used to describe scientific literature published online. We want to define the representation of JATS data elements in schema.org and have this as an addition to BioSchemas. This projects requires an engaged critical thinker; the task at hand needs more analysis than coding. The student will analyze the JATS specification, determine what data elements from that specification describe the publication and the content and then, map these to Bioschemas. If needed, then the student will propose new data elements. If possible, the student will also design and implement the corresponding parser, making it easier to extract from JATS those data elements that are part of the resulting Bioschemas specification. </p>
+<p>The Journal Article Tag Suite (JATS) is an XML format used to describe scientific literature published online. We want to define the representation of JATS data elements in schema.org and have this as an addition to Bioschemas. This projects requires an engaged critical thinker; the task at hand needs more analysis than coding. The student will analyze the JATS specification, determine what data elements from that specification describe the publication and the content and then, map these to Bioschemas. If needed, then the student will propose new data elements. If possible, the student will also design and implement the corresponding parser, making it easier to extract from JATS those data elements that are part of the resulting Bioschemas specification. </p>
 <h4>Expected outcomes</h4>
 <ul><li>Mapping JATS data elements to Bioschemas </li>
 <li>Defining additional elements in Bioschemas that make it possible to describe a scientific publication </li>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The website is deployed using [Jekyll](https://jekyllrb.com/).
 See [installation instructions](https://jekyllrb.com/docs/installation/) for full details of installing Jekyll. Below are a quick set of commands that should hopefully get you going:
 
 - Install Jekyll and Dependencies: ```gem install jekyll bundler jekyll-redirect-from``` and ```gem install jekyll-sitemap```
-- Clone the repository: ```git clone https://github.com/BioSchemas/bioschemas.github.io.git```
+- Clone the repository: ```git clone https://github.com/Bioschemas/bioschemas.github.io.git```
 - Run the website: ```jekyll serve```
 
 ## Specifications subtree update
@@ -18,7 +18,7 @@ See [installation instructions](https://jekyllrb.com/docs/installation/) for ful
 
 ## Specifications subtree creation
 
-1. Reference to specifications repository using as local alias **subtree_specs** ```git remote add subtree_specs https://github.com/BioSchemas/specifications.git```
+1. Reference to specifications repository using as local alias **subtree_specs** ```git remote add subtree_specs https://github.com/Bioschemas/specifications.git```
 2. Subtree creation, the subtree is stored in the dir **_bsc_specs**, represented in the subtree command by the prefix value. ```subtree add --prefix=_bsc_specs/ subtree_specs master```
 3. ```git push origin master```
 

--- a/_bibliography/publications.bib
+++ b/_bibliography/publications.bib
@@ -1,4 +1,4 @@
-// File containing bibtex entries of papers about BioSchemas
+// File containing bibtex entries of papers about Bioschemas
 // These are rendered using a jekyll plugin
 
 @InProceedings{garciaetal2017:bioschemas:SWAT4HCLS2017,
@@ -60,7 +60,7 @@ OPTannote = {}
 
 @article{goble2017bioschemas-ismb-poster,
 abstract={Project Website: http://bioschemas.org/
-Source Code: https://github.com/BioSchemas/bioschemas
+Source Code: https://github.com/Bioschemas/bioschemas
 License: Creative Commons Attribution-ShareAlike License (version 3.0)
 Abstract
 Schema.org provides a way to add semantic markup to web pages. It describes ‘types’ of information, which then have ‘properties’. For example, ‘Event’ is a type that has properties like ‘startDate’, ‘endDate’ and ‘description’. Bioschemas aims to improve data interoperability in life sciences by encouraging people in life science to use schema.org markup. This structured information then makes it easier to discover, collate and analyse distributed data. Bioschemas reuses and extends schema.org in a number of ways: defining a minimum information model for the datatype being described using as few concepts as possible and only where necessary adding new properties, and the introduction of cardinalities and controlled vocabularies. The main outcome of Bioschemas is a collection of specifications that provide guidelines to facilitate a more consistent adoption of schema.org markup within the life sciences for the “Find” part of the FAIR (Findable, Accessible, Interoperable, Reusable) principles.

--- a/_config.yml
+++ b/_config.yml
@@ -6,15 +6,15 @@
 # 'jekyll serve'. If you change this file, please restart the server process.
 
 # Site settings
-title: BioSchemas
+title: Bioschemas
 email: contact@bioschemas.org
 description: > # this means to ignore newlines until "baseurl:"
-  BioSchemas relies and extends from schema.org and aims to reuse existing
+  Bioschemas relies and extends from schema.org and aims to reuse existing
   standards and reach consensus among a wide number of life sciences organizations and communities.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "http://bioschemas.org" # the base hostname & protocol for your site
-twitter_username: BioSchemas
-github_username:  BioSchemas
+twitter_username: Bioschemas
+github_username:  Bioschemas
 permalink: /404.html
 
 # Build settings

--- a/_groups/Beacons.md
+++ b/_groups/Beacons.md
@@ -8,7 +8,7 @@ type: generic
 description: Specification for Beacon Type
 lead: [SerenaScollen, AudaldLloret]
 email: enquiries@bioschemas.org
-issues: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Beacon
+issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Beacon
 folder: https://drive.google.com/drive/folders/0BwpCuN9mloG8WTl6X3hkeFIwems
 
 # Page attributes

--- a/_groups/Biodiversity.md
+++ b/_groups/Biodiversity.md
@@ -8,7 +8,7 @@ type: biological
 description: Specification for biodiversity-related profiles and/or types
 lead: [FranckMichel, LeylaGarcia]
 email: enquiries@bioschemas.org
-issues: https://github.com/BioSchemas/specifications/labels/type%3A%20Taxon
+issues: https://github.com/Bioschemas/specifications/labels/type%3A%20Taxon
 folder: https://drive.google.com/drive/folders/1Fp2AKbb07So7rVvUhnQIjpl8HLPSwpbP
 
 # Page attributes

--- a/_groups/BiologicalEntities.md
+++ b/_groups/BiologicalEntities.md
@@ -8,7 +8,7 @@ type: generic
 description: Specification for biological entities
 lead: [CarlosHorro, LeylaGarcia, PhilippeRocca-Serra]
 email: enquiries@bioschemas.org
-issues: https://github.com/BioSchemas/bioschemas/labels/type%3A%20biochementity
+issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20biochementity
 folder: https://drive.google.com/open?id=0B0fE3oOZIq44MUxtQWlYYmdvWnc
 
 # Page attributes

--- a/_groups/Chemicals.md
+++ b/_groups/Chemicals.md
@@ -8,7 +8,7 @@ type: biological
 description: Specification for protein type
 lead: [EgonWillighagen, RicardoArcila, DavidMendez]
 email: enquiries@bioschemas.org
-issues: https://github.com/BioSchemas/specifications/labels/type%3A%20Chemistry
+issues: https://github.com/Bioschemas/specifications/labels/type%3A%20Chemistry
 folder: https://drive.google.com/drive/folders/0B7J0zlrcfEkGNnk3MXhyb01mTEk
 
 # Page attributes

--- a/_groups/Community.md
+++ b/_groups/Community.md
@@ -8,7 +8,7 @@ type: other
 description: 'The objective of this workstream is to support this project and the involvement of the Bioschemas community.'
 lead: [CaroleGoble, AlasdairGray]
 email: enquiries@bioschemas.org
-issues: https://github.com/BioSchemas/bioschemas/labels/topic%3A%20community
+issues: https://github.com/Bioschemas/bioschemas/labels/topic%3A%20community
 folder: https://drive.google.com/drive/u/1/folders/0Bw_p-HKWUjHoRWgxWHcwVHNQUGM
 
 abstract: 'This project includes many stakeholders and several workstreams. For this project to be successful it will require good communication and coordination, not just among partners but also with the Bioschemas community.'

--- a/_groups/DNA.md
+++ b/_groups/DNA.md
@@ -9,7 +9,7 @@ type: biological
 description: Specification for DNA Type
 lead: [JamesAlastairMcLaughlin, ChristianAtallah]
 email: enquiries@bioschemas.org
-issues: https://github.com/BioSchemas/specifications/labels/type%3A%20DNA
+issues: https://github.com/Bioschemas/specifications/labels/type%3A%20DNA
 folder: https://drive.google.com/drive/folders/1Ar4E1UivzIfCxi8MB_FzYSkEO_EUbe8e
 
 # Page attributes

--- a/_groups/DataRepositories.md
+++ b/_groups/DataRepositories.md
@@ -8,7 +8,7 @@ type: generic
 description: Specification for data catalog profile
 lead: [HenningHermjakob]
 email: enquiries@bioschemas.org
-issues: https://github.com/BioSchemas/bioschemas/labels/type%3A%20DataCatalog
+issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20DataCatalog
 folder: https://drive.google.com/open?id=0Bw_p-HKWUjHoNDJNUWltYVBkV1k
 
 # Page attributes

--- a/_groups/Datasets.md
+++ b/_groups/Datasets.md
@@ -8,7 +8,7 @@ type: generic
 description: Specification for Dataset
 lead: [SusannaSansone]
 email: enquiries@bioschemas.org
-issues: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Dataset
+issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Dataset
 folder: https://drive.google.com/open?id=0B2tKthYRS0f5aEhkU1Q4aEE5TEU
 
 # Page attributes

--- a/_groups/Events.md
+++ b/_groups/Events.md
@@ -8,7 +8,7 @@ type: generic
 description: Specification for events
 lead: [MartinCook]
 email: enquiries@bioschemas.org
-issues: https://github.com/BioSchemas/bioschemas/labels/type%3A%20event
+issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20event
 folder: https://drive.google.com/drive/u/1/folders/0B6crv12s8piRODVQX2U2NHlkdXM
 
 # Page attributes

--- a/_groups/Genes.md
+++ b/_groups/Genes.md
@@ -8,7 +8,7 @@ type: generic
 description: Specification for Beacon Type
 lead: [LeylaGarcia, DeniseCarvalho-Silva]
 email: enquiries@bioschemas.org
-issues: https://github.com/BioSchemas/specifications/labels/type%3A%20Gene
+issues: https://github.com/Bioschemas/specifications/labels/type%3A%20Gene
 folder: https://drive.google.com/open?id=10Qf59xiMItW4c48jYh3S1LEd8cCFv0sW
 
 # Page attributes

--- a/_groups/LabProtocols.md
+++ b/_groups/LabProtocols.md
@@ -8,7 +8,7 @@ type: generic
 description: Specification for biological laboratory protocol Type
 lead: [OlgaXimenaGiraldo, AlexanderGarcia]
 email: enquiries@bioschemas.org
-issues: https://github.com/BioSchemas/bioschemas/labels/type%3A%20LabProtocol
+issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20LabProtocol
 folder: https://drive.google.com/drive/folders/0B0fE3oOZIq44TzFwejFEbE9WdXM
 
 # Page attributes

--- a/_groups/Organizations.md
+++ b/_groups/Organizations.md
@@ -8,7 +8,7 @@ type: generic
 description: Specification for organization
 lead: [RafaelJimenez, RichardHolland]
 email: enquiries@bioschemas.org
-issues: https://github.com/BioSchemas/bioschemas/labels/type%3A%20organization
+issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20organization
 folder: https://drive.google.com/drive/u/1/folders/0B1TdgUL4-iBaOXVaZ0szWlRQc2M
 
 # Page attributes

--- a/_groups/People.md
+++ b/_groups/People.md
@@ -8,7 +8,7 @@ type: generic
 description: Specification for describing people
 lead: [NiallBeard]
 email: enquiries@bioschemas.org
-issues: https://github.com/BioSchemas/bioschemas/labels/type%3A%20person
+issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20person
 folder: https://drive.google.com/drive/u/1/folders/0B6crv12s8piRd1hFM2JUeS1wSEk
 
 # Page attributes

--- a/_groups/Phenotypes.md
+++ b/_groups/Phenotypes.md
@@ -8,7 +8,7 @@ type: biological
 description: Specification for phenotype profile
 lead: [FedericoLopezGomez]
 email: enquiries@bioschemas.org
-issues: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Phenotype
+issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Phenotype
 folder: https://drive.google.com/open?id=1zznGVUcp4yTSzyMoIA7BF9k-nieOSHbL
 
 # Page attributes

--- a/_groups/Proteins.md
+++ b/_groups/Proteins.md
@@ -8,7 +8,7 @@ type: biological
 description: Specification for protein type
 lead: [MariaMartin, LeylaGarcia]
 email: enquiries@bioschemas.org
-issues: https://github.com/BioSchemas/bioschemas/labels/type%3A%20protein
+issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20protein
 folder: https://drive.google.com/drive/folders/0B0fE3oOZIq44eFktTmhFQlhLeDA
 
 # Page attributes

--- a/_groups/Publications.md
+++ b/_groups/Publications.md
@@ -9,11 +9,11 @@ description: Specifications for scholarly publication related profiles
 lead: [AlexanderGarcia, LeylaGarcia]
 email: enquiries@bioschemas.org
 issues:
-  - https://github.com/BioSchemas/bioschemas/labels/type%3A%20Scholarlyarticle
-  - https://github.com/BioSchemas/bioschemas/labels/type%3A%20Journal
-  - https://github.com/BioSchemas/bioschemas/labels/type%3A%20PublicationIssue
-  - https://github.com/BioSchemas/bioschemas/labels/type%3A%20PublicationVolume
-  - https://github.com/BioSchemas/bioschemas/labels/type%3A%20SemanticAnnotation
+  - https://github.com/Bioschemas/bioschemas/labels/type%3A%20Scholarlyarticle
+  - https://github.com/Bioschemas/bioschemas/labels/type%3A%20Journal
+  - https://github.com/Bioschemas/bioschemas/labels/type%3A%20PublicationIssue
+  - https://github.com/Bioschemas/bioschemas/labels/type%3A%20PublicationVolume
+  - https://github.com/Bioschemas/bioschemas/labels/type%3A%20SemanticAnnotation
 folder:
   - https://drive.google.com/drive/folders/1CgEyta4d7vFfYT7r7w9HtLZ4kAidDmJI
 

--- a/_groups/Samples.md
+++ b/_groups/Samples.md
@@ -8,7 +8,7 @@ type: biological
 description: Specification for sample profile
 lead: [HelenParkinson, TonyBurdett, MelanieCourtot]
 email: enquiries@bioschemas.org
-issues: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Sample
+issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Sample
 folder: https://drive.google.com/drive/folders/0Bw_p-HKWUjHoaWhkTnBka2FWRE0
 
 # Page attributes

--- a/_groups/Standards.md
+++ b/_groups/Standards.md
@@ -8,7 +8,7 @@ type: generic
 description: Specification for standards
 lead: [PeterMcQuilton]
 email: enquiries@bioschemas.org
-issues: https://github.com/BioSchemas/bioschemas/labels/type%3A%20standard
+issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20standard
 folder: https://drive.google.com/drive/u/1/folders/0Bw_p-HKWUjHoaDRIWlVwUXNJcHM
 
 # Page attributes

--- a/_groups/Studies.md
+++ b/_groups/Studies.md
@@ -8,7 +8,7 @@ type: generic
 description: Developing a profile and type to capture studies and their associated projects
 lead: [To be determined]
 email: enquiries@bioschemas.org    
-issues: https://github.com/BioSchemas/specifications/labels/type%3A%20Study
+issues: https://github.com/Bioschemas/specifications/labels/type%3A%20Study
 folder: https://drive.google.com/drive/folders/1ml4elMOIlLUOie4i8gnXmP5eNn-8D2QD
 
 # Page attributes

--- a/_groups/Technical.md
+++ b/_groups/Technical.md
@@ -9,7 +9,7 @@ type: generic
 description:
 lead: [JustinClark-Casey]
 email: enquiries@bioschemas.org
-issues: https://github.com/BioSchemas/bioschemas/labels/SupportSoftware
+issues: https://github.com/Bioschemas/bioschemas/labels/SupportSoftware
 
 # Page attributes
 abstract: 'The technical group focus on aspects of implementing <a href="http://bioschemas.org">Bioschemas</a> markup. Please see the <a href="http://bioschemas.org/specifications/">Specifications</a> page for the schemas themselves. Please see the <a href="http://bioschemas.org/tools/">tools</a> page for tools that can help in publishing or consuming markup.'
@@ -26,7 +26,7 @@ members:
     <h3>Links</h3>
     <ul>
         <li>
-            <a href="https://github.com/BioSchemas/specifications/wiki/Technical">Main wiki page for Bioschemas implementation information </a>
+            <a href="https://github.com/Bioschemas/specifications/wiki/Technical">Main wiki page for Bioschemas implementation information </a>
         </li>
     </ul>
 </div>

--- a/_groups/Tools.md
+++ b/_groups/Tools.md
@@ -8,7 +8,7 @@ type: generic
 description: Specification for tools
 lead: [RicardoArcila, JustinClark-Casey, LeylaGarcia]
 email: enquiries@bioschemas.org
-issues: https://github.com/BioSchemas/bioschemas/labels/type%3A%20tool
+issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20tool
 folder: https://drive.google.com/open?id=0BzDhyOWTnRNTYkdQNHppUjZ3U2M
 
 # Page attributes

--- a/_groups/Training.md
+++ b/_groups/Training.md
@@ -8,7 +8,7 @@ type: generic
 description: Specification for describing training resources such as materials and courses.
 lead: [NiallBeard, GabriellaRustici]
 email: enquiries@bioschemas.org
-issues: https://github.com/BioSchemas/bioschemas/labels/type%3A%20training%20material
+issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20training%20material
 folder: https://drive.google.com/drive/u/1/folders/0B6crv12s8piRT0w5VXRUc09VTFU
 
 # Page attributes

--- a/_groups/Validation.md
+++ b/_groups/Validation.md
@@ -10,7 +10,7 @@ lead: [AlasdairGray]
 email: enquiries@bioschemas.org
 
 # Progress status
-issues: https://github.com/BioSchemas/bioschemas/labels/Validation
+issues: https://github.com/Bioschemas/bioschemas/labels/Validation
 
 # Page attributes
 abstract: 'Though search engines provide validation of the schema.org structured data provided in a page it does not make an analysis of the content of a site and do not validate important features in Bioschemas like compliance with content guidelines, vocabularies or cardinality.'

--- a/_groups/Workflow.md
+++ b/_groups/Workflow.md
@@ -8,7 +8,7 @@ type: generic
 description: Description for Workflow related data, pattern of activities and so on.
 lead: [AlanWilliams, StuartOwen, BertDroesbeke]
 email: enquiries@bioschemas.org
-issues: https://github.com/BioSchemas/bioschemas/labels/type%3A%20ComputationalWorkflow
+issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20ComputationalWorkflow
 folder: https://drive.google.com/open?id=10QSvgnEGFXTeOT8qz4-4xwZgLT5GJrqG
 
 # Page attributes

--- a/_groups/_unused_/ProteinAnnotation.md
+++ b/_groups/_unused_/ProteinAnnotation.md
@@ -8,7 +8,7 @@ active: true
 type: biological
 description: Specification for protein annotation profile
 lead: [MariaMartin]
-issues: https://github.com/BioSchemas/bioschemas/labels/type%3A%20proteinannotations
+issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20proteinannotations
 folder: https://drive.google.com/drive/folders/0B0fE3oOZIq44c2dqVVRkaVZ6X2M
 
 # Progress status

--- a/_groups/_unused_/ProteinStructure.md
+++ b/_groups/_unused_/ProteinStructure.md
@@ -8,7 +8,7 @@ active: true
 type: biological
 description: Specification for protein structure profile
 lead: [MariaMartin]
-issues: https://github.com/BioSchemas/bioschemas/labels/type%3A%20proteinstructure
+issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20proteinstructure
 folder: https://drive.google.com/drive/folders/0B0fE3oOZIq44U1gzLWgtV0VBaTQ
 
 # Progress status

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <title>{% if page.title %}
-  			{{ page.title | prepend:'BioSchemas - ' | escape }}
+  			{{ page.title | prepend:'Bioschemas - ' | escape }}
   		{% else %}
   			{{ site.title | escape }}
   		{% endif %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,7 +3,7 @@
 <div id="header_wrap" class="outer">
     <header class="inner">
 
-        <a id="forkme_banner" href="https://github.com/BioSchemas">GitHub</a>
+        <a id="forkme_banner" href="https://github.com/Bioschemas">GitHub</a>
         <a id="twitter_banner" href="https://twitter.com/bioschemas">Twitter</a>
 
         <div class="biohex-logo">
@@ -17,7 +17,7 @@
 
         {% if page.spec_type != "Profile" and page.spec_type != "Type"%}
         <div class="git-edit">
-            <a target="_blank" href="https://github.com/BioSchemas/bioschemas.github.io/tree/master/{{page.path}}" class="btn btn-bioschema btn-sm" role="button">
+            <a target="_blank" href="https://github.com/Bioschemas/bioschemas.github.io/tree/master/{{page.path}}" class="btn btn-bioschema btn-sm" role="button">
                 <b>Edit me&nbsp;</b>
                 <i class="fas fa-pencil-alt"></i>
             </a>        

--- a/_includes/mobile_navbar.html
+++ b/_includes/mobile_navbar.html
@@ -20,7 +20,7 @@
         <p><a href="/people/" class="link-navbar"><div class="mobile_buttons">People</div></a></p>
         <p><a href="/publications/" class="link-navbar"><div class="mobile_buttons">Publications</div></a></p>
         <p><a href="/community/" class="link-navbar"><div class="mobile_buttons">Community</div></a></p>
-        <p><a href="https://github.com/BioSchemas/governance/blob/master/governance.md" class="link-navbar"><div class="mobile_buttons">Governance</div></a></p>
+        <p><a href="https://github.com/Bioschemas/governance/blob/master/governance.md" class="link-navbar"><div class="mobile_buttons">Governance</div></a></p>
         <p><a href="/liveDeploys/" class="link-navbar"><div class="mobile_buttons">Live deploys</div></a></p>
     </div>
 

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -20,7 +20,7 @@
           <div class="dropdown-menu" aria-labelledby="btnCommunity">
             <a class="dropdown-item" href="http://www.macs.hw.ac.uk/SWeL/BioschemasGenerator/">Markup Generator</a>
             <a class="dropdown-item" href="/software/">Tools</a>
-            <a class="dropdown-item" href="https://github.com/BioSchemas/specifications/wiki/Technical">Technical Wiki</a>
+            <a class="dropdown-item" href="https://github.com/Bioschemas/specifications/wiki/Technical">Technical Wiki</a>
             <a class="dropdown-item" href="/liveDeploys/">Live deploys</a>
           </div>
         </div>
@@ -41,8 +41,8 @@
             About
             </button>
             <div class="dropdown-menu" aria-labelledby="btnCommunity">
-                <a class="dropdown-item" href="https://github.com/BioSchemas/governance/blob/master/governance.md">Governance</a>
-                <a class="dropdown-item" href="https://github.com/BioSchemas/governance/blob/master/codeOfConduct.md">Code of Conduct</a>
+                <a class="dropdown-item" href="https://github.com/Bioschemas/governance/blob/master/governance.md">Governance</a>
+                <a class="dropdown-item" href="https://github.com/Bioschemas/governance/blob/master/codeOfConduct.md">Code of Conduct</a>
                 <a class="dropdown-item" href="/publications/">Publications</a>
                 <a class="dropdown-item" href="/funders">Funders</a>
                 <a class="dropdown-item" href="/community/logos">Logos</a>

--- a/_includes/profile_start.html
+++ b/_includes/profile_start.html
@@ -171,55 +171,55 @@
             <td class="spec_links">
                {% if page.use_cases_url == '' or page.use_cases_url == nil %}
                <a>
-               <img src="/images/use_case_spec.png" alt="View BioSchemas {{ page.name }} Use Cases"  style="filter: grayscale(100%);">
+               <img src="/images/use_case_spec.png" alt="View Bioschemas {{ page.name }} Use Cases"  style="filter: grayscale(100%);">
                </a>
                {%else%}
                <a href="{{page.use_cases_url}}">
-               <img src="/images/use_case_spec.png" alt="View BioSchemas {{ page.name }} Use Cases">
+               <img src="/images/use_case_spec.png" alt="View Bioschemas {{ page.name }} Use Cases">
                </a>
                {%endif%}
             </td>
             <td class="spec_links">
                {% if page.cross_walk_url == '' %}
                <a>
-               <img src="/images/cross_walk.png" alt="View BioSchemas {{ page.name }} Cross Walk"  style="filter: grayscale(100%);">
+               <img src="/images/cross_walk.png" alt="View Bioschemas {{ page.name }} Cross Walk"  style="filter: grayscale(100%);">
                </a>
                {%else%}
                <a href="{{page.cross_walk_url}}" target="_blank">
-               <img src="/images/cross_walk.png" alt="View BioSchemas {{ page.name }} Cross Walk">
+               <img src="/images/cross_walk.png" alt="View Bioschemas {{ page.name }} Cross Walk">
                </a>
                {%endif%}
             </td>
             <td class="spec_links">
                {% if page.gh_tasks == '' %}
                <a>
-               <img src="/images/specs_tasks.png" alt="BioSchemas {{ page.name }} Github Tasks or Issues" style="filter: grayscale(100%);">
+               <img src="/images/specs_tasks.png" alt="Bioschemas {{ page.name }} Github Tasks or Issues" style="filter: grayscale(100%);">
                </a>
                {% else %}
                <a href="{{page.gh_tasks}}" target="_blank">
-               <img src="/images/specs_tasks.png" alt="BioSchemas {{ page.name }} Github Tasks or Issues">
+               <img src="/images/specs_tasks.png" alt="Bioschemas {{ page.name }} Github Tasks or Issues">
                </a>
                {% endif %}
             </td>
             <td class="spec_links" target="_blank">
                {% if page.spec_info.full_example == '' %}
                <a>
-               <img src="/images/spec_examples.png" alt="View BioSchemas {{ page.name }} Examples" style="filter: grayscale(100%);">
+               <img src="/images/spec_examples.png" alt="View Bioschemas {{ page.name }} Examples" style="filter: grayscale(100%);">
                </a>
                {% else %}
                <a href="{{page.spec_info.full_example}}" target="_blank">
-               <img src="/images/spec_examples.png" alt="View BioSchemas {{ page.name }} Examples">
+               <img src="/images/spec_examples.png" alt="View Bioschemas {{ page.name }} Examples">
                </a>
                {% endif %}
             </td>
             <td class="spec_links">
                {% if page.live_deploy == '' %}
                <a>
-               <img src="/images/live_deploy.png" alt="View BioSchemas {{ page.name }} Examples" style="filter: grayscale(100%);">
+               <img src="/images/live_deploy.png" alt="View Bioschemas {{ page.name }} Examples" style="filter: grayscale(100%);">
                </a>
                {% else %}
                <a href="{{page.live_deploy}}">
-               <img src="/images/live_deploy.png" alt="View BioSchemas {{ page.name }} Examples">
+               <img src="/images/live_deploy.png" alt="View Bioschemas {{ page.name }} Examples">
                </a>
                {% endif %}
             </td>

--- a/_includes/profile_table_rows.html
+++ b/_includes/profile_table_rows.html
@@ -16,55 +16,55 @@
           <td class="spec_links">
             {% if spec.use_cases_url == '' or spec.use_cases_url == nil %}
             <a>
-            <img src="/images/use_case_spec.png" alt="View BioSchemas {{ spec.spec_info.title }} Use Cases"  style="filter: grayscale(100%);">
+            <img src="/images/use_case_spec.png" alt="View Bioschemas {{ spec.spec_info.title }} Use Cases"  style="filter: grayscale(100%);">
             </a>
             {%else%}
             <a href="{{spec.use_cases_url}}">
-            <img src="/images/use_case_spec.png" alt="View BioSchemas {{ spec.spec_info.title }} Use Cases">
+            <img src="/images/use_case_spec.png" alt="View Bioschemas {{ spec.spec_info.title }} Use Cases">
             </a>
             {%endif%}
           </td>
           <td class="spec_links">
             {% if spec.cross_walk_url == '' %}
             <a>
-            <img src="/images/cross_walk.png" alt="View BioSchemas {{ spec.spec_info.title }} Cross Walk"  style="filter: grayscale(100%);">
+            <img src="/images/cross_walk.png" alt="View Bioschemas {{ spec.spec_info.title }} Cross Walk"  style="filter: grayscale(100%);">
             </a>
             {%else%}
             <a href="{{spec.cross_walk_url}}" target="_blank">
-            <img src="/images/cross_walk.png" alt="View BioSchemas {{ spec.spec_info.title }} Cross Walk">
+            <img src="/images/cross_walk.png" alt="View Bioschemas {{ spec.spec_info.title }} Cross Walk">
             </a>
             {%endif%}
           </td>
           <td class="spec_links">
             {% if spec.gh_tasks == '' %}
             <a>
-            <img src="/images/specs_tasks.png" alt="BioSchemas {{ spec.spec_info.title }} Github Tasks or Issues" style="filter: grayscale(100%);">
+            <img src="/images/specs_tasks.png" alt="Bioschemas {{ spec.spec_info.title }} Github Tasks or Issues" style="filter: grayscale(100%);">
             </a>
             {% else %}
             <a href="{{spec.gh_tasks}}" target="_blank">
-            <img src="/images/specs_tasks.png" alt="BioSchemas {{ spec.spec_info.title }} Github Tasks or Issues">
+            <img src="/images/specs_tasks.png" alt="Bioschemas {{ spec.spec_info.title }} Github Tasks or Issues">
             </a>
             {% endif %}
           </td>
           <td class="spec_links">
             {% if spec.spec_info.full_example == '' %}
             <a>
-            <img src="/images/spec_examples.png" alt="View BioSchemas {{ spec.spec_info.title }} Examples" style="filter: grayscale(100%);">
+            <img src="/images/spec_examples.png" alt="View Bioschemas {{ spec.spec_info.title }} Examples" style="filter: grayscale(100%);">
             </a>
             {% else %}
             <a href="{{spec.spec_info.full_example}}" target="_blank">
-            <img src="/images/spec_examples.png" alt="View BioSchemas {{ spec.spec_info.title }} Examples">
+            <img src="/images/spec_examples.png" alt="View Bioschemas {{ spec.spec_info.title }} Examples">
             </a>
             {% endif %}
           </td>
           <td class="spec_links">
             {% if spec.live_deploy == '' %}
             <a>
-            <img src="/images/live_deploy.png" alt="View BioSchemas {{ spec.spec_info.title }} Examples" style="filter: grayscale(100%);">
+            <img src="/images/live_deploy.png" alt="View Bioschemas {{ spec.spec_info.title }} Examples" style="filter: grayscale(100%);">
             </a>
             {% else %}
             <a href="{{spec.live_deploy}}">
-            <img src="/images/live_deploy.png" alt="View BioSchemas {{ spec.spec_info.title }} Examples">
+            <img src="/images/live_deploy.png" alt="View Bioschemas {{ spec.spec_info.title }} Examples">
             </a>
             {% endif %}
           </td>

--- a/_includes/type_start.html
+++ b/_includes/type_start.html
@@ -155,11 +155,11 @@ This is a new {{page.spec_type}} that fits into the schema.org hierarchy as foll
     <td class="spec_links">
         {% if page.gh_tasks == '' %}
           <a>
-            <img src="/images/specs_tasks.png" alt="BioSchemas {{ spec.name }} Github Tasks or Issues" style="filter: grayscale(100%);">
+            <img src="/images/specs_tasks.png" alt="Bioschemas {{ spec.name }} Github Tasks or Issues" style="filter: grayscale(100%);">
           </a>
         {% else %}
           <a href="{{page.gh_tasks}}" target="_blank">
-            <img src="/images/specs_tasks.png" alt="BioSchemas {{ spec.name }} Github Tasks or Issues">
+            <img src="/images/specs_tasks.png" alt="Bioschemas {{ spec.name }} Github Tasks or Issues">
           </a>
         {% endif %}
     </td>

--- a/_layouts/group-details.html
+++ b/_layouts/group-details.html
@@ -25,11 +25,11 @@
                            <td class="spec_links">
                               {% if page.folder %}
                               <a href="{{page.folder}}" target="_blank">
-                                <img src="/images/Google_Drive_logo.png" alt="View BioSchemas {{ page.name }} Folder">
+                                <img src="/images/Google_Drive_logo.png" alt="View Bioschemas {{ page.name }} Folder">
                               </a>
                               {%else%}
                               <a>
-                                <img src="/images/Google_Drive_logo.png" alt="View BioSchemas {{ page.name }} Folder"  style="filter: grayscale(100%);">
+                                <img src="/images/Google_Drive_logo.png" alt="View Bioschemas {{ page.name }} Folder"  style="filter: grayscale(100%);">
                               </a>
                               {%endif%}
                            </td>
@@ -37,11 +37,11 @@
                            <td class="spec_links">
                               {% if page.gh_tasks == '' %}
                               <a>
-                              <img src="/images/specs_tasks.png" alt="BioSchemas {{ page.name }} Github Tasks or Issues" style="filter: grayscale(100%);">
+                              <img src="/images/specs_tasks.png" alt="Bioschemas {{ page.name }} Github Tasks or Issues" style="filter: grayscale(100%);">
                               </a>
                               {% else %}
                               <a href="{{page.issues}}" target="_blank">
-                              <img src="/images/specs_tasks.png" alt="BioSchemas {{ page.name }} Github Tasks or Issues">
+                              <img src="/images/specs_tasks.png" alt="Bioschemas {{ page.name }} Github Tasks or Issues">
                               </a>
                               {% endif %}
                            </td>

--- a/_meetings/2015-11_BMBWorkshop.html
+++ b/_meetings/2015-11_BMBWorkshop.html
@@ -1,6 +1,6 @@
 ---
 layout: meeting
-name: BioSchemas Community Workshop
+name: Bioschemas Community Workshop
 title: BMB Satellite Workshop
 dates: 19 November 2015
 start_date: 2015-11-19

--- a/_profiles/Beacon/0.2-DRAFT-2018_04_23.html
+++ b/_profiles/Beacon/0.2-DRAFT-2018_04_23.html
@@ -16,7 +16,7 @@ spec_type: Profile
 group: beacons
 use_cases_url: /useCases/Beacon/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1Hl-K9wBtp8Ys0OJxzj8SC72xDKX_OeKDSs5ioZpPfTw/
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Beacon
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Beacon
 live_deploy: ''
 
 parent_type: DataCatalog
@@ -37,7 +37,7 @@ spec_info:
   version: 0.2-DRAFT-2018_04_23
   version_date: 20180423T140938
   official_type: ""
-  full_example: https://github.com/BioSchemas/specifications/tree/master/Beacon/examples
+  full_example: https://github.com/Bioschemas/specifications/tree/master/Beacon/examples
 mapping:
 - property: aggregator
   expected_types:

--- a/_profiles/BioSample/0.1-DRAFT-2019_11_12.html
+++ b/_profiles/BioSample/0.1-DRAFT-2019_11_12.html
@@ -15,7 +15,7 @@ spec_type: Profile
 group: samples
 use_cases_url: /useCases/Sample/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1kcq7fEP1sQ9zf2YRNoyUYY87ahkz4ZsnRXHEb89KiOg
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Sample
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Sample
 live_deploy: ''
 
 parent_type: BioChemEntity

--- a/_profiles/ChemicalSubstance/0.1-DRAFT-2018_12_07.html
+++ b/_profiles/ChemicalSubstance/0.1-DRAFT-2018_12_07.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: chemicals
 use_cases_url: '/useCases/ChemicalSubstance/'
 cross_walk_url: 'https://docs.google.com/spreadsheets/d/1ZuJHrUwpkWACAt0De6OXhlWZ9pSRTJ1m9H954i8-FvQ/edit?ts=5bebfe78&pli=1#gid=1261485211'
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Chemistry
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Chemistry
 live_deploy: ''
 
 parent_type: Thing
@@ -29,7 +29,7 @@ spec_info:
   version: 0.1-DRAFT-2018_12_07
   version_date: 20181207T110158
   official_type: ""
-  full_example: https://github.com/BioSchemas/specifications/tree/master/ChemicalSubstance/examples/0.1-DRAFT/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/ChemicalSubstance/examples/0.1-DRAFT/
 mapping:
 - property: alternateName
   expected_types:

--- a/_profiles/ChemicalSubstance/0.2-DRAFT-2019_06_11.html
+++ b/_profiles/ChemicalSubstance/0.2-DRAFT-2019_06_11.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: chemicals
 use_cases_url: '/useCases/ChemicalSubstance/'
 cross_walk_url: 'https://docs.google.com/spreadsheets/d/1-E7IbF6Fe2uMyTpWMvthci8Lx58kXxlcz8BiXLmJTdk/'
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Chemistry
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Chemistry
 live_deploy: ''
 
 parent_type: Thing
@@ -29,7 +29,7 @@ spec_info:
   version: 0.2-DRAFT-2019_06_11
   version_date: 20190611T145905
   official_type: ""
-  full_example: https://github.com/BioSchemas/specifications/tree/master/ChemicalSubstance/examples
+  full_example: https://github.com/Bioschemas/specifications/tree/master/ChemicalSubstance/examples
 mapping:
 - property: alternateName
   expected_types:

--- a/_profiles/ChemicalSubstance/0.3-DRAFT-2019_11_11.html
+++ b/_profiles/ChemicalSubstance/0.3-DRAFT-2019_11_11.html
@@ -10,7 +10,7 @@ spec_type: Profile
 group: chemicals
 use_cases_url: '/useCases/ChemicalSubstance/'
 cross_walk_url: 'https://docs.google.com/spreadsheets/d/1z1PsEDmDEADzc5NgvPlwEyXxAAA_m3U4QE5jrW8Qly8/edit#gid=1483018794'
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Chemistry
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Chemistry
 live_deploy: ''
 
 parent_type: Thing
@@ -30,7 +30,7 @@ spec_info:
   version: 0.3-DRAFT-2019_11_11
   version_date: 20191111T161831
   official_type: ""
-  full_example: https://github.com/BioSchemas/specifications/tree/master/ChemicalSubstance/examples
+  full_example: https://github.com/Bioschemas/specifications/tree/master/ChemicalSubstance/examples
 mapping:
 - property: alternateName
   expected_types:

--- a/_profiles/ChemicalSubstance/0.4-RELEASE.html
+++ b/_profiles/ChemicalSubstance/0.4-RELEASE.html
@@ -16,7 +16,7 @@ spec_type: Profile
 group: chemicals
 use_cases_url: '/useCases/ChemicalSubstance/'
 cross_walk_url: 'https://docs.google.com/spreadsheets/d/1rf-tiNFfRq-Sjt_gbnyK_rs1ofcVOqdHDh9Wp-RdiRI/edit#gid=1483018794'
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Chemistry
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Chemistry
 live_deploy: ''
 
 parent_type: Thing
@@ -39,7 +39,7 @@ spec_info:
   version: 0.4-RELEASE
   version_date: 20200407T114823
   official_type: ""
-  full_example: https://github.com/BioSchemas/specifications/tree/master/ChemicalSubstance/examples
+  full_example: https://github.com/Bioschemas/specifications/tree/master/ChemicalSubstance/examples
 mapping:
 - property: alternateName
   expected_types:

--- a/_profiles/ComputationalWorkflow/0.1-DRAFT-2019_02_08.html
+++ b/_profiles/ComputationalWorkflow/0.1-DRAFT-2019_02_08.html
@@ -11,7 +11,7 @@ spec_type: Profile
 group: workflow
 use_cases_url: 
 cross_walk_url: https://docs.google.com/spreadsheets/d/1E_wZV77rHntJ6ismn7f-Gyng3XAEGY415xNiqwoihLM/
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Workflow
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Workflow
 live_deploy: ''
 
 parent_type: HowTo

--- a/_profiles/ComputationalWorkflow/0.2-DRAFT-2019_11_29.html
+++ b/_profiles/ComputationalWorkflow/0.2-DRAFT-2019_11_29.html
@@ -12,7 +12,7 @@ spec_type: Profile
 group: workflow
 use_cases_url:
 cross_walk_url: https://docs.google.com/spreadsheets/d/1Z3eQrj5Gbs3WGVd1cXUzpL6X1v8Y8cWg-oe2nKzXgzo/edit
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Workflow
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Workflow
 live_deploy: ''
 
 parent_type: SoftwareSourceCode

--- a/_profiles/ComputationalWorkflow/0.3-DRAFT-2020_03_03.html
+++ b/_profiles/ComputationalWorkflow/0.3-DRAFT-2020_03_03.html
@@ -12,7 +12,7 @@ spec_type: Profile
 group: workflow
 use_cases_url:
 cross_walk_url: https://docs.google.com/spreadsheets/d/1ovlPQqq6roDayInfj9e9FRidriw9Do4p7EVNF9hWCYU/edit
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Workflow
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Workflow
 live_deploy: ''
 
 parent_type: SoftwareSourceCode

--- a/_profiles/ComputationalWorkflow/0.4-DRAFT-2020_05_11.html
+++ b/_profiles/ComputationalWorkflow/0.4-DRAFT-2020_05_11.html
@@ -12,7 +12,7 @@ spec_type: Profile
 group: workflow
 use_cases_url:
 cross_walk_url: https://docs.google.com/spreadsheets/d/10nptDOo0WCulyyZ2kXWoIF0Coq_hzd2SD1IEJCKHLz4/edit
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Workflow
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Workflow
 live_deploy: /liveDeploys/
 
 parent_type: SoftwareSourceCode

--- a/_profiles/ComputationalWorkflow/0.5-DRAFT-2020_07_21.html
+++ b/_profiles/ComputationalWorkflow/0.5-DRAFT-2020_07_21.html
@@ -21,7 +21,7 @@ spec_type: Profile
 group: workflow
 use_cases_url: /useCases/ComputationalWorkflow
 cross_walk_url: https://docs.google.com/spreadsheets/d/1O4kdba-_iHtRnoydfXelrGyuvZxJMGDBrPll9-hJsLw/edit#gid=1483018794
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Workflow
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Workflow
 live_deploy: /liveDeploys/
 
 parent_type: ComputationalWorkflow
@@ -45,7 +45,7 @@ spec_info:
   version: 0.5-DRAFT-2020_07_21
   version_date: 20200722T044734
   official_type: http://bioschemas.org/ComputationalWorkflow
-  full_example: https://github.com/BioSchemas/specifications/tree/master/ComputationalWorkflow/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/ComputationalWorkflow/examples/
 mapping:
 - property: alternateName
   expected_types:

--- a/_profiles/Course/0.1-DRAFT-2018_04_25.html
+++ b/_profiles/Course/0.1-DRAFT-2018_04_25.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: trainingmaterials
 use_cases_url: ''
 cross_walk_url: https://docs.google.com/spreadsheets/d/1cQ6mDbsG_cMX2EDAN8xH6-9yMRba8-rErlPeP8HTs8A
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Course
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Course
 live_deploy: ''
 
 parent_type: Course

--- a/_profiles/Course/0.1-DRAFT-2018_09_25.html
+++ b/_profiles/Course/0.1-DRAFT-2018_09_25.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: training
 use_cases_url: ''
 cross_walk_url: https://docs.google.com/spreadsheets/d/1cQ6mDbsG_cMX2EDAN8xH6-9yMRba8-rErlPeP8HTs8A
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Course
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Course
 live_deploy: ''
 
 parent_type: Course

--- a/_profiles/Course/0.3-DRAFT-2018_11_16.html
+++ b/_profiles/Course/0.3-DRAFT-2018_11_16.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: training
 use_cases_url: ''
 cross_walk_url: https://docs.google.com/spreadsheets/d/1cQ6mDbsG_cMX2EDAN8xH6-9yMRba8-rErlPeP8HTs8A
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Course
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Course
 live_deploy: ''
 
 parent_type: Course

--- a/_profiles/Course/0.5-DRAFT-2019_02_25.html
+++ b/_profiles/Course/0.5-DRAFT-2019_02_25.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: training
 use_cases_url: ''
 cross_walk_url: https://docs.google.com/spreadsheets/d/1cQ6mDbsG_cMX2EDAN8xH6-9yMRba8-rErlPeP8HTs8A
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Course
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Course
 live_deploy: ''
 
 parent_type: Course

--- a/_profiles/Course/0.6-DRAFT-2019_06_06.html
+++ b/_profiles/Course/0.6-DRAFT-2019_06_06.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: training
 use_cases_url: https://docs.google.com/spreadsheets/d/1kyTFfqoUveSeiGEp0K44R7oqLtGTbBWAY8lqlT4KWHo/edit#gid=1483018794
 cross_walk_url: https://docs.google.com/spreadsheets/d/1cQ6mDbsG_cMX2EDAN8xH6-9yMRba8-rErlPeP8HTs8A
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Course
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Course
 live_deploy: ''
 
 parent_type: Course

--- a/_profiles/Course/0.7-DRAFT-2019_11_08.html
+++ b/_profiles/Course/0.7-DRAFT-2019_11_08.html
@@ -16,7 +16,7 @@ spec_type: Profile
 group: training
 use_cases_url: https://docs.google.com/spreadsheets/d/1kyTFfqoUveSeiGEp0K44R7oqLtGTbBWAY8lqlT4KWHo/edit#gid=1483018794
 cross_walk_url: https://docs.google.com/spreadsheets/d/1cQ6mDbsG_cMX2EDAN8xH6-9yMRba8-rErlPeP8HTs8A
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Course
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Course
 live_deploy: ''
 
 parent_type: Course

--- a/_profiles/CourseInstance/0.1-DRAFT-2018_09_24.html
+++ b/_profiles/CourseInstance/0.1-DRAFT-2018_09_24.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: training
 use_cases_url: ''
 cross_walk_url: ''
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20CourseInstance
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20CourseInstance
 live_deploy: ''
 
 parent_type: CourseInstance

--- a/_profiles/CourseInstance/0.3-DRAFT-2018_11_16.html
+++ b/_profiles/CourseInstance/0.3-DRAFT-2018_11_16.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: training
 use_cases_url: ''
 cross_walk_url: ''
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20CourseInstance
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20CourseInstance
 live_deploy: ''
 
 parent_type: CourseInstance

--- a/_profiles/CourseInstance/0.4-DRAFT-2019_02_07.html
+++ b/_profiles/CourseInstance/0.4-DRAFT-2019_02_07.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: training
 use_cases_url: ''
 cross_walk_url: ''
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20CourseInstance
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20CourseInstance
 live_deploy: ''
 
 parent_type: CourseInstance

--- a/_profiles/CourseInstance/0.4-DRAFT-2019_02_08.html
+++ b/_profiles/CourseInstance/0.4-DRAFT-2019_02_08.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: training
 use_cases_url: ''
 cross_walk_url: ''
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20CourseInstance
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20CourseInstance
 live_deploy: ''
 
 parent_type: CourseInstance

--- a/_profiles/CourseInstance/0.5-DRAFT-2019_02_22.html
+++ b/_profiles/CourseInstance/0.5-DRAFT-2019_02_22.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: training
 use_cases_url: ''
 cross_walk_url: ''
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20CourseInstance
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20CourseInstance
 live_deploy: ''
 
 parent_type: CourseInstance

--- a/_profiles/CourseInstance/0.6-DRAFT-2019_06_06.html
+++ b/_profiles/CourseInstance/0.6-DRAFT-2019_06_06.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: training
 use_cases_url: ''
 cross_walk_url: https://docs.google.com/spreadsheets/d/1aoXX0j0DzhmJBfMLNjkv0vVUMCnZsZtRyQhA75ZiY9c/edit#gid=1483018794
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20CourseInstance
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20CourseInstance
 live_deploy: ''
 
 parent_type: CourseInstance

--- a/_profiles/CourseInstance/0.7-DRAFT-2019_11_08.html
+++ b/_profiles/CourseInstance/0.7-DRAFT-2019_11_08.html
@@ -16,7 +16,7 @@ spec_type: Profile
 group: training
 use_cases_url: ''
 cross_walk_url: https://docs.google.com/spreadsheets/d/1aoXX0j0DzhmJBfMLNjkv0vVUMCnZsZtRyQhA75ZiY9c/edit#gid=1483018794
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20CourseInstance
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20CourseInstance
 live_deploy: ''
 
 parent_type: CourseInstance

--- a/_profiles/DataCatalog/0.1-DRAFT-2018_04_25.html
+++ b/_profiles/DataCatalog/0.1-DRAFT-2018_04_25.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: datarepositories
 use_cases_url: /useCases/DataRepositories/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1H12h5VpVNJFzNs2RQJWjXkauCEn3qEsVFzKRoiHHffY
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20DataCatalogue
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20DataCatalogue
 live_deploy: /liveDeploys/
 
 
@@ -29,7 +29,7 @@ spec_info:
   version: 0.1-DRAFT-2018_04_25
   version_date: 20180425T160608
   official_type: ""
-  full_example: https://github.com/BioSchemas/specifications/tree/master/DataCatalog/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/DataCatalog/examples/
 mapping:
 - property: alternateName
   expected_types:

--- a/_profiles/DataCatalog/0.2-DRAFT-2018_11_13.html
+++ b/_profiles/DataCatalog/0.2-DRAFT-2018_11_13.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: datarepositories
 use_cases_url: /useCases/DataRepositories/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1mIRsRHdl9bzGQrOEVcMiwvh5ZsCcGNsNfai2sZOBxQ0/edit#gid=1483018794
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20DataCatalogue
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20DataCatalogue
 live_deploy: /liveDeploys/
 
 parent_type: DataCatalog
@@ -28,7 +28,7 @@ spec_info:
   version: 0.2-DRAFT-2018_11_13
   version_date: 20181130T115638
   official_type: http://schema.org/DataCatalog
-  full_example: https://github.com/BioSchemas/specifications/tree/master/DataCatalog/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/DataCatalog/examples/
 mapping:
 - property: about
   expected_types:

--- a/_profiles/DataCatalog/0.2-DRAFT-2019_01_15.html
+++ b/_profiles/DataCatalog/0.2-DRAFT-2019_01_15.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: datarepositories
 use_cases_url: /useCases/DataRepositories/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1mIRsRHdl9bzGQrOEVcMiwvh5ZsCcGNsNfai2sZOBxQ0/edit#gid=1483018794
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20DataCatalogue
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20DataCatalogue
 live_deploy: /liveDeploys/
 
 parent_type: DataCatalog
@@ -28,7 +28,7 @@ spec_info:
   version: 0.2-DRAFT-2019_01_15
   version_date: 20190115T211050
   official_type: http://schema.org/DataCatalog
-  full_example: https://github.com/BioSchemas/specifications/tree/master/DataCatalog/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/DataCatalog/examples/
 mapping:
 - property: about
   expected_types:

--- a/_profiles/DataCatalog/0.2-DRAFT-2019_01_28.html
+++ b/_profiles/DataCatalog/0.2-DRAFT-2019_01_28.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: datarepositories
 use_cases_url: /useCases/DataRepositories/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1mIRsRHdl9bzGQrOEVcMiwvh5ZsCcGNsNfai2sZOBxQ0/
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20DataCatalog
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20DataCatalog
 live_deploy: /liveDeploys/
 
 parent_type: DataCatalog
@@ -28,7 +28,7 @@ spec_info:
   version: 0.2-DRAFT-2019_01_28
   version_date: 20190128T204141
   official_type: http://schema.org/DataCatalog
-  full_example: https://github.com/BioSchemas/specifications/tree/master/DataCatalog/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/DataCatalog/examples/
 mapping:
 - property: about
   expected_types:

--- a/_profiles/DataCatalog/0.2-RELEASE-2019_06_14.html
+++ b/_profiles/DataCatalog/0.2-RELEASE-2019_06_14.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: datarepositories
 use_cases_url: /useCases/DataRepository/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1mIRsRHdl9bzGQrOEVcMiwvh5ZsCcGNsNfai2sZOBxQ0/
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20DataCatalog
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20DataCatalog
 live_deploy: /liveDeploys/
 
 
@@ -29,7 +29,7 @@ spec_info:
   version: 0.2-RELEASE-2019_06_14
   version_date: 20190614T144341
   official_type: http://schema.org/DataCatalog
-  full_example: https://github.com/BioSchemas/specifications/tree/master/DataCatalog/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/DataCatalog/examples/
 mapping:
 - property: about
   expected_types:

--- a/_profiles/DataCatalog/0.3-DRAFT-2019_06_20.html
+++ b/_profiles/DataCatalog/0.3-DRAFT-2019_06_20.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: datarepositories
 use_cases_url: /useCases/DataRepository/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1mIRsRHdl9bzGQrOEVcMiwvh5ZsCcGNsNfai2sZOBxQ0/
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20DataCatalog
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20DataCatalog
 live_deploy: /liveDeploys/
 
 
@@ -29,7 +29,7 @@ spec_info:
   version: 0.3-DRAFT-2019_06_20
   version_date: 20190620T095210
   official_type: http://schema.org/DataCatalog
-  full_example: https://github.com/BioSchemas/specifications/tree/master/DataCatalog/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/DataCatalog/examples/
 mapping:
 - property: about
   expected_types:

--- a/_profiles/DataCatalog/0.3-RELEASE-2019_07_01.html
+++ b/_profiles/DataCatalog/0.3-RELEASE-2019_07_01.html
@@ -17,7 +17,7 @@ spec_type: Profile
 group: datarepositories
 use_cases_url: /useCases/DataRepository/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1kB_0vPm78oPZOE9wJWFvBnlU9PN6j9Jk0FzqoqxImYA/
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20DataCatalog
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20DataCatalog
 live_deploy: /liveDeploys/
 
 
@@ -38,7 +38,7 @@ spec_info:
   version: 0.3-RELEASE-2019_07_01
   version_date: 20190701T144909
   official_type: http://schema.org/DataCatalog
-  full_example: https://github.com/BioSchemas/specifications/tree/master/DataCatalog/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/DataCatalog/examples/
 mapping:
 - property: about
   expected_types:

--- a/_profiles/DataRecord/0.1-DRAFT-2018_04_25.html
+++ b/_profiles/DataRecord/0.1-DRAFT-2018_04_25.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: data
 use_cases_url: /useCases/Datasets
 cross_walk_url: https://docs.google.com/spreadsheets/d/1XzrZxFIuG3TS9RU8vACoUjAvaADLmI_FrIk7O3BEkxY/
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20DataRecord
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20DataRecord
 live_deploy: ''
 
 parent_type: Dataset
@@ -29,7 +29,7 @@ spec_info:
   version: 0.1-DRAFT-2018_04_25
   version_date: 20180425T170205
   official_type: ""
-  full_example: https://github.com/BioSchemas/specifications/tree/master/DataRecord/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/DataRecord/examples/
 mapping:
 - property: additionalProperty
   expected_types:

--- a/_profiles/DataRecord/0.2-DRAFT-2019_06_14.html
+++ b/_profiles/DataRecord/0.2-DRAFT-2019_06_14.html
@@ -16,7 +16,7 @@ spec_type: Profile
 group: data
 use_cases_url: /useCases/Dataset/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1AsyfN0GAio_0ZFzc-zSvWilK2aaT1NYtL40DWAvj638/
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20DataRecord
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20DataRecord
 live_deploy: /liveDeploys/
 
 parent_type: Dataset
@@ -37,7 +37,7 @@ spec_info:
   version: 0.2-DRAFT-2019_06_14
   version_date: 20190614T155922
   official_type: ""
-  full_example: https://github.com/BioSchemas/specifications/tree/master/DataRecord/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/DataRecord/examples/
 mapping:
 - property: additionalProperty
   expected_types:

--- a/_profiles/Dataset/0.2-DRAFT-2018_02_25.html
+++ b/_profiles/Dataset/0.2-DRAFT-2018_02_25.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: data
 use_cases_url: /useCases/Datasets
 cross_walk_url: https://docs.google.com/spreadsheets/d/1XzrZxFIuG3TS9RU8vACoUjAvaADLmI_FrIk7O3BEkxY/
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Dataset
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Dataset
 live_deploy: /liveDeploys/
 
 parent_type: Dataset
@@ -27,7 +27,7 @@ spec_info:
   version: 0.2-DRAFT-2018_02_25
   version_date: 20180225T144349
   official_type: ""
-  full_example: "https://github.com/BioSchemas/specifications/tree/master/Dataset/examples/"
+  full_example: "https://github.com/Bioschemas/specifications/tree/master/Dataset/examples/"
 mapping:
 - property: citation
   expected_types:

--- a/_profiles/Dataset/0.3-DRAFT-2018_11_12.html
+++ b/_profiles/Dataset/0.3-DRAFT-2018_11_12.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: data
 use_cases_url: /useCases/Datasets
 cross_walk_url: https://docs.google.com/spreadsheets/d/1IUw5tdUvzTs3ogxgBNYTtUrVtlO2Czv6yiavyNfct8w/edit#gid=1483018794
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Dataset
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Dataset
 live_deploy: /liveDeploys/
 
 parent_type: Dataset
@@ -28,7 +28,7 @@ spec_info:
   version: 0.3-DRAFT-2018_11_12
   version_date: 20181127T101121
   official_type: http://schema.org/Dataset
-  full_example: https://github.com/BioSchemas/specifications/tree/master/Dataset/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/Dataset/examples/
 mapping:
 - property: citation
   expected_types:

--- a/_profiles/Dataset/0.3-RELEASE-2019_06_14.html
+++ b/_profiles/Dataset/0.3-RELEASE-2019_06_14.html
@@ -17,7 +17,7 @@ spec_type: Profile
 group: data
 use_cases_url: /useCases/Dataset/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1IUw5tdUvzTs3ogxgBNYTtUrVtlO2Czv6yiavyNfct8w/edit#gid=1483018794
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Dataset
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Dataset
 live_deploy: /liveDeploys/
 
 
@@ -37,7 +37,7 @@ spec_info:
   version: 0.3-RELEASE-2019_06_14
   version_date: 20190614T213421
   official_type: http://schema.org/Dataset
-  full_example: https://github.com/BioSchemas/specifications/tree/master/Dataset/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/Dataset/examples/
 mapping:
 - property: citation
   expected_types:

--- a/_profiles/Dataset/0.4-DRAFT.html
+++ b/_profiles/Dataset/0.4-DRAFT.html
@@ -1,0 +1,2692 @@
+---
+layout: profile-display
+previous_version: !!null ""
+previous_release: !!null ""
+name: BSDataset
+official_type: Dataset
+schema_version: '10.0'
+type_base_url: "https://schema.org/"
+description: "A body of structured information describing some topic(s) of interest."
+version: '0.1'
+version_date: 20201008T185344
+status: DRAFT
+spec_type: Profile
+group: data
+use_cases_url: /useCases/BSDataset/
+gh_tasks: "https://github.com/Bioschemas/specifications/labels/type%3A%20BSDataset"
+full_example: >-
+  https://github.com/Bioschemas/specifications/tree/master/BSDataset/examples/0.1
+hierarchy:
+- type_name: Thing
+  type_base_url: "https://schema.org/"
+- type_name: CreativeWork
+  type_base_url: "https://schema.org/"
+- type_name: Dataset
+  type_base_url: "https://schema.org/"
+mapping:
+- property: catalog
+  expected_types:
+  - type_name: DataCatalog
+    type_base_url: "https://schema.org/"
+  description: "A data catalog which contains this dataset."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: 'http://www.w3.org/ns/dcat#catalog'
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "catalog": {"@id": "https://example.com/datacatalog/345", "@type": "DataCatalog"}
+    }
+- property: datasetTimeInterval
+  expected_types:
+  - type_name: DateTime
+    type_base_url: "https://schema.org/"
+  description: >-
+    The range of temporal applicability of a dataset, e.g. for a 2011 census dataset,
+    the year 2011 (in ISO 8601 time interval format).
+  type: 'bioschemas'
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "datasetTimeInterval": "2020-10-08T17:33:08+01:00"
+    }
+- property: distribution
+  expected_types:
+  - type_name: DataDownload
+    type_base_url: "https://schema.org/"
+  description: >-
+    A downloadable form of this dataset, at a specific location, in a specific format.
+  type: 'external'
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "distribution": {"@id": "https://example.com/datadownload/345", "@type": "DataDownload"}
+    }
+- property: includedDataCatalog
+  expected_types:
+  - type_name: DataCatalog
+    type_base_url: "https://schema.org/"
+  description: >-
+    A data catalog which contains this dataset (this property was previously 'catalog',
+    preferred name is now 'includedInDataCatalog').
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "includedDataCatalog": {"@id": "https://example.com/datacatalog/345", "@type": "DataCatalog"}
+    }
+- property: includedInDataCatalog
+  expected_types:
+  - type_name: DataCatalog
+    type_base_url: "https://schema.org/"
+  description: "A data catalog which contains this dataset."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "includedInDataCatalog": {"@id": "https://example.com/datacatalog/345", "@type": "DataCatalog"}
+    }
+- property: issn
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: >-
+    The International Standard Serial Number (ISSN) that identifies this serial publication.
+    You can repeat this property to identify different formats of, or the linking
+    ISSN (ISSN-L) for, this serial publication.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "issn": "example issn"
+    }
+- property: measurementTechnique
+  expected_types:
+  - type_name: URL
+    type_base_url: "https://schema.org/"
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: |-
+    A technique or technology used in a <a class="localLink" href="http://schema.org/Dataset">Dataset</a> (or <a class="localLink" href="http://schema.org/DataDownload">DataDownload</a>, <a class="localLink" href="http://schema.org/DataCatalog">DataCatalog</a>),
+    corresponding to the method used for measuring the corresponding variable(s) (described using <a class="localLink" href="http://schema.org/variableMeasured">variableMeasured</a>). This is oriented towards scientific and scholarly dataset publication but may have broader applicability; it is not intended as a full representation of measurement, but rather as a high level summary for dataset discovery.<br/><br/>
+
+    For example, if <a class="localLink" href="http://schema.org/variableMeasured">variableMeasured</a> is: molecule concentration, <a class="localLink" href="http://schema.org/measurementTechnique">measurementTechnique</a> could be: "mass spectrometry" or "nmr spectroscopy" or "colorimetry" or "immunofluorescence".<br/><br/>
+
+    If the <a class="localLink" href="http://schema.org/variableMeasured">variableMeasured</a> is "depression rating", the <a class="localLink" href="http://schema.org/measurementTechnique">measurementTechnique</a> could be "Zung Scale" or "HAM-D" or "Beck Depression Inventory".<br/><br/>
+
+    If there are several <a class="localLink" href="http://schema.org/variableMeasured">variableMeasured</a> properties recorded for some given data object, use a <a class="localLink" href="http://schema.org/PropertyValue">PropertyValue</a> for each <a class="localLink" href="http://schema.org/variableMeasured">variableMeasured</a> and attach the corresponding <a class="localLink" href="http://schema.org/measurementTechnique">measurementTechnique</a>.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "measurementTechnique": "https://purl.example.org/measurementtechnique-345"
+    }
+- property: variableMeasured
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  - type_name: PropertyValue
+    type_base_url: "https://schema.org/"
+  description: >-
+    The variableMeasured property can indicate (repeated as necessary) the  variables
+    that are measured in some dataset, either described as text or as pairs of identifier
+    and description using PropertyValue.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "variableMeasured": "example variablemeasured"
+    }
+- property: variablesMeasured
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  - type_name: PropertyValue
+    type_base_url: "https://schema.org/"
+  description: >-
+    Originally named <a class="localLink" href="http://schema.org/variablesMeasured">variablesMeasured</a>,
+    The <a class="localLink" href="http://schema.org/variableMeasured">variableMeasured</a>
+    property can indicate (repeated as necessary) the  variables that are measured
+    in some dataset, either described as text or as pairs of identifier and description
+    using PropertyValue.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "variablesMeasured": "example variablesmeasured"
+    }
+- property: about
+  expected_types:
+  - type_name: Thing
+    type_base_url: "https://schema.org/"
+  description: "The subject matter of the content."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "about": {"@id": "https://example.com/thing/345", "@type": "Thing"}
+    }
+- property: abstract
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: >-
+    An abstract is a short description that summarizes a <a class="localLink" href="http://schema.org/CreativeWork">CreativeWork</a>.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "abstract": "example abstract"
+    }
+- property: accessMode
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: >-
+    The human sensory perceptual system or cognitive faculty through which a person
+    may process or perceive information. Expected values include: auditory, tactile,
+    textual, visual, colorDependent, chartOnVisual, chemOnVisual, diagramOnVisual,
+    mathOnVisual, musicOnVisual, textOnVisual.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "accessMode": "example accessmode"
+    }
+- property: accessModeSufficient
+  expected_types:
+  - type_name: ItemList
+    type_base_url: "https://schema.org/"
+  description: >-
+    A list of single or combined accessModes that are sufficient to understand all
+    the intellectual content of a resource. Expected values include:  auditory, tactile,
+    textual, visual.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "accessModeSufficient": {"@type": "ItemList"}
+    }
+- property: accessibilityAPI
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: >-
+    Indicates that the resource is compatible with the referenced accessibility API
+    (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists
+    possible values</a>).
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "accessibilityAPI": "example accessibilityapi"
+    }
+- property: accessibilityControl
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: >-
+    Identifies input methods that are sufficient to fully control the described resource
+    (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas wiki lists
+    possible values</a>).
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "accessibilityControl": "example accessibilitycontrol"
+    }
+- property: accessibilityFeature
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: >-
+    Content features of the resource, such as accessible media, alternatives and supported
+    enhancements for accessibility (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas
+    wiki lists possible values</a>).
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "accessibilityFeature": "example accessibilityfeature"
+    }
+- property: accessibilityHazard
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: >-
+    A characteristic of the described resource that is physiologically dangerous to
+    some users. Related to WCAG 2.0 guideline 2.3 (<a href="http://www.w3.org/wiki/WebSchemas/Accessibility">WebSchemas
+    wiki lists possible values</a>).
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "accessibilityHazard": "example accessibilityhazard"
+    }
+- property: accessibilitySummary
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: >-
+    A human-readable summary of specific accessibility features or deficiencies, consistent
+    with the other accessibility metadata but expressing subtleties such as "short
+    descriptions are present but long descriptions will be needed for non-visual users"
+    or "short descriptions are present and no long descriptions are needed."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "accessibilitySummary": "example accessibilitysummary"
+    }
+- property: accountablePerson
+  expected_types:
+  - type_name: Person
+    type_base_url: "https://schema.org/"
+  description: "Specifies the Person that is legally accountable for the CreativeWork."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "accountablePerson": {"@id": "https://orcid.org/0000-0002-1825-0097", "@type": "Person"}
+    }
+- property: acquireLicensePage
+  expected_types:
+  - type_name: URL
+    type_base_url: "https://schema.org/"
+  - type_name: CreativeWork
+    type_base_url: "https://schema.org/"
+  description: >-
+    Indicates a page documenting how licenses can be purchased or otherwise acquired,
+    for the current item.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "acquireLicensePage": "https://purl.example.org/acquirelicensepage-345"
+    }
+- property: aggregateRating
+  expected_types:
+  - type_name: AggregateRating
+    type_base_url: "https://schema.org/"
+  description: >-
+    The overall rating, based on a collection of reviews or ratings, of the item.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "aggregateRating": {"@type": "AggregateRating"}
+    }
+- property: alternativeHeadline
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: "A secondary title of the CreativeWork."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "alternativeHeadline": "example alternativeheadline"
+    }
+- property: assesses
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  - type_name: DefinedTerm
+    type_base_url: "https://schema.org/"
+  description: >-
+    The item being described is intended to assess the competency or learning outcome
+    defined by the referenced term.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "assesses": "example assesses"
+    }
+- property: associatedMedia
+  expected_types:
+  - type_name: MediaObject
+    type_base_url: "https://schema.org/"
+  description: >-
+    A media object that encodes this CreativeWork. This property is a synonym for
+    encoding.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "associatedMedia": {"@id": "https://example.com/mediaobject/345", "@type": "MediaObject"}
+    }
+- property: audience
+  expected_types:
+  - type_name: Audience
+    type_base_url: "https://schema.org/"
+  description: "An intended audience, i.e. a group for whom something was created."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "audience": {"@type": "Audience"}
+    }
+- property: audio
+  expected_types:
+  - type_name: MusicRecording
+    type_base_url: "https://schema.org/"
+  - type_name: AudioObject
+    type_base_url: "https://schema.org/"
+  - type_name: Clip
+    type_base_url: "https://schema.org/"
+  description: "An embedded audio object."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "audio": {"@id": "https://example.com/musicrecording/345", "@type": "MusicRecording"}
+    }
+- property: author
+  expected_types:
+  - type_name: Person
+    type_base_url: "https://schema.org/"
+  - type_name: Organization
+    type_base_url: "https://schema.org/"
+  description: >-
+    The author of this content or rating. Please note that author is special in that
+    HTML 5 provides a special mechanism for indicating authorship via the rel tag.
+    That is equivalent to this and may be used interchangeably.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "author": {"@id": "https://orcid.org/0000-0002-1825-0097", "@type": "Person"}
+    }
+- property: award
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: "An award won by or for this item."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "award": "example award"
+    }
+- property: awards
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: "Awards won by or for this item."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "awards": "example awards"
+    }
+- property: character
+  expected_types:
+  - type_name: Person
+    type_base_url: "https://schema.org/"
+  description: "Fictional person connected with a creative work."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "character": {"@id": "https://orcid.org/0000-0002-1825-0097", "@type": "Person"}
+    }
+- property: citation
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  - type_name: CreativeWork
+    type_base_url: "https://schema.org/"
+  description: >-
+    A citation or reference to another creative work, such as another publication,
+    web page, scholarly article, etc.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "citation": "example citation"
+    }
+- property: comment
+  expected_types:
+  - type_name: Comment
+    type_base_url: "https://schema.org/"
+  description: "Comments, typically from users."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "comment": {"@id": "https://example.com/comment/345", "@type": "Comment"}
+    }
+- property: commentCount
+  expected_types:
+  - type_name: Integer
+    type_base_url: "https://schema.org/"
+  description: >-
+    The number of comments this CreativeWork (e.g. Article, Question or Answer) has
+    received. This is most applicable to works published in Web sites with commenting
+    system; additional comments may exist elsewhere.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "commentCount": 123
+    }
+- property: conditionsOfAccess
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: |-
+    Conditions that affect the availability of, or method(s) of access to, an item. Typically used for real world items such as an <a class="localLink" href="http://schema.org/ArchiveComponent">ArchiveComponent</a> held by an <a class="localLink" href="http://schema.org/ArchiveOrganization">ArchiveOrganization</a>. This property is not suitable for use as a general Web access control mechanism. It is expressed only in natural language.<br/><br/>
+
+    For example "Available by appointment from the Reading Room" or "Accessible only from logged-in accounts ".
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "conditionsOfAccess": "example conditionsofaccess"
+    }
+- property: contentLocation
+  expected_types:
+  - type_name: Place
+    type_base_url: "https://schema.org/"
+  description: >-
+    The location depicted or described in the content. For example, the location in
+    a photograph or painting.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "contentLocation": {"@id": "https://example.com/place/345", "@type": "Place"}
+    }
+- property: contentRating
+  expected_types:
+  - type_name: Rating
+    type_base_url: "https://schema.org/"
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: "Official rating of a piece of content&#x2014;for example,'MPAA PG-13'."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "contentRating": {"@type": "Rating"}
+    }
+- property: contentReferenceTime
+  expected_types:
+  - type_name: DateTime
+    type_base_url: "https://schema.org/"
+  description: >-
+    The specific time described by a creative work, for works (e.g. articles, video
+    objects etc.) that emphasise a particular moment within an Event.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "contentReferenceTime": "2020-10-08T17:33:08+01:00"
+    }
+- property: contributor
+  expected_types:
+  - type_name: Person
+    type_base_url: "https://schema.org/"
+  - type_name: Organization
+    type_base_url: "https://schema.org/"
+  description: "A secondary contributor to the CreativeWork or Event."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "contributor": {"@id": "https://orcid.org/0000-0002-1825-0097", "@type": "Person"}
+    }
+- property: copyrightHolder
+  expected_types:
+  - type_name: Person
+    type_base_url: "https://schema.org/"
+  - type_name: Organization
+    type_base_url: "https://schema.org/"
+  description: "The party holding the legal copyright to the CreativeWork."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "copyrightHolder": {"@id": "https://orcid.org/0000-0002-1825-0097", "@type": "Person"}
+    }
+- property: copyrightYear
+  expected_types:
+  - type_name: Number
+    type_base_url: "https://schema.org/"
+  description: >-
+    The year during which the claimed copyright for the CreativeWork was first asserted.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "copyrightYear": 123
+    }
+- property: correction
+  expected_types:
+  - type_name: CorrectionComment
+    type_base_url: "https://schema.org/"
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  - type_name: URL
+    type_base_url: "https://schema.org/"
+  description: >-
+    Indicates a correction to a <a class="localLink" href="http://schema.org/CreativeWork">CreativeWork</a>,
+    either via a <a class="localLink" href="http://schema.org/CorrectionComment">CorrectionComment</a>,
+    textually or in another document.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "correction": {"@id": "https://example.com/correctioncomment/345", "@type": "CorrectionComment"}
+    }
+- property: creativeWorkStatus
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  - type_name: DefinedTerm
+    type_base_url: "https://schema.org/"
+  description: >-
+    The status of a creative work in terms of its stage in a lifecycle. Example terms
+    include Incomplete, Draft, Published, Obsolete. Some organizations define a set
+    of terms for the stages of their publication lifecycle.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "creativeWorkStatus": "example creativeworkstatus"
+    }
+- property: creator
+  expected_types:
+  - type_name: Person
+    type_base_url: "https://schema.org/"
+  - type_name: Organization
+    type_base_url: "https://schema.org/"
+  description: >-
+    The creator/author of this CreativeWork. This is the same as the Author property
+    for CreativeWork.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "creator": {"@id": "https://orcid.org/0000-0002-1825-0097", "@type": "Person"}
+    }
+- property: dateCreated
+  expected_types:
+  - type_name: DateTime
+    type_base_url: "https://schema.org/"
+  - type_name: Date
+    type_base_url: "https://schema.org/"
+  description: >-
+    The date on which the CreativeWork was created or the item was added to a DataFeed.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "dateCreated": "2020-10-08T17:33:08+01:00"
+    }
+- property: dateModified
+  expected_types:
+  - type_name: DateTime
+    type_base_url: "https://schema.org/"
+  - type_name: Date
+    type_base_url: "https://schema.org/"
+  description: >-
+    The date on which the CreativeWork was most recently modified or when the item's
+    entry was modified within a DataFeed.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "dateModified": "2020-10-08T17:33:08+01:00"
+    }
+- property: datePublished
+  expected_types:
+  - type_name: Date
+    type_base_url: "https://schema.org/"
+  - type_name: DateTime
+    type_base_url: "https://schema.org/"
+  description: "Date of first broadcast/publication."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "datePublished": "2020-10-08"
+    }
+- property: discussionUrl
+  expected_types:
+  - type_name: URL
+    type_base_url: "https://schema.org/"
+  description: "A link to the page containing the comments of the CreativeWork."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "discussionUrl": "https://purl.example.org/discussionurl-345"
+    }
+- property: editEIDR
+  expected_types:
+  - type_name: URL
+    type_base_url: "https://schema.org/"
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: |-
+    An <a href="https://eidr.org/">EIDR</a> (Entertainment Identifier Registry) <a class="localLink" href="http://schema.org/identifier">identifier</a> representing a specific edit / edition for a work of film or television.<br/><br/>
+
+    For example, the motion picture known as "Ghostbusters" whose <a class="localLink" href="http://schema.org/titleEIDR">titleEIDR</a> is "10.5240/7EC7-228A-510A-053E-CBB8-J", has several edits e.g. "10.5240/1F2A-E1C5-680A-14C6-E76B-I" and "10.5240/8A35-3BEE-6497-5D12-9E4F-3".<br/><br/>
+
+    Since schema.org types like <a class="localLink" href="http://schema.org/Movie">Movie</a> and <a class="localLink" href="http://schema.org/TVEpisode">TVEpisode</a> can be used for both works and their multiple expressions, it is possible to use <a class="localLink" href="http://schema.org/titleEIDR">titleEIDR</a> alone (for a general description), or alongside <a class="localLink" href="http://schema.org/editEIDR">editEIDR</a> for a more edit-specific description.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "editEIDR": "https://purl.example.org/editeidr-345"
+    }
+- property: editor
+  expected_types:
+  - type_name: Person
+    type_base_url: "https://schema.org/"
+  description: "Specifies the Person who edited the CreativeWork."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "editor": {"@id": "https://orcid.org/0000-0002-1825-0097", "@type": "Person"}
+    }
+- property: educationalAlignment
+  expected_types:
+  - type_name: AlignmentObject
+    type_base_url: "https://schema.org/"
+  description: |-
+    An alignment to an established educational framework.<br/><br/>
+
+    This property should not be used where the nature of the alignment can be described using a simple property, for example to express that a resource <a class="localLink" href="http://schema.org/teaches">teaches</a> or <a class="localLink" href="http://schema.org/assesses">assesses</a> a competency.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "educationalAlignment": {"@type": "AlignmentObject"}
+    }
+- property: educationalLevel
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  - type_name: DefinedTerm
+    type_base_url: "https://schema.org/"
+  - type_name: URL
+    type_base_url: "https://schema.org/"
+  description: >-
+    The level in terms of progression through an educational or training context.
+    Examples of educational levels include 'beginner', 'intermediate' or 'advanced',
+    and formal sets of level indicators.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "educationalLevel": "example educationallevel"
+    }
+- property: educationalUse
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: >-
+    The purpose of a work in the context of education; for example, 'assignment',
+    'group work'.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "educationalUse": "example educationaluse"
+    }
+- property: encoding
+  expected_types:
+  - type_name: MediaObject
+    type_base_url: "https://schema.org/"
+  description: >-
+    A media object that encodes this CreativeWork. This property is a synonym for
+    associatedMedia.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "encoding": {"@id": "https://example.com/mediaobject/345", "@type": "MediaObject"}
+    }
+- property: encodingFormat
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  - type_name: URL
+    type_base_url: "https://schema.org/"
+  description: |-
+    Media type typically expressed using a MIME format (see <a href="http://www.iana.org/assignments/media-types/media-types.xhtml">IANA site</a> and <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">MDN reference</a>) e.g. application/zip for a SoftwareApplication binary, audio/mpeg for .mp3 etc.).<br/><br/>
+
+    In cases where a <a class="localLink" href="http://schema.org/CreativeWork">CreativeWork</a> has several media type representations, <a class="localLink" href="http://schema.org/encoding">encoding</a> can be used to indicate each <a class="localLink" href="http://schema.org/MediaObject">MediaObject</a> alongside particular <a class="localLink" href="http://schema.org/encodingFormat">encodingFormat</a> information.<br/><br/>
+
+    Unregistered or niche encoding and file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia/Wikidata entry.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "encodingFormat": "example encodingformat"
+    }
+- property: encodings
+  expected_types:
+  - type_name: MediaObject
+    type_base_url: "https://schema.org/"
+  description: "A media object that encodes this CreativeWork."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "encodings": {"@id": "https://example.com/mediaobject/345", "@type": "MediaObject"}
+    }
+- property: exampleOfWork
+  expected_types:
+  - type_name: CreativeWork
+    type_base_url: "https://schema.org/"
+  description: >-
+    A creative work that this work is an example/instance/realization/derivation of.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "exampleOfWork": {"@id": "https://example.com/creativework/345", "@type": "CreativeWork"}
+    }
+- property: expires
+  expected_types:
+  - type_name: Date
+    type_base_url: "https://schema.org/"
+  description: >-
+    Date the content expires and is no longer useful or available. For example a <a
+    class="localLink" href="http://schema.org/VideoObject">VideoObject</a> or <a class="localLink"
+    href="http://schema.org/NewsArticle">NewsArticle</a> whose availability or relevance
+    is time-limited, or a <a class="localLink" href="http://schema.org/ClaimReview">ClaimReview</a>
+    fact check whose publisher wants to indicate that it may no longer be relevant
+    (or helpful to highlight) after some date.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "expires": "2020-10-08"
+    }
+- property: fileFormat
+  expected_types:
+  - type_name: URL
+    type_base_url: "https://schema.org/"
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: >-
+    Media type, typically MIME format (see <a href="http://www.iana.org/assignments/media-types/media-types.xhtml">IANA
+    site</a>) of the content e.g. application/zip of a SoftwareApplication binary.
+    In cases where a CreativeWork has several media type representations, 'encoding'
+    can be used to indicate each MediaObject alongside particular fileFormat information.
+    Unregistered or niche file formats can be indicated instead via the most appropriate
+    URL, e.g. defining Web page or a Wikipedia entry.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "fileFormat": "https://purl.example.org/fileformat-345"
+    }
+- property: funder
+  expected_types:
+  - type_name: Organization
+    type_base_url: "https://schema.org/"
+  - type_name: Person
+    type_base_url: "https://schema.org/"
+  description: >-
+    A person or organization that supports (sponsors) something through some kind
+    of financial contribution.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "funder": {"@id": "https://example.com/organization/345", "@type": "Organization"}
+    }
+- property: genre
+  expected_types:
+  - type_name: URL
+    type_base_url: "https://schema.org/"
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: "Genre of the creative work, broadcast channel or group."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "genre": "https://purl.example.org/genre-345"
+    }
+- property: hasPart
+  expected_types:
+  - type_name: CreativeWork
+    type_base_url: "https://schema.org/"
+  description: >-
+    Indicates an item or CreativeWork that is part of this item, or CreativeWork (in
+    some sense).
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "hasPart": {"@id": "https://example.com/creativework/345", "@type": "CreativeWork"}
+    }
+- property: headline
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: "Headline of the article."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "headline": "example headline"
+    }
+- property: inLanguage
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  - type_name: Language
+    type_base_url: "https://schema.org/"
+  description: >-
+    The language of the content or performance or used in an action. Please use one
+    of the language codes from the <a href="http://tools.ietf.org/html/bcp47">IETF
+    BCP 47 standard</a>. See also <a class="localLink" href="http://schema.org/availableLanguage">availableLanguage</a>.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "inLanguage": "example inlanguage"
+    }
+- property: interactionStatistic
+  expected_types:
+  - type_name: InteractionCounter
+    type_base_url: "https://schema.org/"
+  description: >-
+    The number of interactions for the CreativeWork using the WebSite or SoftwareApplication.
+    The most specific child type of InteractionCounter should be used.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "interactionStatistic": {"@type": "InteractionCounter"}
+    }
+- property: interactivityType
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: >-
+    The predominant mode of learning supported by the learning resource. Acceptable
+    values are 'active', 'expositive', or 'mixed'.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "interactivityType": "example interactivitytype"
+    }
+- property: isAccessibleForFree
+  expected_types:
+  - type_name: Boolean
+    type_base_url: "https://schema.org/"
+  description: "A flag to signal that the item, event, or place is accessible for\
+    \ free."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "isAccessibleForFree": false
+    }
+- property: isBasedOn
+  expected_types:
+  - type_name: Product
+    type_base_url: "https://schema.org/"
+  - type_name: CreativeWork
+    type_base_url: "https://schema.org/"
+  - type_name: URL
+    type_base_url: "https://schema.org/"
+  description: >-
+    A resource from which this work is derived or from which it is a modification
+    or adaption.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "isBasedOn": {"@id": "https://example.com/product/345", "@type": "Product"}
+    }
+- property: isBasedOnUrl
+  expected_types:
+  - type_name: URL
+    type_base_url: "https://schema.org/"
+  - type_name: CreativeWork
+    type_base_url: "https://schema.org/"
+  - type_name: Product
+    type_base_url: "https://schema.org/"
+  description: >-
+    A resource that was used in the creation of this resource. This term can be repeated
+    for multiple sources. For example, http://example.com/great-multiplication-intro.html.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "isBasedOnUrl": "https://purl.example.org/isbasedonurl-345"
+    }
+- property: isFamilyFriendly
+  expected_types:
+  - type_name: Boolean
+    type_base_url: "https://schema.org/"
+  description: "Indicates whether this content is family friendly."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "isFamilyFriendly": false
+    }
+- property: isPartOf
+  expected_types:
+  - type_name: URL
+    type_base_url: "https://schema.org/"
+  - type_name: CreativeWork
+    type_base_url: "https://schema.org/"
+  description: >-
+    Indicates an item or CreativeWork that this item, or CreativeWork (in some sense),
+    is part of.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "isPartOf": "https://purl.example.org/ispartof-345"
+    }
+- property: keywords
+  expected_types:
+  - type_name: DefinedTerm
+    type_base_url: "https://schema.org/"
+  - type_name: URL
+    type_base_url: "https://schema.org/"
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: >-
+    Keywords or tags used to describe this content. Multiple entries in a keywords
+    list are typically delimited by commas.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "keywords": {"@type": "DefinedTerm"}
+    }
+- property: learningResourceType
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: >-
+    The predominant type or kind characterizing the learning resource. For example,
+    'presentation', 'handout'.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "learningResourceType": "example learningresourcetype"
+    }
+- property: license
+  expected_types:
+  - type_name: CreativeWork
+    type_base_url: "https://schema.org/"
+  - type_name: URL
+    type_base_url: "https://schema.org/"
+  description: "A license document that applies to this content, typically indicated\
+    \ by URL."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "license": {"@id": "https://example.com/creativework/345", "@type": "CreativeWork"}
+    }
+- property: locationCreated
+  expected_types:
+  - type_name: Place
+    type_base_url: "https://schema.org/"
+  description: >-
+    The location where the CreativeWork was created, which may not be the same as
+    the location depicted in the CreativeWork.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "locationCreated": {"@id": "https://example.com/place/345", "@type": "Place"}
+    }
+- property: mainEntity
+  expected_types:
+  - type_name: Thing
+    type_base_url: "https://schema.org/"
+  description: "Indicates the primary entity described in some page or other CreativeWork."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "mainEntity": {"@id": "https://example.com/thing/345", "@type": "Thing"}
+    }
+- property: maintainer
+  expected_types:
+  - type_name: Organization
+    type_base_url: "https://schema.org/"
+  - type_name: Person
+    type_base_url: "https://schema.org/"
+  description: >-
+    A maintainer of a <a class="localLink" href="http://schema.org/Dataset">Dataset</a>,
+    software package (<a class="localLink" href="http://schema.org/SoftwareApplication">SoftwareApplication</a>),
+    or other <a class="localLink" href="http://schema.org/Project">Project</a>. A
+    maintainer is a <a class="localLink" href="http://schema.org/Person">Person</a>
+    or <a class="localLink" href="http://schema.org/Organization">Organization</a>
+    that manages contributions to, and/or publication of, some (typically complex)
+    artifact. It is common for distributions of software and data to be based on "upstream"
+    sources. When <a class="localLink" href="http://schema.org/maintainer">maintainer</a>
+    is applied to a specific version of something e.g. a particular version or packaging
+    of a <a class="localLink" href="http://schema.org/Dataset">Dataset</a>, it is
+    always  possible that the upstream source has a different maintainer. The <a class="localLink"
+    href="http://schema.org/isBasedOn">isBasedOn</a> property can be used to indicate
+    such relationships between datasets to make the different maintenance roles clear.
+    Similarly in the case of software, a package may have dedicated maintainers working
+    on integration into software distributions such as Ubuntu, as well as upstream
+    maintainers of the underlying work.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "maintainer": {"@id": "https://example.com/organization/345", "@type": "Organization"}
+    }
+- property: material
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  - type_name: Product
+    type_base_url: "https://schema.org/"
+  - type_name: URL
+    type_base_url: "https://schema.org/"
+  description: "A material that something is made from, e.g. leather, wool, cotton,\
+    \ paper."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "material": "example material"
+    }
+- property: materialExtent
+  expected_types:
+  - type_name: QuantitativeValue
+    type_base_url: "https://schema.org/"
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: >-
+    The quantity of the materials being described or an expression of the physical
+    space they occupy.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "materialExtent": {"@type": "QuantitativeValue"}
+    }
+- property: mentions
+  expected_types:
+  - type_name: Thing
+    type_base_url: "https://schema.org/"
+  description: >-
+    Indicates that the CreativeWork contains a reference to, but is not necessarily
+    about a concept.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "mentions": {"@id": "https://example.com/thing/345", "@type": "Thing"}
+    }
+- property: offers
+  expected_types:
+  - type_name: Demand
+    type_base_url: "https://schema.org/"
+  - type_name: Offer
+    type_base_url: "https://schema.org/"
+  description: >-
+    An offer to provide this item&#x2014;for example, an offer to sell a product,
+    rent the DVD of a movie, perform a service, or give away tickets to an event.
+    Use <a class="localLink" href="http://schema.org/businessFunction">businessFunction</a>
+    to indicate the kind of transaction offered, i.e. sell, lease, etc. This property
+    can also be used to describe a <a class="localLink" href="http://schema.org/Demand">Demand</a>.
+    While this property is listed as expected on a number of common types, it can
+    be used in others. In that case, using a second type, such as Product or a subtype
+    of Product, can clarify the nature of the offer.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "offers": {"@type": "Demand"}
+    }
+- property: pattern
+  expected_types:
+  - type_name: DefinedTerm
+    type_base_url: "https://schema.org/"
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: >-
+    A pattern that something has, for example 'polka dot', 'striped', 'Canadian flag'.
+    Values are typically expressed as text, although links to controlled value schemes
+    are also supported.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "pattern": {"@type": "DefinedTerm"}
+    }
+- property: position
+  expected_types:
+  - type_name: Integer
+    type_base_url: "https://schema.org/"
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: "The position of an item in a series or sequence of items."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "position": 123
+    }
+- property: producer
+  expected_types:
+  - type_name: Organization
+    type_base_url: "https://schema.org/"
+  - type_name: Person
+    type_base_url: "https://schema.org/"
+  description: >-
+    The person or organization who produced the work (e.g. music album, movie, tv/radio
+    series etc.).
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "producer": {"@id": "https://example.com/organization/345", "@type": "Organization"}
+    }
+- property: provider
+  expected_types:
+  - type_name: Organization
+    type_base_url: "https://schema.org/"
+  - type_name: Person
+    type_base_url: "https://schema.org/"
+  description: >-
+    The service provider, service operator, or service performer; the goods producer.
+    Another party (a seller) may offer those services or goods on behalf of the provider.
+    A provider may also serve as the seller.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "provider": {"@id": "https://example.com/organization/345", "@type": "Organization"}
+    }
+- property: publication
+  expected_types:
+  - type_name: PublicationEvent
+    type_base_url: "https://schema.org/"
+  description: "A publication event associated with the item."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "publication": {"@id": "https://example.com/publicationevent/345", "@type": "PublicationEvent"}
+    }
+- property: publisher
+  expected_types:
+  - type_name: Person
+    type_base_url: "https://schema.org/"
+  - type_name: Organization
+    type_base_url: "https://schema.org/"
+  description: "The publisher of the creative work."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "publisher": {"@id": "https://orcid.org/0000-0002-1825-0097", "@type": "Person"}
+    }
+- property: publisherImprint
+  expected_types:
+  - type_name: Organization
+    type_base_url: "https://schema.org/"
+  description: "The publishing division which published the comic."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "publisherImprint": {"@id": "https://example.com/organization/345", "@type": "Organization"}
+    }
+- property: publishingPrinciples
+  expected_types:
+  - type_name: URL
+    type_base_url: "https://schema.org/"
+  - type_name: CreativeWork
+    type_base_url: "https://schema.org/"
+  description: |-
+    The publishingPrinciples property indicates (typically via <a class="localLink" href="http://schema.org/URL">URL</a>) a document describing the editorial principles of an <a class="localLink" href="http://schema.org/Organization">Organization</a> (or individual e.g. a <a class="localLink" href="http://schema.org/Person">Person</a> writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a <a class="localLink" href="http://schema.org/CreativeWork">CreativeWork</a> (e.g. <a class="localLink" href="http://schema.org/NewsArticle">NewsArticle</a>) the principles are those of the party primarily responsible for the creation of the <a class="localLink" href="http://schema.org/CreativeWork">CreativeWork</a>.<br/><br/>
+
+    While such policies are most typically expressed in natural language, sometimes related information (e.g. indicating a <a class="localLink" href="http://schema.org/funder">funder</a>) can be expressed using schema.org terminology.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "publishingPrinciples": "https://purl.example.org/publishingprinciples-345"
+    }
+- property: recordedAt
+  expected_types:
+  - type_name: Event
+    type_base_url: "https://schema.org/"
+  description: >-
+    The Event where the CreativeWork was recorded. The CreativeWork may capture all
+    or part of the event.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "recordedAt": {"@id": "https://example.com/event/345", "@type": "Event"}
+    }
+- property: releasedEvent
+  expected_types:
+  - type_name: PublicationEvent
+    type_base_url: "https://schema.org/"
+  description: "The place and time the release was issued, expressed as a PublicationEvent."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "releasedEvent": {"@id": "https://example.com/publicationevent/345", "@type": "PublicationEvent"}
+    }
+- property: review
+  expected_types:
+  - type_name: Review
+    type_base_url: "https://schema.org/"
+  description: "A review of the item."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "review": {"@id": "https://example.com/review/345", "@type": "Review"}
+    }
+- property: reviews
+  expected_types:
+  - type_name: Review
+    type_base_url: "https://schema.org/"
+  description: "Review of the item."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "reviews": {"@id": "https://example.com/review/345", "@type": "Review"}
+    }
+- property: schemaVersion
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  - type_name: URL
+    type_base_url: "https://schema.org/"
+  description: >-
+    Indicates (by URL or string) a particular version of a schema used in some CreativeWork.
+    For example, a document could declare a schemaVersion using an URL such as http://schema.org/version/2.0/
+    if precise indication of schema version was required by some application.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "schemaVersion": "example schemaversion"
+    }
+- property: sdDatePublished
+  expected_types:
+  - type_name: Date
+    type_base_url: "https://schema.org/"
+  description: >-
+    Indicates the date on which the current structured data was generated / published.
+    Typically used alongside <a class="localLink" href="http://schema.org/sdPublisher">sdPublisher</a>
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "sdDatePublished": "2020-10-08"
+    }
+- property: sdLicense
+  expected_types:
+  - type_name: URL
+    type_base_url: "https://schema.org/"
+  - type_name: CreativeWork
+    type_base_url: "https://schema.org/"
+  description: >-
+    A license document that applies to this structured data, typically indicated by
+    URL.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "sdLicense": "https://purl.example.org/sdlicense-345"
+    }
+- property: sdPublisher
+  expected_types:
+  - type_name: Organization
+    type_base_url: "https://schema.org/"
+  - type_name: Person
+    type_base_url: "https://schema.org/"
+  description: |-
+    Indicates the party responsible for generating and publishing the current structured data markup, typically in cases where the structured data is derived automatically from existing published content but published on a different site. For example, student projects and open data initiatives often re-publish existing content with more explicitly structured metadata. The
+    <a class="localLink" href="http://schema.org/sdPublisher">sdPublisher</a> property helps make such practices more explicit.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "sdPublisher": {"@id": "https://example.com/organization/345", "@type": "Organization"}
+    }
+- property: size
+  expected_types:
+  - type_name: QuantitativeValue
+    type_base_url: "https://schema.org/"
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  - type_name: DefinedTerm
+    type_base_url: "https://schema.org/"
+  description: >-
+    A standardized size of a product or creative work, often simplifying richer information
+    into a simple textual string, either through referring to named sizes or (in the
+    case of product markup), by adopting conventional simplifications. Use of QuantitativeValue
+    with a unitCode or unitText can add more structure; in other cases, the /width,
+    /height, /depth and /weight properties may be more applicable.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "size": {"@type": "QuantitativeValue"}
+    }
+- property: sourceOrganization
+  expected_types:
+  - type_name: Organization
+    type_base_url: "https://schema.org/"
+  description: "The Organization on whose behalf the creator was working."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "sourceOrganization": {"@id": "https://example.com/organization/345", "@type": "Organization"}
+    }
+- property: spatial
+  expected_types:
+  - type_name: Place
+    type_base_url: "https://schema.org/"
+  description: |-
+    The "spatial" property can be used in cases when more specific properties
+    (e.g. <a class="localLink" href="http://schema.org/locationCreated">locationCreated</a>, <a class="localLink" href="http://schema.org/spatialCoverage">spatialCoverage</a>, <a class="localLink" href="http://schema.org/contentLocation">contentLocation</a>) are not known to be appropriate.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "spatial": {"@id": "https://example.com/place/345", "@type": "Place"}
+    }
+- property: spatialCoverage
+  expected_types:
+  - type_name: Place
+    type_base_url: "https://schema.org/"
+  description: |-
+    The spatialCoverage of a CreativeWork indicates the place(s) which are the focus of the content. It is a subproperty of
+          contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates
+          areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "spatialCoverage": {"@id": "https://example.com/place/345", "@type": "Place"}
+    }
+- property: sponsor
+  expected_types:
+  - type_name: Person
+    type_base_url: "https://schema.org/"
+  - type_name: Organization
+    type_base_url: "https://schema.org/"
+  description: >-
+    A person or organization that supports a thing through a pledge, promise, or financial
+    contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "sponsor": {"@id": "https://orcid.org/0000-0002-1825-0097", "@type": "Person"}
+    }
+- property: teaches
+  expected_types:
+  - type_name: DefinedTerm
+    type_base_url: "https://schema.org/"
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: >-
+    The item being described is intended to help a person learn the competency or
+    learning outcome defined by the referenced term.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "teaches": {"@type": "DefinedTerm"}
+    }
+- property: temporal
+  expected_types:
+  - type_name: DateTime
+    type_base_url: "https://schema.org/"
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: |-
+    The "temporal" property can be used in cases where more specific properties
+    (e.g. <a class="localLink" href="http://schema.org/temporalCoverage">temporalCoverage</a>, <a class="localLink" href="http://schema.org/dateCreated">dateCreated</a>, <a class="localLink" href="http://schema.org/dateModified">dateModified</a>, <a class="localLink" href="http://schema.org/datePublished">datePublished</a>) are not known to be appropriate.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "temporal": "2020-10-08T17:33:08+01:00"
+    }
+- property: temporalCoverage
+  expected_types:
+  - type_name: DateTime
+    type_base_url: "https://schema.org/"
+  - type_name: URL
+    type_base_url: "https://schema.org/"
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: |-
+    The temporalCoverage of a CreativeWork indicates the period that the content applies to, i.e. that it describes, either as a DateTime or as a textual string indicating a time period in <a href="https://en.wikipedia.org/wiki/ISO_8601#Time_intervals">ISO 8601 time interval format</a>. In
+          the case of a Dataset it will typically indicate the relevant time period in a precise notation (e.g. for a 2011 census dataset, the year 2011 would be written "2011/2012"). Other forms of content e.g. ScholarlyArticle, Book, TVSeries or TVEpisode may indicate their temporalCoverage in broader terms - textually or via well-known URL.
+          Written works such as books may sometimes have precise temporal coverage too, e.g. a work set in 1939 - 1945 can be indicated in ISO 8601 interval format format via "1939/1945".<br/><br/>
+
+    Open-ended date ranges can be written with ".." in place of the end date. For example, "2015-11/.." indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "temporalCoverage": "2020-10-08T17:33:08+01:00"
+    }
+- property: text
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: "The textual content of this CreativeWork."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "text": "example text"
+    }
+- property: thumbnailUrl
+  expected_types:
+  - type_name: URL
+    type_base_url: "https://schema.org/"
+  description: "A thumbnail image relevant to the Thing."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "thumbnailUrl": "https://purl.example.org/thumbnailurl-345"
+    }
+- property: timeRequired
+  expected_types:
+  - type_name: Duration
+    type_base_url: "https://schema.org/"
+  description: >-
+    Approximate or typical time it takes to work with or through this learning resource
+    for the typical intended target audience, e.g. 'PT30M', 'PT1H25M'.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "timeRequired": {"@type": "Duration"}
+    }
+- property: translationOfWork
+  expected_types:
+  - type_name: CreativeWork
+    type_base_url: "https://schema.org/"
+  description: "The work that this work has been translated from. e.g. \u7269\u79CD\
+    \u8D77\u6E90 is a translationOf \u201COn the Origin of Species\u201D"
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "translationOfWork": {"@id": "https://example.com/creativework/345", "@type": "CreativeWork"}
+    }
+- property: translator
+  expected_types:
+  - type_name: Organization
+    type_base_url: "https://schema.org/"
+  - type_name: Person
+    type_base_url: "https://schema.org/"
+  description: >-
+    Organization or person who adapts a creative work to different languages, regional
+    differences and technical requirements of a target market, or that translates
+    during some event.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "translator": {"@id": "https://example.com/organization/345", "@type": "Organization"}
+    }
+- property: typicalAgeRange
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: "The typical expected age range, e.g. '7-9', '11-'."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "typicalAgeRange": "example typicalagerange"
+    }
+- property: usageInfo
+  expected_types:
+  - type_name: CreativeWork
+    type_base_url: "https://schema.org/"
+  - type_name: URL
+    type_base_url: "https://schema.org/"
+  description: |-
+    The schema.org <a class="localLink" href="http://schema.org/usageInfo">usageInfo</a> property indicates further information about a <a class="localLink" href="http://schema.org/CreativeWork">CreativeWork</a>. This property is applicable both to works that are freely available and to those that require payment or other transactions. It can reference additional information e.g. community expectations on preferred linking and citation conventions, as well as purchasing details. For something that can be commercially licensed, usageInfo can provide detailed, resource-specific information about licensing options.<br/><br/>
+
+    This property can be used alongside the license property which indicates license(s) applicable to some piece of content. The usageInfo property can provide information about other licensing options, e.g. acquiring commercial usage rights for an image that is also available under non-commercial creative commons licenses.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "usageInfo": {"@id": "https://example.com/creativework/345", "@type": "CreativeWork"}
+    }
+- property: version
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  - type_name: Number
+    type_base_url: "https://schema.org/"
+  description: "The version of the CreativeWork embodied by a specified resource."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "version": "example version"
+    }
+- property: video
+  expected_types:
+  - type_name: VideoObject
+    type_base_url: "https://schema.org/"
+  - type_name: Clip
+    type_base_url: "https://schema.org/"
+  description: "An embedded video object."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "video": {"@id": "https://example.com/videoobject/345", "@type": "VideoObject"}
+    }
+- property: workExample
+  expected_types:
+  - type_name: CreativeWork
+    type_base_url: "https://schema.org/"
+  description: >-
+    Example/instance/realization/derivation of the concept of this creative work.
+    eg. The paperback edition, first edition, or eBook.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "workExample": {"@id": "https://example.com/creativework/345", "@type": "CreativeWork"}
+    }
+- property: workTranslation
+  expected_types:
+  - type_name: CreativeWork
+    type_base_url: "https://schema.org/"
+  description: "A work that is a translation of the content of this work. e.g. \u897F\
+    \u904A\u8A18 has an English workTranslation \u201CJourney to the West\u201D,a\
+    \ German workTranslation \u201CMonkeys Pilgerfahrt\u201D and a Vietnamese  translation\
+    \ T\xE2y du k\xFD b\xECnh kh\u1EA3o."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "workTranslation": {"@id": "https://example.com/creativework/345", "@type": "CreativeWork"}
+    }
+- property: additionalType
+  expected_types:
+  - type_name: URL
+    type_base_url: "https://schema.org/"
+  description: >-
+    An additional type for the item, typically used for adding more specific types
+    from external vocabularies in microdata syntax. This is a relationship between
+    something and a class that the thing is in. In RDFa syntax, it is better to use
+    the native RDFa syntax - the 'typeof' attribute - for multiple types. Schema.org
+    tools may have only weaker understanding of extra types, in particular those defined
+    externally.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "additionalType": "https://purl.example.org/additionaltype-345"
+    }
+- property: alternateName
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: "An alias for the item."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "alternateName": "example alternatename"
+    }
+- property: description
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: "A description of the item."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "description": "example description"
+    }
+- property: disambiguatingDescription
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: >-
+    A sub property of description. A short description of the item used to disambiguate
+    from other, similar items. Information from other properties (in particular, name)
+    may be necessary for the description to be useful for disambiguation.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "disambiguatingDescription": "example disambiguatingdescription"
+    }
+- property: identifier
+  expected_types:
+  - type_name: PropertyValue
+    type_base_url: "https://schema.org/"
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  - type_name: URL
+    type_base_url: "https://schema.org/"
+  description: >-
+    The identifier property represents any kind of identifier for any kind of <a class="localLink"
+    href="http://schema.org/Thing">Thing</a>, such as ISBNs, GTIN codes, UUIDs etc.
+    Schema.org provides dedicated properties for representing many of these, either
+    as textual strings or as URL (URI) links. See <a href="/docs/datamodel.html#identifierBg">background
+    notes</a> for more details.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "identifier": {"@type": "PropertyValue"}
+    }
+- property: image
+  expected_types:
+  - type_name: URL
+    type_base_url: "https://schema.org/"
+  - type_name: ImageObject
+    type_base_url: "https://schema.org/"
+  description: >-
+    An image of the item. This can be a <a class="localLink" href="http://schema.org/URL">URL</a>
+    or a fully described <a class="localLink" href="http://schema.org/ImageObject">ImageObject</a>.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "image": "https://purl.example.org/image-345"
+    }
+- property: mainEntityOfPage
+  expected_types:
+  - type_name: URL
+    type_base_url: "https://schema.org/"
+  - type_name: CreativeWork
+    type_base_url: "https://schema.org/"
+  description: >-
+    Indicates a page (or other CreativeWork) for which this thing is the main entity
+    being described. See <a href="/docs/datamodel.html#mainEntityBackground">background
+    notes</a> for details.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "mainEntityOfPage": "https://purl.example.org/mainentityofpage-345"
+    }
+- property: name
+  expected_types:
+  - type_name: Text
+    type_base_url: "https://schema.org/"
+  description: "The name of the item."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "name": "example name"
+    }
+- property: potentialAction
+  expected_types:
+  - type_name: Action
+    type_base_url: "https://schema.org/"
+  description: >-
+    Indicates a potential Action, which describes an idealized action in which this
+    thing would play an 'object' role.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "potentialAction": {"@id": "https://example.com/action/345", "@type": "Action"}
+    }
+- property: sameAs
+  expected_types:
+  - type_name: URL
+    type_base_url: "https://schema.org/"
+  description: >-
+    URL of a reference Web page that unambiguously indicates the item's identity.
+    E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website.
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "sameAs": "https://purl.example.org/sameas-345"
+    }
+- property: subjectOf
+  expected_types:
+  - type_name: CreativeWork
+    type_base_url: "https://schema.org/"
+  - type_name: Event
+    type_base_url: "https://schema.org/"
+  description: "A CreativeWork or Event about this Thing."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "subjectOf": {"@id": "https://example.com/creativework/345", "@type": "CreativeWork"}
+    }
+- property: url
+  expected_types:
+  - type_name: URL
+    type_base_url: "https://schema.org/"
+  description: "URL of the item."
+  type: ''
+  type_url: ''
+  bsc_description: "TODO: Bioschemas description"
+  equivalentProperty: ''
+  marginality: Unspecified
+  cardinality: ''
+  controlled_vocab: ''
+  example: |-
+    { "@context": "https://schema.org/",
+      "@id": "https://example.com/dataset/123",
+      "@type": "Dataset",
+      "url": "https://purl.example.org/url-345"
+    }
+---

--- a/_profiles/Dataset/0.5-RELEASE.html
+++ b/_profiles/Dataset/0.5-RELEASE.html
@@ -1,0 +1,71 @@
+---
+layout: profile-display
+previous_version: '0.4-DRAFT'
+previous_release: '0.3-RELEASE-2019_06_14'
+
+description: Dataset
+full_example: https://github.com/Bioschemas/specifications/tree/master/Dataset/examples/0.5-RELEASE
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Dataset
+group: data
+hierarchy:
+- type_name: Thing
+  type_base_url: "https://schema.org/"
+- type_name: CreativeWork
+  type_base_url: "https://schema.org/"
+- type_name: Dataset
+  type_base_url: "https://schema.org/"
+mapping:
+- bsc_description: A short summary describing a dataset.
+  cardinality: ONE
+  controlled_vocab: ""
+  description: A description of the item.
+  example: |-
+    {
+    "@type": "Dataset",
+     "description": "Liquid chromatography coupled to mass spectrometry (LC-MS) has become a standard technology in metabolomics. In particular, label-free quantification based on LC-MS ..."
+    }
+  expected_types:
+  - type_name: Text
+    type_base_url: https://schema.org/
+  marginality: Minimum
+  property: description
+  type: ""
+  type_url: ""
+- bsc_description: Bioschemas description
+  cardinality: null
+  controlled_vocab: null
+  description: schema property description
+  example: null
+  expected_types:
+  - type_name: Text
+    type_base_url: https://schema.org/
+  - type_name: BioChemEntity
+    type_base_url: https://bioschemas.org/
+  marginality: Not Applicable
+  property: notApplicableProperty
+  type: null
+  type_url: null
+- bsc_description: Bioschemas description
+  cardinality: null
+  controlled_vocab: null
+  description: schema property description
+  example: null
+  expected_types:
+  - type_name: measurementTechnique
+    type_base_url: https://pending.schema.org/
+  - type_name: ExistingOtherType
+    type_base_url: https://example.com/
+  marginality: Unspecified
+  property: unspecifiedProperty
+  type: null
+  type_url: null
+name: Dataset
+official_type: Dataset
+schema_version: 10.0
+spec_type: Profile
+status: RELEASE
+type_base_url: https://schema.org/
+use_cases_url: /useCases/Dataset/
+version: '0.5-RELEASE'
+version_date: 20201007T133511
+---

--- a/_profiles/Event/0.1-DRAFT-2018_03_10.html
+++ b/_profiles/Event/0.1-DRAFT-2018_03_10.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: events
 use_cases_url: /useCases/Events/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1Hu1dmrS7jPgHWp8hUQWve9BzaYZi_EzTj9-gDuI9sBM/
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Event
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Event
 live_deploy: /liveDeploys/
 
 parent_type: Event
@@ -27,7 +27,7 @@ spec_info:
   version: 0.1-DRAFT-2018_03_10
   version_date: 20180310T144349
   official_type: ""
-  full_example: "https://github.com/BioSchemas/specifications/tree/master/Event/examples/"
+  full_example: "https://github.com/Bioschemas/specifications/tree/master/Event/examples/"
 mapping:
 - property: acceptanceNotificationDate
   expected_types:

--- a/_profiles/Event/0.2-DRAFT-2019_06_14.html
+++ b/_profiles/Event/0.2-DRAFT-2019_06_14.html
@@ -16,7 +16,7 @@ spec_type: Profile
 group: events
 use_cases_url: /useCases/Event/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1FOdOiFwrrWCF5S9aL-XICMr0xy3aSj5WnKn35zlfblg/
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Event
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Event
 live_deploy: /liveDeploys/
 
 parent_type: Event
@@ -34,7 +34,7 @@ spec_info:
   version: 0.2-DRAFT-2019_06_14
   version_date: 20190614T161036
   official_type: ""
-  full_example: https://github.com/BioSchemas/specifications/tree/master/Event/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/Event/examples/
 mapping:
 - property: acceptanceNotificationDate
   expected_types:

--- a/_profiles/FormalParameter/0.1-DRAFT-2020_06_23.html
+++ b/_profiles/FormalParameter/0.1-DRAFT-2020_06_23.html
@@ -16,7 +16,7 @@ spec_type: Profile
 group: workflow
 use_cases_url:
 cross_walk_url: 
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20FormalParameter
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20FormalParameter
 live_deploy: ''
 
 parent_type: FormalParameter

--- a/_profiles/FormalParameter/0.1-DRAFT-2020_07_21.html
+++ b/_profiles/FormalParameter/0.1-DRAFT-2020_07_21.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: workflow
 use_cases_url: /useCases/ComputationalWorkflow
 cross_walk_url: https://docs.google.com/spreadsheets/d/1VKntwxkgjvup6yfzaPZsBN3h5aKWU5nuTKGEds3GzeQ/edit#gid=1483018794
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Workflow
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Workflow
 live_deploy: /liveDeploys/
 
 parent_type: FormalParameter
@@ -29,7 +29,7 @@ spec_info:
   version: 0.1-DRAFT-2020_07_21
   version_date: 20200721T070439
   official_type: http://schema.org/FormalParameter
-  full_example: https://github.com/BioSchemas/specifications/tree/master/FormalParameter/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/FormalParameter/examples/
 mapping:
 - property: additionalType
   expected_types:

--- a/_profiles/Gene/0.3-DRAFT-2018_08_21.html
+++ b/_profiles/Gene/0.3-DRAFT-2018_08_21.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: genes
 use_cases_url: /useCases/Genes/
 cross_walk_url: 
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Gene
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Gene
 live_deploy: ''
 
 parent_type: Thing
@@ -28,7 +28,7 @@ spec_info:
   version: 0.3-DRAFT-2018_08_21
   version_date: 20180821T113200
   official_type: http://purl.obolibrary.org/obo/SO_0000704
-  full_example: https://github.com/BioSchemas/bioschemas.github.io/tree/master/_devSpecs/Gene/examples
+  full_example: https://github.com/Bioschemas/bioschemas.github.io/tree/master/_devSpecs/Gene/examples
 mapping:
 - property: additionalProperty
   expected_types:

--- a/_profiles/Gene/0.4-DRAFT-2018_11_09.html
+++ b/_profiles/Gene/0.4-DRAFT-2018_11_09.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: genes
 use_cases_url: /useCases/Genes/
 cross_walk_url: https://docs.google.com/spreadsheets/d/15yAvj5m-Ak_hbkSGrBx2fuhTfcQh-gY1mLT1jdOu5a0/edit#gid=1483018794
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Gene
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Gene
 live_deploy: ''
 
 parent_type: Thing
@@ -28,7 +28,7 @@ spec_info:
   version: 0.4-DRAFT-2018_11_09
   version_date: 20181109T120441
   official_type: http://bioschema.org/Gene
-  full_example: https://github.com/BioSchemas/bioschemas.github.io/tree/master/_devSpecs/Gene/examples
+  full_example: https://github.com/Bioschemas/bioschemas.github.io/tree/master/_devSpecs/Gene/examples
 mapping:
 - property: additionalProperty
   expected_types:

--- a/_profiles/Gene/0.4-RELEASE-2019_11_10.html
+++ b/_profiles/Gene/0.4-RELEASE-2019_11_10.html
@@ -10,7 +10,7 @@ spec_type: Profile
 group: genes
 use_cases_url: /useCases/Gene/
 cross_walk_url: https://docs.google.com/spreadsheets/d/15yAvj5m-Ak_hbkSGrBx2fuhTfcQh-gY1mLT1jdOu5a0/edit#gid=1483018794
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Gene
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Gene
 live_deploy: /liveDeploys/
 
 
@@ -31,7 +31,7 @@ spec_info:
   version: 0.4-RELEASE-2019_11_10
   version_date: 20181110T092310
   official_type: http://bioschemas.org/Gene
-  full_example: https://github.com/BioSchemas/Specifications/tree/master/Gene/
+  full_example: https://github.com/Bioschemas/Specifications/tree/master/Gene/
 mapping:
 - property: additionalProperty
   expected_types:

--- a/_profiles/Gene/0.5-DRAFT-2019_06_14.html
+++ b/_profiles/Gene/0.5-DRAFT-2019_06_14.html
@@ -10,7 +10,7 @@ spec_type: Profile
 group: genes
 use_cases_url: /useCases/Gene/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1nxWYEAgpW8EDWBHjUffz3F7wijSoAJeTZKEH5zytmDw
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Gene
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Gene
 live_deploy: /liveDeploys/
 
 
@@ -31,7 +31,7 @@ spec_info:
   version: 0.5-DRAFT-2019_06_14
   version_date: 20190614T220732
   official_type: http://bioschemas.org/Gene
-  full_example: https://github.com/BioSchemas/Specifications/tree/master/Gene/examples
+  full_example: https://github.com/Bioschemas/Specifications/tree/master/Gene/examples
 mapping:
 - property: additionalProperty
   expected_types:

--- a/_profiles/Gene/0.6-DRAFT-2020_04_02.html
+++ b/_profiles/Gene/0.6-DRAFT-2020_04_02.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: genes
 use_cases_url: /useCases/Gene/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1mN3b5_MsuSLWv3J7KVj8vY6lnPmlJa8iaIBbu2eQLOQ
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Gene
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Gene
 live_deploy: /liveDeploys/
 
 
@@ -29,7 +29,7 @@ spec_info:
     a Gene.
     <h4>Summary of Changes</h4>
     Changes introduced on Gene profile 0.6-DRAFT-2020_04_02 in response to
-    <a href="https://github.com/BioSchemas/specifications/issues/353">issue 353</a><ul><li>encodes
+    <a href="https://github.com/Bioschemas/specifications/issues/353">issue 353</a><ul><li>encodes
     property updated to encodesBioChemEntity, still recommended</li><li>additionalProperty
     removed</li><li>associatedDisease range updated</li><li>examples using DefinedTerm
     now include link to external vocabularies via property inDefinedTermSet (hasMolecularFunction,
@@ -45,7 +45,7 @@ spec_info:
   version: 0.6-DRAFT-2020_04_02
   version_date: 20200402T194732
   official_type: http://bioschemas.org/Gene
-  full_example: https://github.com/BioSchemas/Specifications/tree/master/Gene/examples
+  full_example: https://github.com/Bioschemas/Specifications/tree/master/Gene/examples
 mapping:
 - property: alternateName
   expected_types:

--- a/_profiles/Gene/0.7-RELEASE.html
+++ b/_profiles/Gene/0.7-RELEASE.html
@@ -17,7 +17,7 @@ spec_type: Profile
 group: genes
 use_cases_url: /useCases/Gene/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1fNmcZp636iTywG7EK7EK-LmQtHBN6cbKGa_K84MFujU/edit#gid=1483018794
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Gene
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Gene
 live_deploy: /liveDeploys/
 
 
@@ -51,7 +51,7 @@ spec_info:
   version: 0.7-RELEASE
   version_date: 20200407T115832
   official_type: http://bioschemas.org/Gene
-  full_example: https://github.com/BioSchemas/Specifications/tree/master/Gene/examples
+  full_example: https://github.com/Bioschemas/Specifications/tree/master/Gene/examples
 mapping:
 - property: alternateName
   expected_types:

--- a/_profiles/Journal/0.1-DRAFT-2019_01_29.html
+++ b/_profiles/Journal/0.1-DRAFT-2019_01_29.html
@@ -12,7 +12,7 @@ cross_walk_url: [
   "https://docs.google.com/spreadsheets/d/1ecj0bzyRO3tSTyHrKtDGfBwC5bIhgRCmv3yR8ylR_G4", 
   "https://drive.google.com/drive/folders/1CgEyta4d7vFfYT7r7w9HtLZ4kAidDmJI"
 ]
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Journal
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Journal
 live_deploy: ''
 
 

--- a/_profiles/Journal/0.1-DRAFT-2019_01_31.html
+++ b/_profiles/Journal/0.1-DRAFT-2019_01_31.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: biotea2bioschemas
 use_cases_url: /useCases/PublicationIssue/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1ecj0bzyRO3tSTyHrKtDGfBwC5bIhgRCmv3yR8ylR_G4
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Journal
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Journal
 live_deploy: ''
 
  

--- a/_profiles/Journal/0.1-DRAFT-2019_02_08.html
+++ b/_profiles/Journal/0.1-DRAFT-2019_02_08.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: biotea2bioschemas
 use_cases_url: /useCases/PublicationIssue/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1ecj0bzyRO3tSTyHrKtDGfBwC5bIhgRCmv3yR8ylR_G4
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Journal
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Journal
 live_deploy: ''
  
 

--- a/_profiles/Journal/0.1-DRAFT-2019_03_02.html
+++ b/_profiles/Journal/0.1-DRAFT-2019_03_02.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: biotea2bioschemas
 use_cases_url: /useCases/PublicationIssue/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1ecj0bzyRO3tSTyHrKtDGfBwC5bIhgRCmv3yR8ylR_G4
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Journal
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Journal
 live_deploy: ''
 
 parent_type: Periodical

--- a/_profiles/Journal/0.1-DRAFT-2019_03_15.html
+++ b/_profiles/Journal/0.1-DRAFT-2019_03_15.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: publications
 use_cases_url: /useCases/PublicationIssue/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1cRtlx0UPer-qyLoEbynBsNINacAD--6UpJnWg4WLO2g
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Journal
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Journal
 live_deploy: ''
 
 
@@ -32,7 +32,7 @@ spec_info:
   version: 0.1-DRAFT-2019_03_15
   version_date: 20190208T100317
   official_type: schema:Collection
-  full_example: https://github.com/BioSchemas/specifications/tree/master/ScholarlyPublications
+  full_example: https://github.com/Bioschemas/specifications/tree/master/ScholarlyPublications
 mapping:
 - property: about
   expected_types:

--- a/_profiles/Journal/0.1-DRAFT-2019_09_05.html
+++ b/_profiles/Journal/0.1-DRAFT-2019_09_05.html
@@ -15,7 +15,7 @@ spec_type: Profile
 group: publications
 use_cases_url: /useCases/PublicationIssue/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1cRtlx0UPer-qyLoEbynBsNINacAD--6UpJnWg4WLO2g
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Journal
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Journal
 live_deploy: ''
 
 parent_type: Periodical
@@ -36,7 +36,7 @@ spec_info:
   version: 0.1-DRAFT-2019_05_09
   version_date: 20190509T053117
   official_type: schema:Collection
-  full_example: https://github.com/BioSchemas/specifications/tree/master/ScholarlyPublications
+  full_example: https://github.com/Bioschemas/specifications/tree/master/ScholarlyPublications
 mapping:
 - property: about
   expected_types:

--- a/_profiles/Journal/0.1-DRAFT-2019_11_20.html
+++ b/_profiles/Journal/0.1-DRAFT-2019_11_20.html
@@ -10,7 +10,7 @@ spec_type: Profile
 group: publications
 use_cases_url: /useCases/PublicationIssue/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1cRtlx0UPer-qyLoEbynBsNINacAD--6UpJnWg4WLO2g
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Journal
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Journal
 live_deploy: ''
 
 parent_type: Periodical
@@ -30,7 +30,7 @@ spec_info:
   version: 0.1-DRAFT-2019_11_20
   version_date: 20190509T053117
   official_type: schema:Collection
-  full_example: https://github.com/BioSchemas/specifications/tree/master/ScholarlyPublications
+  full_example: https://github.com/Bioschemas/specifications/tree/master/ScholarlyPublications
 mapping:
 - property: about
   expected_types:

--- a/_profiles/Journal/0.1-DRAFT-2019_11_21.html
+++ b/_profiles/Journal/0.1-DRAFT-2019_11_21.html
@@ -16,7 +16,7 @@ spec_type: Profile
 group: publications
 use_cases_url: /useCases/PublicationIssue/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1cRtlx0UPer-qyLoEbynBsNINacAD--6UpJnWg4WLO2g
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Journal
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Journal
 live_deploy: ''
 
 parent_type: Periodical
@@ -36,7 +36,7 @@ spec_info:
   version: 0.1-DRAFT-2019_11_21
   version_date: 20190509T053117
   official_type: schema:Collection
-  full_example: https://github.com/BioSchemas/specifications/tree/master/ScholarlyPublications
+  full_example: https://github.com/Bioschemas/specifications/tree/master/ScholarlyPublications
 mapping:
 - property: about
   expected_types:

--- a/_profiles/LabProtocol/0.2-DRAFT-2018_03_09.html
+++ b/_profiles/LabProtocol/0.2-DRAFT-2018_03_09.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: labprotocols
 use_cases_url: /useCases/LabProtocol/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1RWYIphvcBMHl8SLJl5-xRMZI0YaYrtJtClBSoOPL4xQ
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20LabProtocol
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20LabProtocol
 live_deploy: ''
 
 parent_type: CreativeWork
@@ -33,7 +33,7 @@ spec_info:
   version: "0.2-DRAFT-2018_03_09"
   version_date: 20180309T000000
   official_type: ""
-  full_example: "https://github.com/BioSchemas/specifications/tree/master/LabProtocol/examples/"
+  full_example: "https://github.com/Bioschemas/specifications/tree/master/LabProtocol/examples/"
 mapping:
 - property: additionalType
   expected_types:

--- a/_profiles/LabProtocol/0.3-DRAFT-2019_06_14.html
+++ b/_profiles/LabProtocol/0.3-DRAFT-2019_06_14.html
@@ -10,7 +10,7 @@ spec_type: Profile
 group: labprotocols
 use_cases_url: /useCases/LabProtocol/
 cross_walk_url: https://docs.google.com/spreadsheets/d/16PRB0Izdlj43-pTVcepi-2okjhBkiTjno_bkRBP0PeE/
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20LabProtocol
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20LabProtocol
 live_deploy: ''
 
 parent_type: CreativeWork
@@ -29,7 +29,7 @@ spec_info:
   version: 0.3-DRAFT-2019_06_14
   version_date: 20190614T205321
   official_type: http://bioschemas.org/LabProtocol
-  full_example: https://github.com/BioSchemas/Specifications/tree/master/LabProtocol/examples
+  full_example: https://github.com/Bioschemas/Specifications/tree/master/LabProtocol/examples
 mapping:
 - property: additionalType
   expected_types:

--- a/_profiles/LabProtocol/0.4-DRAFT-2020_07_23.html
+++ b/_profiles/LabProtocol/0.4-DRAFT-2020_07_23.html
@@ -10,7 +10,7 @@ spec_type: Profile
 group: labprotocols
 use_cases_url: /useCases/LabProtocol/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1RWYIphvcBMHl8SLJl5-xRMZI0YaYrtJtClBSoOPL4xQ
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20LabProtocol
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20LabProtocol
 live_deploy: ''
 
 parent_type: CreativeWork
@@ -26,17 +26,17 @@ spec_info:
   description: 'This LabProtocol profile specification presents the markup for describing
     a LabProtocol.<h4>Summary of Changes</h4>    Changes since previous draft of the
     LabProtocols profile:    <ul>      <li>''used'' added at the end to elements used
-    in the protocol, see <a href=''https://github.com/BioSchemas/specifications/issues/265''>issue
+    in the protocol, see <a href=''https://github.com/Bioschemas/specifications/issues/265''>issue
     265</a></li>      <li>Protocols advantages, limitations, outcomes, purpose and
     application were mixed up in the previous draft, they have been revised.</li>      <li>Short
-    examples have been added per properties, see <a href=''https://github.com/BioSchemas/specifications/issues/179''>issue
+    examples have been added per properties, see <a href=''https://github.com/Bioschemas/specifications/issues/179''>issue
     179</a>.</li>      <li>Links to the ontologies were revised.</li>      <li>Property
     descriptions were revised.</li>      <li>Description property removed as we have now steps.</li>      
     <li>Still pending: issue 331.</li>    </ul>'
   version: '0.4-DRAFT-2020_07_23'
   version_date: 20200723T141248
   official_type: http://bioschemas.org/LabProtocol
-  full_example: https://github.com/BioSchemas/Specifications/tree/master/LabProtocol/examples
+  full_example: https://github.com/Bioschemas/Specifications/tree/master/LabProtocol/examples
 mapping:
 - property: author
   expected_types:

--- a/_profiles/LabProtocol/0.5-DRAFT-2020_09_01.html
+++ b/_profiles/LabProtocol/0.5-DRAFT-2020_09_01.html
@@ -19,7 +19,7 @@ spec_type: Profile
 group: labprotocols
 use_cases_url: /useCases/LabProtocol/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1dyRNuAI45zHbbv1b-tDBHwLQcEuzXP_7WmaXQm9YDlM
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20LabProtocol
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20LabProtocol
 live_deploy: ''
 
 parent_type: labProtocol
@@ -40,22 +40,22 @@ spec_info:
     and operations executed to perform experimental research in biological and biomedical areas. 
     <h4>Summary of Changes</h4>    Changes since previous draft of the
     LabProtocols profile:    <ul>      <li>LabProtocol profile definition updated
-    to the one on the type, see <a href=''https://github.com/BioSchemas/specifications/issues/331''>issue
-    331</a></li>      <li>Description property added, see <a href=''https://github.com/BioSchemas/specifications/issues/436''>issue
-    436</a></li>      <li>Title added as minimum, see <a href=''https://github.com/BioSchemas/specifications/issues/438''>issue
+    to the one on the type, see <a href=''https://github.com/Bioschemas/specifications/issues/331''>issue
+    331</a></li>      <li>Description property added, see <a href=''https://github.com/Bioschemas/specifications/issues/436''>issue
+    436</a></li>      <li>Title added as minimum, see <a href=''https://github.com/Bioschemas/specifications/issues/438''>issue
     438</a>.</li>      <li>Protocol advantage property description updated, see <a
-    href=''https://github.com/BioSchemas/specifications/issues/440''>issue 440</a></li>      <li>Time
+    href=''https://github.com/Bioschemas/specifications/issues/440''>issue 440</a></li>      <li>Time
     properties updated (totalTime as it was plus performTime and prepTime as optional),
-    see <a href=''https://github.com/BioSchemas/specifications/issues/441''>issue
+    see <a href=''https://github.com/Bioschemas/specifications/issues/441''>issue
     441</a></li>      <li>ReagentUsed property description updated, now using CHEBI
     definition, also MolecularEntity and ChemicalSubstance to the range list added,
-    see <a href=''https://github.com/BioSchemas/specifications/issues/442''>issue
+    see <a href=''https://github.com/Bioschemas/specifications/issues/442''>issue
     442</a></li>            <li>LabProtocol now used as the parent type for this profile, 
-      see <a href=''https://github.com/BioSchemas/specifications/issues/443''>issue 443</a></li>    </ul>'
+      see <a href=''https://github.com/Bioschemas/specifications/issues/443''>issue 443</a></li>    </ul>'
   version: 0.5-DRAFT-2020_09_01
   version_date: 20200901T154721
   official_type: http://bioschemas.org/LabProtocol
-  full_example: https://github.com/BioSchemas/Specifications/tree/master/LabProtocol/examples
+  full_example: https://github.com/Bioschemas/Specifications/tree/master/LabProtocol/examples
 mapping:
 - property: author
   expected_types:

--- a/_profiles/MolecularEntity/0.2-DRAFT-2018_11_14.html
+++ b/_profiles/MolecularEntity/0.2-DRAFT-2018_11_14.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: chemicals
 use_cases_url: '/useCases/MolecularEntity/'
 cross_walk_url: 'https://docs.google.com/spreadsheets/d/13M-7CiaCbIJEFQd8m4darqLW5r4W3A_OnPlnDulnCKA/edit#gid=1261485211'
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Chemistry
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Chemistry
 live_deploy: ''
 
 parent_type: Thing
@@ -30,7 +30,7 @@ spec_info:
   version: 0.2-DRAFT-2018_11_14
   version_date: 20181114T111335
   official_type: ""
-  full_example: https://github.com/BioSchemas/specifications/blob/master/Chemical/examples/chembl-jsonld.json
+  full_example: https://github.com/Bioschemas/specifications/blob/master/Chemical/examples/chembl-jsonld.json
 mapping:
 - property: alternateName
   expected_types:

--- a/_profiles/MolecularEntity/0.2-DRAFT-2018_11_15.html
+++ b/_profiles/MolecularEntity/0.2-DRAFT-2018_11_15.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: chemicals
 use_cases_url: '/useCases/MolecularEntity/'
 cross_walk_url: https://docs.google.com/spreadsheets/d/13M-7CiaCbIJEFQd8m4darqLW5r4W3A_OnPlnDulnCKA/
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Chemistry
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Chemistry
 live_deploy: ''
 
 parent_type: Thing
@@ -29,7 +29,7 @@ spec_info:
   version: 0.2-DRAFT-2018_11_15
   version_date: 20181115T093002
   official_type: ""
-  full_example: https://github.com/BioSchemas/specifications/tree/master/MolecularEntity/examples
+  full_example: https://github.com/Bioschemas/specifications/tree/master/MolecularEntity/examples
 mapping:
 - property: alternateName
   expected_types:

--- a/_profiles/MolecularEntity/0.4-DRAFT-2019_11_11.html
+++ b/_profiles/MolecularEntity/0.4-DRAFT-2019_11_11.html
@@ -11,7 +11,7 @@ spec_type: Profile
 group: chemicals
 use_cases_url: '/useCases/MolecularEntity/'
 cross_walk_url: https://docs.google.com/spreadsheets/d/1KXcNfvUCQQ0kYswp2w17ZQ_5I7xXiAX-0XtaGauSloU/edit#gid=1483018794
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Chemistry
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Chemistry
 live_deploy: /liveDeploys/
 
 
@@ -32,7 +32,7 @@ spec_info:
   version: 0.4-DRAFT-2019_11_11
   version_date: 20191111T212126
   official_type: https://schema.org/MolecularEntity
-  full_example: https://github.com/BioSchemas/specifications/blob/master/Chemical/examples/chembl-jsonld.json
+  full_example: https://github.com/Bioschemas/specifications/blob/master/Chemical/examples/chembl-jsonld.json
 mapping:
 - property: alternateName
   expected_types:

--- a/_profiles/MolecularEntity/0.5-RELEASE.html
+++ b/_profiles/MolecularEntity/0.5-RELEASE.html
@@ -17,7 +17,7 @@ spec_type: Profile
 group: chemicals
 use_cases_url: '/useCases/MolecularEntity/'
 cross_walk_url: 'https://docs.google.com/spreadsheets/d/1KKg8JJzK3GybuVrvdZxbMqG2PYkU_0e7gTUqWzGx3QQ/edit#gid=1483018794'
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Chemistry
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Chemistry
 live_deploy: /liveDeploys/
 
 
@@ -40,7 +40,7 @@ spec_info:
   version: 0.5-RELEASE
   version_date: 20200407T134325
   official_type: https://schema.org/MolecularEntity
-  full_example: https://github.com/BioSchemas/specifications/blob/master/Chemical/examples/chembl-jsonld.json
+  full_example: https://github.com/Bioschemas/specifications/blob/master/Chemical/examples/chembl-jsonld.json
 mapping:
 - property: alternateName
   expected_types:

--- a/_profiles/Organization/0.1-DRAFT-2018_03_13.html
+++ b/_profiles/Organization/0.1-DRAFT-2018_03_13.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: organizations
 use_cases_url: /useCases/Organization/
 cross_walk_url: https://docs.google.com/spreadsheets/d/14UoeVmh2eRRWlyQgOJWAuCIW7DMuwhLH6O3CBeXfoTI/edit#gid=1261485211
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Organization
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Organization
 live_deploy: ''
 
 parent_type: Organization

--- a/_profiles/Organization/0.2-DRAFT-2019_07_17.html
+++ b/_profiles/Organization/0.2-DRAFT-2019_07_17.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: organizations
 use_cases_url: /useCases/Organization/
 cross_walk_url: ''
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Organization
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Organization
 live_deploy: ''
 
 

--- a/_profiles/Organization/0.2-DRAFT-2019_07_19.html
+++ b/_profiles/Organization/0.2-DRAFT-2019_07_19.html
@@ -16,7 +16,7 @@ spec_type: Profile
 group: organizations
 use_cases_url: /useCases/Organization/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1Cy45Llql88NvkqwRw7WD1y8HeVQ4z5_V6MhJh6hhbks/
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Organization
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Organization
 live_deploy: ''
 
 parent_type: Organization

--- a/_profiles/Person/0.1-DRAFT-2018_03_14.html
+++ b/_profiles/Person/0.1-DRAFT-2018_03_14.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: people
 use_cases_url: /useCases/Person/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1_Hc_RD0GvdxuuO921ZGoQGZEFkcEjcS5J6dQVD2cwiQ
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20person
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20person
 live_deploy: ''
 
 parent_type: Person

--- a/_profiles/Person/0.2-DRAFT-2019_07_19.html
+++ b/_profiles/Person/0.2-DRAFT-2019_07_19.html
@@ -16,7 +16,7 @@ spec_type: Profile
 group: people
 use_cases_url: /useCases/Person/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1vliGiKWlHzqXWcGPa15l0PzJbQGXPKxYPq8Mups_or4
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20person
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20person
 live_deploy: ''
 
 

--- a/_profiles/Phenotype/0.1-DRAFT-2018_11_15.html
+++ b/_profiles/Phenotype/0.1-DRAFT-2018_11_15.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: phenotypes
 use_cases_url: '/useCases/Phenotype/'
 cross_walk_url: https://docs.google.com/spreadsheets/d/1ynkICcogm_eVDH2Y7IYr3Nf2GFbGntUWFN3yHy8bSGI
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Phenotype
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Phenotype
 live_deploy: ''
 
 
@@ -28,7 +28,7 @@ spec_info:
   version: 0.1-DRAFT-2018_11_15
   version_date: 20181115T172726
   official_type: http://bioschemas.org/Phenotype
-  full_example: https://github.com/BioSchemas/Specifications/tree/master/Phenotype/
+  full_example: https://github.com/Bioschemas/Specifications/tree/master/Phenotype/
 mapping:
 - property: additionalProperty
   expected_types:

--- a/_profiles/Phenotype/0.2-DRAFT.html
+++ b/_profiles/Phenotype/0.2-DRAFT.html
@@ -16,7 +16,7 @@ spec_type: Profile
 group: phenotypes
 use_cases_url: '/useCases/Phenotype/'
 cross_walk_url: https://docs.google.com/spreadsheets/d/1Vk8C-T6tjTL-s_u3xiCnjp87zVWCPQVbzySv1jqsK78/
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Phenotype
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Phenotype
 live_deploy: ''
 
 
@@ -40,7 +40,7 @@ spec_info:
   version: 0.2-DRAFT
   version_date: 20200605T160522
   official_type: http://bioschemas.org/Phenotype
-  full_example: https://github.com/BioSchemas/Specifications/tree/master/Phenotype/
+  full_example: https://github.com/Bioschemas/Specifications/tree/master/Phenotype/
 mapping:
 - property: additionalProperty
   expected_types:

--- a/_profiles/Protein/0.10-DRAFT-2020_04_02.html
+++ b/_profiles/Protein/0.10-DRAFT-2020_04_02.html
@@ -10,7 +10,7 @@ spec_type: Profile
 group: proteins
 use_cases_url: /useCases/Protein/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1F8CafZUF9zw5HK-gKuiwwVqsjxPinEthXnrlI4Gzjzs
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Protein
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Protein
 live_deploy: /liveDeploys/
 
 parent_type: Protein
@@ -28,7 +28,7 @@ spec_info:
     used for a Protein plus examples on how to use them.
     <h4>Summary of Changes</h4>
     Changes introduced on Protein
-    profile 0.10-DRAFT-2020_04_02 in response to <a href="https://github.com/BioSchemas/specifications/issues/410">issue
+    profile 0.10-DRAFT-2020_04_02 in response to <a href="https://github.com/Bioschemas/specifications/issues/410">issue
     410</a>
     <ul><li>range of taxonomicRange updated</li></ul>
     Additional changes after looking at BioChemEntity

--- a/_profiles/Protein/0.11-RELEASE.html
+++ b/_profiles/Protein/0.11-RELEASE.html
@@ -18,7 +18,7 @@ spec_type: Profile
 group: proteins
 use_cases_url: /useCases/Protein/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1FgZIcvUqPNSjAivMOopEPP1cD8TJ8ofG7A51MdHhw8s/edit#gid=1483018794
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Protein
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Protein
 live_deploy: /liveDeploys/
 
 parent_type: Protein

--- a/_profiles/Protein/0.5-DRAFT-2018_08_15.html
+++ b/_profiles/Protein/0.5-DRAFT-2018_08_15.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: proteins
 use_cases_url: /useCases/Proteins/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1QQH4AkzdwPT1Qt5OLmH5HosLpkFU7khwE4Ql9_Cb9ZQ
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Protein
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Protein
 live_deploy: /liveDeploys/
 
 parent_type: BioChemEntity
@@ -28,7 +28,7 @@ spec_info:
   version: 0.5-DRAFT-2018_08_15
   version_date: 20180815T152236
   official_type: http://purl.obolibrary.org/obo/PR_000000001
-  full_example: https://github.com/BioSchemas/bioschemas.github.io/tree/master/_devSpecs/Protein/examples
+  full_example: https://github.com/Bioschemas/bioschemas.github.io/tree/master/_devSpecs/Protein/examples
 mapping:
 - property: additionalProperty
   expected_types:

--- a/_profiles/Protein/0.5-DRAFT-2018_11_09.html
+++ b/_profiles/Protein/0.5-DRAFT-2018_11_09.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: proteins
 use_cases_url: /useCases/Proteins/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1agujmyTPuysB0268Nptfbg6IVI_5Su3I9do092oYEdE/edit#gid=1483018794
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Protein
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Protein
 live_deploy: /liveDeploys/
 
 
@@ -31,7 +31,7 @@ spec_info:
   version: 0.5-DRAFT-2018_11_09
   version_date: 20181109T131238
   official_type: http://bioschemas.org/Protein
-  full_example: https://github.com/BioSchemas/bioschemas.github.io/tree/master/_devSpecs/Protein/examples
+  full_example: https://github.com/Bioschemas/bioschemas.github.io/tree/master/_devSpecs/Protein/examples
 mapping:
 - property: additionalProperty
   expected_types:

--- a/_profiles/Protein/0.5-DRAFT-2018_11_10.html
+++ b/_profiles/Protein/0.5-DRAFT-2018_11_10.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: proteins
 use_cases_url: /useCases/Proteins/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1agujmyTPuysB0268Nptfbg6IVI_5Su3I9do092oYEdE/edit#gid=1483018794
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Protein
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Protein
 live_deploy: /liveDeploys/
 
 parent_type: Protein
@@ -28,7 +28,7 @@ spec_info:
   version: 0.5-DRAFT-2018_11_10
   version_date: 20181110T103004
   official_type: http://bioschemas.org/Protein
-  full_example: https://github.com/BioSchemas/bioschemas.github.io/tree/master/_devSpecs/Protein/examples
+  full_example: https://github.com/Bioschemas/bioschemas.github.io/tree/master/_devSpecs/Protein/examples
 mapping:
 - property: additionalProperty
   expected_types:

--- a/_profiles/Protein/0.6-DRAFT-2018_11_10.html
+++ b/_profiles/Protein/0.6-DRAFT-2018_11_10.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: proteins
 use_cases_url: /useCases/Proteins/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1agujmyTPuysB0268Nptfbg6IVI_5Su3I9do092oYEdE/edit#gid=1483018794
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Protein
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Protein
 live_deploy: /liveDeploys/
 
 parent_type: Protein
@@ -28,7 +28,7 @@ spec_info:
   version: 0.6-DRAFT-2018_11_10
   version_date: 20181110T113226
   official_type: http://bioschemas.org/Protein
-  full_example: https://github.com/BioSchemas/Specifications/tree/master/Protein/examples
+  full_example: https://github.com/Bioschemas/Specifications/tree/master/Protein/examples
 mapping:
 - property: additionalProperty
   expected_types:

--- a/_profiles/Protein/0.6-RELEASE-2018_11_10.html
+++ b/_profiles/Protein/0.6-RELEASE-2018_11_10.html
@@ -10,7 +10,7 @@ spec_type: Profile
 group: proteins
 use_cases_url: /useCases/Proteins/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1agujmyTPuysB0268Nptfbg6IVI_5Su3I9do092oYEdE/edit#gid=1483018794
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Protein
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Protein
 live_deploy: /liveDeploys/
 
 parent_type: Protein
@@ -29,7 +29,7 @@ spec_info:
   version: 0.6-RELEASE-2018_11_10
   version_date: 20181110T113226
   official_type: http://bioschemas.org/Protein
-  full_example: https://github.com/BioSchemas/Specifications/tree/master/Protein/examples
+  full_example: https://github.com/Bioschemas/Specifications/tree/master/Protein/examples
 mapping:
 - property: additionalProperty
   expected_types:

--- a/_profiles/Protein/0.8-DRAFT-2019_05_08.html
+++ b/_profiles/Protein/0.8-DRAFT-2019_05_08.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: proteins
 use_cases_url: /useCases/Protein/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1UbTy5OACa08ZTX9yk35AaVRUS6YBm1jBqwgG-Y41KGc
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Protein
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Protein
 live_deploy: /liveDeploys/
 
 

--- a/_profiles/Protein/0.9-DRAFT-2019_08_20.html
+++ b/_profiles/Protein/0.9-DRAFT-2019_08_20.html
@@ -11,7 +11,7 @@ spec_type: Profile
 group: proteins
 use_cases_url: /useCases/Protein/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1UbTy5OACa08ZTX9yk35AaVRUS6YBm1jBqwgG-Y41KGc
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Protein
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Protein
 live_deploy: /liveDeploys/
 
 parent_type: Protein

--- a/_profiles/ProteinAnnotation/0.4-DRAFT-2018_02_25.html
+++ b/_profiles/ProteinAnnotation/0.4-DRAFT-2018_02_25.html
@@ -16,7 +16,7 @@ spec_type: Profile
 group: proteins
 use_cases_url: /useCases/Protein/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1KNVv3xedOpckk3ZcILnPmlys2DTzpk8KnkRwVFR2SL0
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20ProteinAnnotation
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20ProteinAnnotation
 live_deploy: /liveDeploys/
 
 parent_type: BioChemEntity

--- a/_profiles/ProteinStructure/0.5-DRAFT-2018_08_15.html
+++ b/_profiles/ProteinStructure/0.5-DRAFT-2018_08_15.html
@@ -16,7 +16,7 @@ spec_type: Profile
 group: proteins
 use_cases_url: /useCases/Protein/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1MfvX5tJs5mKA835e-98eaLmN5_5xYjFfcMcbtdMRtC4
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Protein
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Protein
 live_deploy: /liveDeploys/
 
 

--- a/_profiles/PublicationIssue/0.1-DRAFT-2019_01_31.html
+++ b/_profiles/PublicationIssue/0.1-DRAFT-2019_01_31.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: biotea2bioschemas
 use_cases_url: /useCases/PublicationIssue/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1ecj0bzyRO3tSTyHrKtDGfBwC5bIhgRCmv3yR8ylR_G4
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20PublicationIssue
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20PublicationIssue
 live_deploy: ''
 
 parent_type: PublicationIssue

--- a/_profiles/PublicationIssue/0.1-DRAFT-2019_02_08.html
+++ b/_profiles/PublicationIssue/0.1-DRAFT-2019_02_08.html
@@ -17,7 +17,7 @@ spec_type: Profile
 group: publications
 use_cases_url: /useCases/PublicationIssue/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1051XQLDg3pcPPPg7ro9cVMZ3nMrQGsBm09a8i1OZarI/
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20PublicationIssue
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20PublicationIssue
 live_deploy: ''
 
 parent_type: PublicationIssue
@@ -37,7 +37,7 @@ spec_info:
   version: 0.1-DRAFT-2019_02_08
   version_date: 20190208T103820
   official_type: schema:PublicationIssue
-  full_example: https://github.com/BioSchemas/specifications/tree/master/ScholarlyPublications
+  full_example: https://github.com/Bioschemas/specifications/tree/master/ScholarlyPublications
 mapping:
 - property: about
   expected_types:

--- a/_profiles/PublicationVolume/0.1-DRAFT-2019_01_31.html
+++ b/_profiles/PublicationVolume/0.1-DRAFT-2019_01_31.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: biotea2bioschemas
 use_cases_url: /useCases/PublicationVolume/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1ecj0bzyRO3tSTyHrKtDGfBwC5bIhgRCmv3yR8ylR_G4
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20PublicationVolume
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20PublicationVolume
 live_deploy: ''
 
 

--- a/_profiles/PublicationVolume/0.1-DRAFT-2019_02_08.html
+++ b/_profiles/PublicationVolume/0.1-DRAFT-2019_02_08.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: biotea2bioschemas
 use_cases_url: /useCases/PublicationVolume/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1ecj0bzyRO3tSTyHrKtDGfBwC5bIhgRCmv3yR8ylR_G4
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20PublicationVolume
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20PublicationVolume
 live_deploy: ''
 
 

--- a/_profiles/PublicationVolume/0.1-DRAFT-2019_02_14.html
+++ b/_profiles/PublicationVolume/0.1-DRAFT-2019_02_14.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: biotea2bioschemas
 use_cases_url: /useCases/PublicationVolume/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1ecj0bzyRO3tSTyHrKtDGfBwC5bIhgRCmv3yR8ylR_G4
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20PublicationVolume
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20PublicationVolume
 live_deploy: ''
 
 

--- a/_profiles/PublicationVolume/0.1-DRAFT-2019_02_15.html
+++ b/_profiles/PublicationVolume/0.1-DRAFT-2019_02_15.html
@@ -16,7 +16,7 @@ spec_type: Profile
 group: publications
 use_cases_url: /useCases/PublicationVolume/
 cross_walk_url: https://docs.google.com/spreadsheets/d/198jnxnTf6rUTPc0ZYgFkP3ZElvHylQU-Tx4LwFDHZQ0
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20PublicationVolume
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20PublicationVolume
 live_deploy: ''
 
 parent_type: PublicationVolume
@@ -37,7 +37,7 @@ spec_info:
   version: 0.1-DRAFT-2019_02_15
   version_date: 20190208T104001
   official_type: schema:PublicationVolume
-  full_example: https://github.com/BioSchemas/specifications/tree/master/ScholarlyPublications
+  full_example: https://github.com/Bioschemas/specifications/tree/master/ScholarlyPublications
 mapping:
 - property: about
   expected_types:

--- a/_profiles/RNA/0.1-DRAFT-2019_11_15.html
+++ b/_profiles/RNA/0.1-DRAFT-2019_11_15.html
@@ -16,7 +16,7 @@ spec_type: Profile
 group: DNA
 use_cases_url: /useCases/DNA/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1N2_6iLktDXlcgkuXJdpW4UKg9M9Q08VfMqtDDS5tEp4/edit#gid=292464567
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20RNA
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20RNA
 live_deploy: /liveDeploys/
 
 parent_type: BioChemEntity

--- a/_profiles/Sample/0.1-DRAFT-2018_02_25.html
+++ b/_profiles/Sample/0.1-DRAFT-2018_02_25.html
@@ -11,7 +11,7 @@ spec_type: Profile
 group: samples
 use_cases_url: /useCases/Samples/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1NltFMzjqezpKhobmqEBEvASLziZjq73a_AqWnNi3IOs/
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Sample
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Sample
 live_deploy: /liveDeploys/
 
 parent_type: BioChemEntity

--- a/_profiles/Sample/0.2-DRAFT-2018_11_09.html
+++ b/_profiles/Sample/0.2-DRAFT-2018_11_09.html
@@ -10,7 +10,7 @@ spec_type: Profile
 group: samples
 use_cases_url: /useCases/Samples/
 cross_walk_url: https://docs.google.com/spreadsheets/d/122y9X5ZxFN5sPDX63ox8UGQlHkddT6O69_e2b_eAv5Y/edit#gid=1483018794
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Sample
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Sample
 live_deploy: /liveDeploys/
 
 parent_type: Sample

--- a/_profiles/Sample/0.2-DRAFT-2018_11_10.html
+++ b/_profiles/Sample/0.2-DRAFT-2018_11_10.html
@@ -10,7 +10,7 @@ spec_type: Profile
 group: samples
 use_cases_url: /useCases/Samples/
 cross_walk_url: https://docs.google.com/spreadsheets/d/122y9X5ZxFN5sPDX63ox8UGQlHkddT6O69_e2b_eAv5Y/edit#gid=1483018794
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Sample
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Sample
 live_deploy: /liveDeploys/
 
 parent_type: Sample
@@ -37,7 +37,7 @@ spec_info:
   version: 0.2-DRAFT-2018_11_10
   version_date: 20181110T110825
   official_type: ""
-  full_example: https://github.com/BioSchemas/specifications/tree/master/Sample/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/Sample/examples/
 mapping:
 - property: additionalProperty
   expected_types:

--- a/_profiles/Sample/0.2-RELEASE-2018_11_10.html
+++ b/_profiles/Sample/0.2-RELEASE-2018_11_10.html
@@ -18,7 +18,7 @@ spec_type: Profile
 group: samples
 use_cases_url: /useCases/Sample/
 cross_walk_url: https://docs.google.com/spreadsheets/d/122y9X5ZxFN5sPDX63ox8UGQlHkddT6O69_e2b_eAv5Y/edit#gid=1483018794
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Sample
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Sample
 live_deploy: /liveDeploys/
 
 parent_type: Sample
@@ -44,7 +44,7 @@ spec_info:
   version: 0.2-RELEASE-2018_11_10
   version_date: 20181110T110825
   official_type: ""
-  full_example: https://github.com/BioSchemas/specifications/tree/master/Sample/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/Sample/examples/
 mapping:
 - property: additionalProperty
   expected_types:

--- a/_profiles/ScholarlyArticle/0.1-DRAFT-2019_01_31.html
+++ b/_profiles/ScholarlyArticle/0.1-DRAFT-2019_01_31.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: biotea2bioschemas
 use_cases_url: /useCases/ScholarlyArticle/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1ecj0bzyRO3tSTyHrKtDGfBwC5bIhgRCmv3yR8ylR_G4
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20ScholarlyArticle
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20ScholarlyArticle
 live_deploy: ''
 
 parent_type: ScholarlyArticle

--- a/_profiles/ScholarlyArticle/0.1-DRAFT-2019_02_03.html
+++ b/_profiles/ScholarlyArticle/0.1-DRAFT-2019_02_03.html
@@ -10,7 +10,7 @@ spec_type: Profile
 group: biotea2bioschemas
 use_cases_url: /useCases/ScholarlyArticle/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1ecj0bzyRO3tSTyHrKtDGfBwC5bIhgRCmv3yR8ylR_G4
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20ScholarlyArticle
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20ScholarlyArticle
 live_deploy: ''
 
 parent_type: ScholarlyArticle

--- a/_profiles/ScholarlyArticle/0.1-DRAFT-2019_02_08.html
+++ b/_profiles/ScholarlyArticle/0.1-DRAFT-2019_02_08.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: biotea2bioschemas
 use_cases_url: /useCases/ScholarlyArticle/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1ecj0bzyRO3tSTyHrKtDGfBwC5bIhgRCmv3yR8ylR_G4
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20ScholarlyArticle
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20ScholarlyArticle
 live_deploy: ''
 
 parent_type: ScholarlyArticle

--- a/_profiles/ScholarlyArticle/0.1-DRAFT-2019_02_14.html
+++ b/_profiles/ScholarlyArticle/0.1-DRAFT-2019_02_14.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: biotea2bioschemas
 use_cases_url: /useCases/ScholarlyArticle/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1ecj0bzyRO3tSTyHrKtDGfBwC5bIhgRCmv3yR8ylR_G4
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20ScholarlyArticle
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20ScholarlyArticle
 live_deploy: ''
 
 parent_type: ScholarlyArticle

--- a/_profiles/ScholarlyArticle/0.1-DRAFT-2019_03_15.html
+++ b/_profiles/ScholarlyArticle/0.1-DRAFT-2019_03_15.html
@@ -16,7 +16,7 @@ spec_type: Profile
 group: publications
 use_cases_url: /useCases/ScholarlyArticle/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1Bu2Jh1AUlJQCEk909yFhb8rz5eWZOQcAQ5ClxKhTJ6M
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20ScholarlyArticle
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20ScholarlyArticle
 live_deploy: ''
 
 parent_type: ScholarlyArticle
@@ -37,7 +37,7 @@ spec_info:
   version: 0.1-DRAFT-2019_03_15
   version_date: 20190208T095928
   official_type: schema:ScholarlyArticle
-  full_example: https://github.com/BioSchemas/specifications/tree/master/ScholarlyPublications
+  full_example: https://github.com/Bioschemas/specifications/tree/master/ScholarlyPublications
 mapping:
 - property: alternateName
   expected_types:

--- a/_profiles/SemanticAnnotation/0.1-DRAFT-2019_02_08.html
+++ b/_profiles/SemanticAnnotation/0.1-DRAFT-2019_02_08.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: publications
 use_cases_url: /useCases/SemanticAnnotation/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1_hsrPFM0htdoNaWF2PCg92bLf_ckOz8ird3kwJBANS0
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20SemanticAnnotation
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20SemanticAnnotation
 live_deploy: ''
 
 parent_type: Collection
@@ -29,7 +29,7 @@ spec_info:
   version: 0.1-DRAFT-2019_02_08
   version_date: 20190208T104450
   official_type: schema:CreativeWork
-  full_example: https://github.com/BioSchemas/specifications/tree/master/ScholarlyPublications
+  full_example: https://github.com/Bioschemas/specifications/tree/master/ScholarlyPublications
 mapping:
 - property: subjectOf
   expected_types:

--- a/_profiles/SemanticAnnotation/0.1-DRAFT-2019_11_19.html
+++ b/_profiles/SemanticAnnotation/0.1-DRAFT-2019_11_19.html
@@ -16,7 +16,7 @@ spec_type: Profile
 group: publications
 use_cases_url: /useCases/SemanticAnnotation/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1_hsrPFM0htdoNaWF2PCg92bLf_ckOz8ird3kwJBANS0
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20SemanticAnnotation
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20SemanticAnnotation
 live_deploy: ''
 
 parent_type: Collection
@@ -34,7 +34,7 @@ spec_info:
   version: 0.1-DRAFT-2019_11_19
   version_date: 20190208T104450
   official_type: schema:CreativeWork
-  full_example: https://github.com/BioSchemas/specifications/tree/master/ScholarlyPublications
+  full_example: https://github.com/Bioschemas/specifications/tree/master/ScholarlyPublications
 mapping:
 - property: subjectOf
   expected_types:

--- a/_profiles/Study/0.1-DRAFT-2018_11_15.html
+++ b/_profiles/Study/0.1-DRAFT-2018_11_15.html
@@ -16,7 +16,7 @@ spec_type: Profile
 group: studies
 use_cases_url: /useCases/Study/
 cross_walk_url: https://docs.google.com/spreadsheets/d/12fvwLvsWsLF9Olz4ueiNn7pnU27OR_ejgxn8Oy4xFPs/
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Study
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Study
 live_deploy: ''
 
 parent_type:
@@ -34,7 +34,7 @@ spec_info:
   version: 0.1-DRAFT-2018_11_15
   version_date: 20181115T164019
   official_type: http://bioschemas.org/Study
-  full_example: https://github.com/BioSchemas/specifications/tree/master/Study/examples
+  full_example: https://github.com/Bioschemas/specifications/tree/master/Study/examples
 mapping:
 - property: about
   expected_types:

--- a/_profiles/Taxon/0.1-DRAFT-2018_06_27.html
+++ b/_profiles/Taxon/0.1-DRAFT-2018_06_27.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: biodiversity
 use_cases_url: ''
 cross_walk_url: https://drive.google.com/open?id=1hHE7SHz9qt6Eg6j6DQgI9BwhrlGOwkO68fzek78m62I
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Taxon
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Taxon
 live_deploy: ''
 
 parent_type: BioChemEntity
@@ -28,7 +28,7 @@ spec_info:
   version: 0.1-DRAFT-2018_06_27
   version_date: 20180627T095507
   official_type: http://rs.tdwg.org/dwc/terms/Taxon
-  full_example: 'https://github.com/BioSchemas/specifications/tree/master/Taxon/examples'
+  full_example: 'https://github.com/Bioschemas/specifications/tree/master/Taxon/examples'
 mapping:
 - property: additionalType
   expected_types:

--- a/_profiles/Taxon/0.1-DRAFT-2018_09_25.html
+++ b/_profiles/Taxon/0.1-DRAFT-2018_09_25.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: biodiversity
 use_cases_url: ''
 cross_walk_url: https://drive.google.com/open?id=1hHE7SHz9qt6Eg6j6DQgI9BwhrlGOwkO68fzek78m62I
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Taxon
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Taxon
 live_deploy: ''
 
 parent_type: BioChemEntity

--- a/_profiles/Taxon/0.1-DRAFT-2018_09_26.html
+++ b/_profiles/Taxon/0.1-DRAFT-2018_09_26.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: biodiversity
 use_cases_url: ''
 cross_walk_url: https://drive.google.com/open?id=1hHE7SHz9qt6Eg6j6DQgI9BwhrlGOwkO68fzek78m62I
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Taxon
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Taxon
 live_deploy: ''
 
 parent_type: BioChemEntity

--- a/_profiles/Taxon/0.2-DRAFT-2018_09_26.html
+++ b/_profiles/Taxon/0.2-DRAFT-2018_09_26.html
@@ -10,7 +10,7 @@ spec_type: Profile
 group: biodiversity
 use_cases_url: /useCases/Taxon/
 cross_walk_url: https://drive.google.com/open?id=1hHE7SHz9qt6Eg6j6DQgI9BwhrlGOwkO68fzek78m62I
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Taxon
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Taxon
 live_deploy: ''
 
 parent_type: BioChemEntity
@@ -29,7 +29,7 @@ spec_info:
   version: 0.2-DRAFT-2018_09_26
   version_date: 20180925T134042
   official_type: http://rs.tdwg.org/dwc/terms/Taxon
-  full_example: https://github.com/BioSchemas/specifications/tree/master/Taxon/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/Taxon/examples/
 mapping:
 - property: additionalType
   expected_types:

--- a/_profiles/Taxon/0.3-DRAFT-2018_11_09.html
+++ b/_profiles/Taxon/0.3-DRAFT-2018_11_09.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: biodiversity
 use_cases_url: /useCases/Taxon/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1HHa0P6bvym1sZcO4GZMH01J_Cl06eXH60IVTp0b_Nas/edit?ts=5be44b29#gid=1483018794
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Taxon
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Taxon
 live_deploy: ''
 
 parent_type: Thing
@@ -28,7 +28,7 @@ spec_info:
   version: 0.3-DRAFT-2018_11_09
   version_date: 20181109T130619
   official_type: http://bioschemas.org/Taxon
-  full_example: https://github.com/BioSchemas/specifications/tree/master/Taxon/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/Taxon/examples/
 mapping:
 - property: additionalType
   expected_types:

--- a/_profiles/Taxon/0.3-DRAFT-2018_11_10.html
+++ b/_profiles/Taxon/0.3-DRAFT-2018_11_10.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: biodiversity
 use_cases_url: /useCases/Taxon/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1HHa0P6bvym1sZcO4GZMH01J_Cl06eXH60IVTp0b_Nas/edit?ts=5be44b29#gid=1483018794
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Taxon
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Taxon
 live_deploy: ''
 
 parent_type: Taxon
@@ -28,7 +28,7 @@ spec_info:
   version: 0.3-DRAFT-2018_11_10
   version_date: 20181110T112249
   official_type: http://bioschemas.org/Taxon
-  full_example: https://github.com/BioSchemas/specifications/tree/master/Taxon/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/Taxon/examples/
 mapping:
 - property: additionalType
   expected_types:

--- a/_profiles/Taxon/0.3-RELEASE-2018_11_10.html
+++ b/_profiles/Taxon/0.3-RELEASE-2018_11_10.html
@@ -10,7 +10,7 @@ spec_type: Profile
 group: biodiversity
 use_cases_url: /useCases/Taxon/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1HHa0P6bvym1sZcO4GZMH01J_Cl06eXH60IVTp0b_Nas/edit?ts=5be44b29#gid=1483018794
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Taxon
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Taxon
 live_deploy: /liveDeploys/
 
 parent_type: Taxon
@@ -29,7 +29,7 @@ spec_info:
   version: 0.3-RELEASE-2018_11_10
   version_date: 20181110T112249
   official_type: http://bioschemas.org/Taxon
-  full_example: https://github.com/BioSchemas/specifications/tree/master/Taxon/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/Taxon/examples/
 mapping:
 - property: additionalType
   expected_types:

--- a/_profiles/Taxon/0.4-DRAFT-2019_06_19.html
+++ b/_profiles/Taxon/0.4-DRAFT-2019_06_19.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: biodiversity
 use_cases_url: /useCases/Taxon/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1f8ovXRF_T_y8CR1ThHgKkF9NjnpLkIoJ_UOlPQwD6DA
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Taxon
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Taxon
 live_deploy: /liveDeploys/
 
 parent_type: Taxon
@@ -30,7 +30,7 @@ spec_info:
   version: 0.4-DRAFT-2019_06_19
   version_date: 20190619T133527
   official_type: http://schema.org/Taxon
-  full_example: https://github.com/BioSchemas/specifications/tree/master/Taxon/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/Taxon/examples/
 mapping:
 - property: additionalType
   expected_types:

--- a/_profiles/Taxon/0.4-DRAFT-2019_06_24.html
+++ b/_profiles/Taxon/0.4-DRAFT-2019_06_24.html
@@ -10,7 +10,7 @@ spec_type: Profile
 group: biodiversity
 use_cases_url: /useCases/Taxon/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1f8ovXRF_T_y8CR1ThHgKkF9NjnpLkIoJ_UOlPQwD6DA
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Taxon
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Taxon
 live_deploy: /liveDeploys/
 
 parent_type: Taxon
@@ -31,7 +31,7 @@ spec_info:
   version: 0.4-DRAFT-2019_06_24
   version_date: 20190619T133527
   official_type: http://schema.org/Taxon
-  full_example: https://github.com/BioSchemas/specifications/tree/master/Taxon/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/Taxon/examples/
 mapping:
 - property: additionalType
   expected_types:

--- a/_profiles/Taxon/0.5-DRAFT-2020_04_06.html
+++ b/_profiles/Taxon/0.5-DRAFT-2020_04_06.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: biodiversity
 use_cases_url: /useCases/Taxon/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1KmjlWB8XvRa9YCSbj979qe3GSfUlY9rw551ZRbJyKfs/edit#gid=1483018794
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Taxon
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Taxon
 live_deploy: /liveDeploys/
 
 parent_type: Taxon
@@ -25,12 +25,12 @@ spec_info:
   description: 'This profile aims to denote a taxon by common properties such as its
     scientific name, taxonomic rank and vernacular names. It is also a means to link
     to existing taxonomic registers where each taxon has a URI. <br/><h4>Summary of Changes</h4>Changes in 0.5:
-    <ul><li>remove hasCategoryCode see <a href="https://github.com/BioSchemas/specifications/issues/408">issue
+    <ul><li>remove hasCategoryCode see <a href="https://github.com/Bioschemas/specifications/issues/408">issue
     408</a></li></ul>'
   version: 0.5-DRAFT-2020_04_06
   version_date: 20200406T214535
   official_type: http://schema.org/Taxon
-  full_example: https://github.com/BioSchemas/specifications/tree/master/Taxon/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/Taxon/examples/
 mapping:
 - property: additionalType
   expected_types:

--- a/_profiles/Taxon/0.6-RELEASE.html
+++ b/_profiles/Taxon/0.6-RELEASE.html
@@ -13,7 +13,7 @@ spec_type: Profile
 group: biodiversity
 use_cases_url: /useCases/Taxon/
 cross_walk_url: https://docs.google.com/spreadsheets/d/18aNmjLlMs7FItcozTZXdktKuZEap2sbqgqgksWQSkD0/edit#gid=1483018794
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Taxon
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Taxon
 live_deploy: /liveDeploys/
 
 parent_type: Taxon
@@ -40,7 +40,7 @@ spec_info:
   version: 0.6-RELEASE
   version_date: 20200407T163935
   official_type: http://schema.org/Taxon
-  full_example: https://github.com/BioSchemas/specifications/tree/master/Taxon/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/Taxon/examples/
 mapping:
 - property: additionalType
   expected_types:

--- a/_profiles/Taxon/0.7-DRAFT.html
+++ b/_profiles/Taxon/0.7-DRAFT.html
@@ -15,7 +15,7 @@ spec_type: Profile
 group: biodiversity
 use_cases_url: /useCases/Taxon/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1ZZxL6_9VvlDJCXMf_0JnIzyBHExxA6eFIiEDKr6gFqY/
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Taxon
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Taxon
 live_deploy: /liveDeploys/
 
 parent_type: Taxon
@@ -37,7 +37,7 @@ spec_info:
   version: 0.7-DRAFT
   version_date: 20200609T171320
   official_type: http://schema.org/Taxon
-  full_example: https://github.com/BioSchemas/specifications/tree/master/Taxon/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/Taxon/examples/
 mapping:
 - property: additionalType
   expected_types:

--- a/_profiles/TaxonName/0.1-DRAFT.html
+++ b/_profiles/TaxonName/0.1-DRAFT.html
@@ -12,7 +12,7 @@ spec_type: Profile
 group: biodiversity
 use_cases_url: /useCases/TaxonName/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1cQPR7KGU0fOHXiRoaJpahEgrX9i6SIc36X8cupfg6_4/
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Taxon
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Taxon
 live_deploy: /liveDeploys/
 
 parent_type: TaxonName
@@ -33,7 +33,7 @@ spec_info:
   version: 0.1-DRAFT
   version_date: 20200609T164927
   official_type: http://schema.org/TaxonName
-  full_example: https://github.com/BioSchemas/specifications/tree/master/TaxonName/0.1-DRAFT_examples
+  full_example: https://github.com/Bioschemas/specifications/tree/master/TaxonName/0.1-DRAFT_examples
 mapping:
 - property: additionalType
   expected_types:

--- a/_profiles/Tool/0.2-DRAFT-2018_08_21.html
+++ b/_profiles/Tool/0.2-DRAFT-2018_08_21.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: tools
 use_cases_url: ''
 cross_walk_url: https://docs.google.com/spreadsheets/d/1s342mMwfXAGl5uwgTCcwsVLQztxRIDwTi92zEouP33o/edit#gid=1063339077
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Tool
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Tool
 live_deploy: /liveDeploys/
 
 parent_type: SoftwareApplication
@@ -33,7 +33,7 @@ spec_info:
   version: 0.2-DRAFT-2018_08_21
   version_date: 20180821T104717
   official_type: http://semanticscience.org/resource/SIO_000097
-  full_example: https://github.com/BioSchemas/specifications/tree/master/Tool/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/Tool/examples/
 mapping:
 - property: alternateName
   expected_types:

--- a/_profiles/Tool/0.3-DRAFT-2018_11_21.html
+++ b/_profiles/Tool/0.3-DRAFT-2018_11_21.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: tools
 use_cases_url: ''
 cross_walk_url: https://docs.google.com/spreadsheets/d/1kogQ4tLMbhnM-B8IKtFNmMenRgqopi76wGKCCyAqUXM
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Tool
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Tool
 live_deploy: /liveDeploys/
 
 parent_type: SoftwareApplication
@@ -33,7 +33,7 @@ spec_info:
   version: 0.3-DRAFT-2018_11_21
   version_date: 20181121T214754
   official_type: http://schema.org/SoftwareApplication
-  full_example: https://github.com/BioSchemas/specifications/tree/master/Tool/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/Tool/examples/
 mapping:
 - property: additionalType
   expected_types:

--- a/_profiles/Tool/0.3-DRAFT-2019_07_18.html
+++ b/_profiles/Tool/0.3-DRAFT-2019_07_18.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: tools
 use_cases_url: ''
 cross_walk_url: https://docs.google.com/spreadsheets/d/1kogQ4tLMbhnM-B8IKtFNmMenRgqopi76wGKCCyAqUXM/edit#gid=1483018794
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Tool
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Tool
 live_deploy: /liveDeploys/
 
 parent_type: SoftwareApplication
@@ -33,7 +33,7 @@ spec_info:
   version: 0.3-DRAFT-2019_07_18
   version_date: 20190718T171129
   official_type: http://schema.org/SoftwareApplication
-  full_example: https://github.com/BioSchemas/specifications/tree/master/Tool/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/Tool/examples/
 mapping:
 - property: additionalType
   expected_types:

--- a/_profiles/Tool/0.4-DRAFT-2019_07_19.html
+++ b/_profiles/Tool/0.4-DRAFT-2019_07_19.html
@@ -16,7 +16,7 @@ spec_type: Profile
 group: tools
 use_cases_url: ''
 cross_walk_url: https://docs.google.com/spreadsheets/d/1kogQ4tLMbhnM-B8IKtFNmMenRgqopi76wGKCCyAqUXM
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Tool
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Tool
 live_deploy: /liveDeploys/
 
 parent_type: SoftwareApplication
@@ -40,7 +40,7 @@ spec_info:
   version: 0.4-DRAFT-2019_07_19
   version_date: 20190719T132121
   official_type: http://schema.org/SoftwareApplication
-  full_example: https://github.com/BioSchemas/specifications/tree/master/Tool/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/Tool/examples/
 mapping:
 - property: additionalType
   expected_types:

--- a/_profiles/TrainingMaterial/0.2-DRAFT-2018_03_07.html
+++ b/_profiles/TrainingMaterial/0.2-DRAFT-2018_03_07.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: training
 use_cases_url: /useCases/TrainingMaterials/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1cQ6mDbsG_cMX2EDAN8xH6-9yMRba8-rErlPeP8HTs8A
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Training%20material
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Training%20material
 live_deploy: ''
 
 parent_type: CreativeWork
@@ -31,7 +31,7 @@ spec_info:
   version: 0.2-DRAFT-2018_03_07
   version_date: 20180307T144349
   official_type: ""
-  full_example: "https://github.com/BioSchemas/specifications/tree/master/TrainingMaterial/examples/"
+  full_example: "https://github.com/Bioschemas/specifications/tree/master/TrainingMaterial/examples/"
 mapping:
 - property: about
   expected_types:

--- a/_profiles/TrainingMaterial/0.4-DRAFT-2018_11_16.html
+++ b/_profiles/TrainingMaterial/0.4-DRAFT-2018_11_16.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: training
 use_cases_url: /useCases/TrainingMaterials/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1cQ6mDbsG_cMX2EDAN8xH6-9yMRba8-rErlPeP8HTs8A
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Training%20material
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Training%20material
 live_deploy: ''
 
 parent_type: CreativeWork
@@ -26,7 +26,7 @@ spec_info:
   version: 0.4-DRAFT-2018_11_16
   version_date: 20181116T103334
   official_type: ""
-  full_example: https://github.com/BioSchemas/specifications/tree/master/TrainingMaterial/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/TrainingMaterial/examples/
 mapping:
 - property: about
   expected_types:

--- a/_profiles/TrainingMaterial/0.4-DRAFT-2019_02_08.html
+++ b/_profiles/TrainingMaterial/0.4-DRAFT-2019_02_08.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: training
 use_cases_url: /useCases/TrainingMaterials/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1cQ6mDbsG_cMX2EDAN8xH6-9yMRba8-rErlPeP8HTs8A
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Training%20material
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Training%20material
 live_deploy: ''
 
 parent_type: CreativeWork
@@ -31,7 +31,7 @@ spec_info:
   version: 0.4-DRAFT-2019_02_08
   version_date: 20190208T145314
   official_type: ""
-  full_example: https://github.com/BioSchemas/specifications/tree/master/TrainingMaterial/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/TrainingMaterial/examples/
 mapping:
 - property: about
   expected_types:

--- a/_profiles/TrainingMaterial/0.5-DRAFT-2019_02_25.html
+++ b/_profiles/TrainingMaterial/0.5-DRAFT-2019_02_25.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: training
 use_cases_url: /useCases/TrainingMaterial/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1cQ6mDbsG_cMX2EDAN8xH6-9yMRba8-rErlPeP8HTs8A
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Training%20material
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Training%20material
 live_deploy: ''
 
 parent_type: CreativeWork
@@ -31,7 +31,7 @@ spec_info:
   version: 0.5-DRAFT-2019_02_25
   version_date: 20190225T153505
   official_type: ""
-  full_example: https://github.com/BioSchemas/specifications/tree/master/TrainingMaterial/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/TrainingMaterial/examples/
 mapping:
 - property: about
   expected_types:

--- a/_profiles/TrainingMaterial/0.6-DRAFT-2019_06_06.html
+++ b/_profiles/TrainingMaterial/0.6-DRAFT-2019_06_06.html
@@ -9,7 +9,7 @@ spec_type: Profile
 group: training
 use_cases_url: /useCases/TrainingMaterial/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1wgpkliR8S6hoxIRtKTogPtFcLAeGWiUn7FhoViMAxng
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Training%20material
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Training%20material
 live_deploy: ''
 
 parent_type: CreativeWork
@@ -31,7 +31,7 @@ spec_info:
   version: 0.6-DRAFT-2019_06_06
   version_date: 20190606T160643
   official_type: ""
-  full_example: https://github.com/BioSchemas/specifications/tree/master/TrainingMaterial/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/TrainingMaterial/examples/
 mapping:
 - property: about
   expected_types:

--- a/_profiles/TrainingMaterial/0.7-DRAFT-2019_11_08.html
+++ b/_profiles/TrainingMaterial/0.7-DRAFT-2019_11_08.html
@@ -16,7 +16,7 @@ spec_type: Profile
 group: training
 use_cases_url: /useCases/TrainingMaterial/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1wgpkliR8S6hoxIRtKTogPtFcLAeGWiUn7FhoViMAxng
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20Training%20material
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Training%20material
 live_deploy: ''
 
 parent_type: CreativeWork
@@ -38,7 +38,7 @@ spec_info:
   version: "0.7-DRAFT-2019_11_08"
   version_date: 20191108T153609
   official_type: ""
-  full_example: https://github.com/BioSchemas/specifications/tree/master/TrainingMaterial/examples/
+  full_example: https://github.com/Bioschemas/specifications/tree/master/TrainingMaterial/examples/
 mapping:
 - property: about
   expected_types:

--- a/_stories/toxTutTeSS.html
+++ b/_stories/toxTutTeSS.html
@@ -6,5 +6,5 @@ specs:
   - Event
   - TrainingMaterial
 external-url: https://www.dtls.nl/2018/07/19/toxicology-data-management-tutorials-automatically-collected-by-european-training-portal-tess/
-description: BioSchemas used to create a system that automatically pulls toxicology-related training materials from the eNanoMapper project into the European training portal TeSS.
+description: Bioschemas used to create a system that automatically pulls toxicology-related training materials from the eNanoMapper project into the European training portal TeSS.
 ---

--- a/_types/BioChemEntity/0.5-RELEASE-2018_03_01.html
+++ b/_types/BioChemEntity/0.5-RELEASE-2018_03_01.html
@@ -10,7 +10,7 @@ description: A BioChemEntity is any object that exists in the physical world and
   BioChemEntity is a flexible and extensible wrapper for Life Sciences entities.
 hierarchy:
 - Thing
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20BioChemEntity
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20BioChemEntity
 group: biologicalentities
 name: BioChemEntity
 parent_type: Thing

--- a/_types/BioChemEntity/0.6-RELEASE-2018_11_09.html
+++ b/_types/BioChemEntity/0.6-RELEASE-2018_11_09.html
@@ -6,7 +6,7 @@ dateModified: 2018-11-09
 description: "Any biological, chemical, or biochemical thing. For example: a protein; a gene; a chemical; a synthetic chemical."
 hierarchy:
 - Thing
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20BioChemEntity
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20BioChemEntity
 group: biologicalentities
 name: BioChemEntity
 parent_type: Thing

--- a/_types/BioChemEntity/0.6-RELEASE-2018_11_10.html
+++ b/_types/BioChemEntity/0.6-RELEASE-2018_11_10.html
@@ -6,7 +6,7 @@ dateModified: 2018-11-10
 description: "Any biological, chemical, or biochemical thing. For example: a protein; a gene; a chemical; a synthetic chemical."
 hierarchy:
 - Thing
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20BioChemEntity
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20BioChemEntity
 group: biologicalentities
 name: BioChemEntity
 parent_type: Thing

--- a/_types/BioChemEntity/0.7-DRAFT-2019_06_14.html
+++ b/_types/BioChemEntity/0.7-DRAFT-2019_06_14.html
@@ -6,7 +6,7 @@ dateModified: 2019-06-14
 description: "Any biological, chemical, or biochemical thing. For example: a protein; a gene; a chemical; a synthetic chemical."
 hierarchy:
 - Thing
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20BioChemEntity
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20BioChemEntity
 group: biologicalentities
 name: BioChemEntity
 parent_type: Thing

--- a/_types/BioChemEntity/0.7-RELEASE-2019_06_19.html
+++ b/_types/BioChemEntity/0.7-RELEASE-2019_06_19.html
@@ -14,7 +14,7 @@ dateModified: 2019-06-14
 description: "Any biological, chemical, or biochemical thing. For example: a protein; a gene; a chemical; a synthetic chemical."
 hierarchy:
 - Thing
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20BioChemEntity
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20BioChemEntity
 group: biologicalentities
 name: BioChemEntity
 parent_type: Thing

--- a/_types/BioChemStructure/0.1-DRAFT-2019_06_20.html
+++ b/_types/BioChemStructure/0.1-DRAFT-2019_06_20.html
@@ -11,7 +11,7 @@ description: WwPDB and related data including modelled and hypothetical data. As
 hierarchy:
 - Thing
 - BioChemEntity
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20BioChemStructure
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20BioChemStructure
 group: chemicals
 name: BioChemStructure
 parent_type: BioChemEntity

--- a/_types/BioSample/0.1-DRAFT-2019_06_14.html
+++ b/_types/BioSample/0.1-DRAFT-2019_06_14.html
@@ -7,7 +7,7 @@ description: "A biological material entity that is representative of a whole. <b
 hierarchy:
 - Thing
 - BioChemEntity
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Sample
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Sample
 group: samples
 name: BioSample
 parent_type: BioChemEntity

--- a/_types/BioSample/0.1-RELEASE-2019_06_19.html
+++ b/_types/BioSample/0.1-RELEASE-2019_06_19.html
@@ -15,7 +15,7 @@ description: "A biological material entity that is representative of a whole. <b
 hierarchy:
 - Thing
 - BioChemEntity
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Sample
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Sample
 group: samples
 name: BioSample
 parent_type: BioChemEntity

--- a/_types/ChemicalSubstance/0.2-DRAFT-2019_06_14.html
+++ b/_types/ChemicalSubstance/0.2-DRAFT-2019_06_14.html
@@ -7,7 +7,7 @@ description: "A chemical substance."
 hierarchy:
 - Thing
 - BioChemEntity
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Chemicals
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Chemicals
 group: chemicals
 name: ChemicalSubstance
 parent_type: BioChemEntity

--- a/_types/ChemicalSubstance/0.2-RELEASE-2019_06_19.html
+++ b/_types/ChemicalSubstance/0.2-RELEASE-2019_06_19.html
@@ -8,7 +8,7 @@ description: "A chemical substance."
 hierarchy:
 - Thing
 - BioChemEntity
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Chemicals
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Chemicals
 group: chemicals
 name: ChemicalSubstance
 parent_type: BioChemEntity

--- a/_types/ChemicalSubstance/0.3-RELEASE-2019_09_02.html
+++ b/_types/ChemicalSubstance/0.3-RELEASE-2019_09_02.html
@@ -16,7 +16,7 @@ description: "A chemical substance is 'a portion of matter of constant compositi
 hierarchy:
 - Thing
 - BioChemEntity
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Chemicals
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Chemicals
 group: chemicals
 name: ChemicalSubstance
 parent_type: BioChemEntity

--- a/_types/ComputationalWorkflow/0.1-DRAFT-2020_07_21.html
+++ b/_types/ComputationalWorkflow/0.1-DRAFT-2020_07_21.html
@@ -20,7 +20,7 @@ hierarchy:
 - Thing
 - CreativeWork
 - SoftwareSourceCode
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Workflow
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Workflow
 group: workflow
 name: ComputationalWorkflow
 parent_type: SoftwareSourceCode

--- a/_types/DNA/0.1-DRAFT-2018_11_13.html
+++ b/_types/DNA/0.1-DRAFT-2018_11_13.html
@@ -7,7 +7,7 @@ description: "DNA"
 hierarchy:
 - Thing
 - BioChemEntity
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20DNA
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20DNA
 group: dna
 name: DNA
 parent_type: BioChemEntity

--- a/_types/DNA/0.2-DRAFT-2019_06_20.html
+++ b/_types/DNA/0.2-DRAFT-2019_06_20.html
@@ -14,7 +14,7 @@ description: "DNA"
 hierarchy:
 - Thing
 - BioChemEntity
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20DNA
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20DNA
 group: dna
 name: DNA
 parent_type: BioChemEntity

--- a/_types/DataRecord/0.1-DRAFT-2018_02_25.html
+++ b/_types/DataRecord/0.1-DRAFT-2018_02_25.html
@@ -9,7 +9,7 @@ description: "A Record acts itself as a dataset although it refers to what could
   seen as the minimum compact, complete and auto-descriptive unit in a dataset, i.e.,
   a record.\n\nBioschemas usage\n\nIn Life Sciences, records will represent a BioChemEntity."
 gh_examples: ''
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20DataRecord
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20DataRecord
 group: data
 hierarchy:
 - Thing

--- a/_types/DataRecord/0.2-DRAFT-2018_11_06.html
+++ b/_types/DataRecord/0.2-DRAFT-2018_11_06.html
@@ -5,7 +5,7 @@ previous_release:
 
 dateModified: 2018-11-06
 description: "A DataRecord acts itself as a dataset although it refers to what could be seen as the minimum compact, complete and auto-descriptive unit in a dataset."
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20DataRecord
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20DataRecord
 group: data
 hierarchy:
 - Thing

--- a/_types/DataRecord/0.3-DRAFT-2019_06_20.html
+++ b/_types/DataRecord/0.3-DRAFT-2019_06_20.html
@@ -11,7 +11,7 @@ previous_release:
 
 dateModified: 2019-06-20
 description: "A DataRecord is a part of a Dataset. Not all datasets naturally fall into parts, and some kinds of datasets (eg. relational and tabular) can be mapped into different senses of \"data record\". Although data records can themselves be viewed as datasets, for simplicity we do not declare this explicitly; if this perspective is needed it can be added using multiple typing."
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20DataRecord
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20DataRecord
 group: data
 hierarchy:
 - Thing

--- a/_types/Enzyme/0.1-DRAFT-2019_06_20.html
+++ b/_types/Enzyme/0.1-DRAFT-2019_06_20.html
@@ -14,7 +14,7 @@ description:
 hierarchy:
 - Thing
 - BioChemEntity
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Enzyme
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Enzyme
 group: proteins
 name: Enzyme
 parent_type: BioChemEntity

--- a/_types/FormalParameter/0.1-DRAFT-2020_07_21.html
+++ b/_types/FormalParameter/0.1-DRAFT-2020_07_21.html
@@ -14,7 +14,7 @@ description: "A FormalParameter is an identified variable used to stand for the 
 hierarchy:
 - Thing
 - Intangible
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Workflow
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Workflow
 group: workflow
 name: FormalParameter
 parent_type: Intangible

--- a/_types/Gene/0.1-RELEASE-2018_11_09.html
+++ b/_types/Gene/0.1-RELEASE-2018_11_09.html
@@ -7,7 +7,7 @@ description: "A gene."
 hierarchy:
 - Thing
 - BioChemEntity
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Gene
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Gene
 group: genes
 name: Gene
 parent_type: BioChemEntity

--- a/_types/Gene/0.1-RELEASE-2018_11_10.html
+++ b/_types/Gene/0.1-RELEASE-2018_11_10.html
@@ -7,7 +7,7 @@ description: "A gene."
 hierarchy:
 - Thing
 - BioChemEntity
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Gene
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Gene
 group: genes
 name: Gene
 parent_type: BioChemEntity

--- a/_types/Gene/0.2-DRAFT-2019_06_14.html
+++ b/_types/Gene/0.2-DRAFT-2019_06_14.html
@@ -7,7 +7,7 @@ description: "A discrete unit of inheritance which affects one or more biologica
 hierarchy:
 - Thing
 - BioChemEntity
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Gene
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Gene
 group: genes
 name: Gene
 parent_type: BioChemEntity

--- a/_types/Gene/0.2-RELEASE-2019_06_19.html
+++ b/_types/Gene/0.2-RELEASE-2019_06_19.html
@@ -7,7 +7,7 @@ description: "A discrete unit of inheritance which affects one or more biologica
 hierarchy:
 - Thing
 - BioChemEntity
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Gene
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Gene
 group: genes
 name: Gene
 parent_type: BioChemEntity

--- a/_types/Gene/0.3-RELEASE-2019_09_02.html
+++ b/_types/Gene/0.3-RELEASE-2019_09_02.html
@@ -15,7 +15,7 @@ description: "A discrete unit of inheritance which affects one or more biologica
 hierarchy:
 - Thing
 - BioChemEntity
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Gene
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Gene
 group: genes
 name: Gene
 parent_type: BioChemEntity

--- a/_types/LabProtocol/0.2-DRAFT-2018_03_09.html
+++ b/_types/LabProtocol/0.2-DRAFT-2018_03_09.html
@@ -9,7 +9,7 @@ Experimental protocols are fundamental information structures that support the d
 <br />
 [1]  Giraldo, O., García, A., López, F., & Corcho, O. (2017). Using semantics for representing experimental protocols. Journal of Biomedical Semantics, 8, 52. <a href="http://doi.org/10.1186/s13326-017-0160-y">http://doi.org/10.1186/s13326-017-0160-y</a>'
 gh_examples: https://docs.google.com/document/d/16KlB9fE2s-USAf0Vo9cTbh_wKEc0BmSxCgQmKQXKLQ8/
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20LabProtocol
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20LabProtocol
 group: labprotocols
 hierarchy:
 - Thing

--- a/_types/LabProtocol/0.3-DRAFT-2019_06_20.html
+++ b/_types/LabProtocol/0.3-DRAFT-2019_06_20.html
@@ -14,7 +14,7 @@ cross_walk_url: https://docs.google.com/spreadsheets/d/1RWYIphvcBMHl8SLJl5-xRMZI
 dateModified: 2019-06-20
 description: 'An experimental protocol is a sequence of tasks and operations executed to perform experimental research in biological and biomedical areas.'
 gh_examples: https://docs.google.com/document/d/16KlB9fE2s-USAf0Vo9cTbh_wKEc0BmSxCgQmKQXKLQ8/
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20LabProtocol
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20LabProtocol
 group: labprotocols
 hierarchy:
 - Thing

--- a/_types/MolecularEntity/0.2-DRAFT-2019_06_14.html
+++ b/_types/MolecularEntity/0.2-DRAFT-2019_06_14.html
@@ -7,7 +7,7 @@ description: "Any constitutionally or isotopically distinct atom, molecule, ion,
 hierarchy:
 - Thing
 - BioChemEntity
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Chemicals
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Chemicals
 group: chemicals
 name: MolecularEntity
 parent_type: BioChemEntity

--- a/_types/MolecularEntity/0.2-RELEASE-2019_06_23.html
+++ b/_types/MolecularEntity/0.2-RELEASE-2019_06_23.html
@@ -7,7 +7,7 @@ description: "Any constitutionally or isotopically distinct atom, molecule, ion,
 hierarchy:
 - Thing
 - BioChemEntity
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Chemicals
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Chemicals
 group: chemicals
 name: MolecularEntity
 parent_type: BioChemEntity

--- a/_types/MolecularEntity/0.3-RELEASE-2019_09_02.html
+++ b/_types/MolecularEntity/0.3-RELEASE-2019_09_02.html
@@ -15,7 +15,7 @@ description: "Any constitutionally or isotopically distinct atom, molecule, ion,
 hierarchy:
 - Thing
 - BioChemEntity
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Chemicals
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Chemicals
 group: chemicals
 name: MolecularEntity
 parent_type: BioChemEntity

--- a/_types/Phenotype/0.1-DRAFT-2018_11_14.html
+++ b/_types/Phenotype/0.1-DRAFT-2018_11_14.html
@@ -7,7 +7,7 @@ dateModified: 2018-11-14
 description: "A phenotype."
 hierarchy:
 - Thing
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Phenotypes
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Phenotypes
 group: phenotypes
 name: Phenotype
 parent_type: Thing

--- a/_types/Phenotype/0.2-DRAFT-2019_06_21.html
+++ b/_types/Phenotype/0.2-DRAFT-2019_06_21.html
@@ -14,7 +14,7 @@ dateModified: 2019-06-21
 description: "A phenotype."
 hierarchy:
 - Thing
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Phenotypes
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Phenotypes
 group: phenotypes
 name: Phenotype
 parent_type: Thing

--- a/_types/Phenotype/0.3-DRAFT-2020_06_07.html
+++ b/_types/Phenotype/0.3-DRAFT-2020_06_07.html
@@ -14,7 +14,7 @@ dateModified: 2020-06-07
 description: "A phenotype."
 hierarchy:
 - Thing
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Phenotypes
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Phenotypes
 group: phenotypes
 name: Phenotype
 parent_type: Thing

--- a/_types/Protein/0.1-RELEASE-2018_11_09.html
+++ b/_types/Protein/0.1-RELEASE-2018_11_09.html
@@ -8,7 +8,7 @@ description: "A protein or a computationally generated protein annotation."
 hierarchy:
 - Thing
 - BioChemEntity
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Protein
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Protein
 group: proteins
 name: Protein
 parent_type: BioChemEntity

--- a/_types/Protein/0.1-RELEASE-2018_11_10.html
+++ b/_types/Protein/0.1-RELEASE-2018_11_10.html
@@ -7,7 +7,7 @@ description: "A protein or a computationally generated protein annotation."
 hierarchy:
 - Thing
 - BioChemEntity
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Protein
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Protein
 group: proteins
 name: Protein
 parent_type: BioChemEntity

--- a/_types/Protein/0.2-DRAFT-2019_06_14.html
+++ b/_types/Protein/0.2-DRAFT-2019_06_14.html
@@ -7,7 +7,7 @@ description: "Protein is here used in its widest possible definition, as classes
 hierarchy:
 - Thing
 - BioChemEntity
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Protein
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Protein
 group: proteins
 name: Protein
 parent_type: BioChemEntity

--- a/_types/Protein/0.2-RELEASE-2019_06_19.html
+++ b/_types/Protein/0.2-RELEASE-2019_06_19.html
@@ -7,7 +7,7 @@ description: "Protein is here used in its widest possible definition, as classes
 hierarchy:
 - Thing
 - BioChemEntity
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Protein
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Protein
 group: proteins
 name: Protein
 parent_type: BioChemEntity

--- a/_types/Protein/0.3-RELEASE-2019_09_02.html
+++ b/_types/Protein/0.3-RELEASE-2019_09_02.html
@@ -15,7 +15,7 @@ description: "Protein is here used in its widest possible definition, as classes
 hierarchy:
 - Thing
 - BioChemEntity
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Protein
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Protein
 group: proteins
 name: Protein
 parent_type: BioChemEntity

--- a/_types/RNA/0.1-DRAFT-2019_06_21.html
+++ b/_types/RNA/0.1-DRAFT-2019_06_21.html
@@ -15,7 +15,7 @@ description: "RNA"
 hierarchy:
 - Thing
 - BioChemEntity
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20RNA
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20RNA
 group: dna
 name: RNA
 parent_type: BioChemEntity

--- a/_types/Sample/0.1-DRAFT-2018_11_06.html
+++ b/_types/Sample/0.1-DRAFT-2018_11_06.html
@@ -7,7 +7,7 @@ dateModified: 2018-11-06
 description: " A material entity that is a portion of a whole, and intended to be representative of the whole. Examples of samples include biomedical samples (blood, urine), commercial samples (carpet, metal)."
 hierarchy:
 - Thing
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Sample
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Sample
 group: samples
 name: Sample
 parent_type: Thing

--- a/_types/Sample/0.1-DRAFT-2018_11_07.html
+++ b/_types/Sample/0.1-DRAFT-2018_11_07.html
@@ -7,7 +7,7 @@ dateModified: 2018-11-06
 description: "A material entity that is a portion of a whole. <p>Comments: Typically samples are intended to be representative of the whole or aspects thereof. Examples of samples include biomedical samples (blood, urine) and commercial samples (carpet, metal).</p>"
 hierarchy:
 - Thing
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Sample
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Sample
 group: samples
 name: Sample
 parent_type: Thing

--- a/_types/Sample/0.2-DRAFT-2018_11_09.html
+++ b/_types/Sample/0.2-DRAFT-2018_11_09.html
@@ -13,7 +13,7 @@ dateModified: 2018-11-09
 description: "A material entity that is representative of a whole. <p>Comments: Typically samples are intended to be representative of the whole or aspects thereof. Examples of samples include biomedical samples (blood, urine) and commercial samples (carpet, metal).</p>"
 hierarchy:
 - Thing
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Sample
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Sample
 group: samples
 name: Sample
 parent_type: Thing

--- a/_types/SequenceAnnotation/0.1-DRAFT-2019_06_21.html
+++ b/_types/SequenceAnnotation/0.1-DRAFT-2019_06_21.html
@@ -11,7 +11,7 @@ description:
 hierarchy:
 - Thing
 - BioChemEntity
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20SequenceAnnotation
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20SequenceAnnotation
 group: proteins
 name: SequenceAnnotation
 parent_type: BioChemEntity

--- a/_types/SequenceMatchingModel/0.1-DRAFT-2019_06_21.html
+++ b/_types/SequenceMatchingModel/0.1-DRAFT-2019_06_21.html
@@ -13,7 +13,7 @@ previous_release:
 dateModified: 2019-06-21
 description: 'A model used to determine sequence matches such as domains in proteins.'
 gh_examples:
-gh_tasks: https://github.com/BioSchemas/bioschemas/labels/type%3A%20SequenceMatchingModel
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20SequenceMatchingModel
 group: proteins
 hierarchy:
 - Thing

--- a/_types/SequenceRange/0.1-DRAFT-2019_06_21.html
+++ b/_types/SequenceRange/0.1-DRAFT-2019_06_21.html
@@ -12,7 +12,7 @@ description:
 hierarchy:
 - Thing
 - BioChemEntity
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20SequenceRange
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20SequenceRange
 group: proteins
 name: SequenceRange
 parent_type: BioChemEntity

--- a/_types/Study/0.1-DRAFT-2018_11_13.html
+++ b/_types/Study/0.1-DRAFT-2018_11_13.html
@@ -7,7 +7,7 @@ dateModified: 2018-11-13
 description: "Study"
 hierarchy:
 - Thing
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Study
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Study
 group: studies
 name: Study
 parent_type: Thing

--- a/_types/Study/0.2-DRAFT-2019_06_21.html
+++ b/_types/Study/0.2-DRAFT-2019_06_21.html
@@ -14,7 +14,7 @@ description: "Study"
 hierarchy:
 - Thing
 - CreativeWork
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Study
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Study
 group: studies
 name: Study
 parent_type: CreativeWork

--- a/_types/Taxon/0.1-RELEASE-2018_11_09.html
+++ b/_types/Taxon/0.1-RELEASE-2018_11_09.html
@@ -8,7 +8,7 @@ dateModified: 2018-11-09
 description: "A set of organisms asserted to represent a natural cohesive biological unit."
 hierarchy:
 - Thing
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Taxon
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Taxon
 group: biodiversity
 name: Taxon
 parent_type: Thing

--- a/_types/Taxon/0.3-DRAFT-2019_11_14.html
+++ b/_types/Taxon/0.3-DRAFT-2019_11_14.html
@@ -7,7 +7,7 @@ dateModified: 2019-06-14
 description: "A set of organisms asserted to represent a natural cohesive biological unit."
 hierarchy:
 - Thing
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Taxon
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Taxon
 group: biodiversity
 name: Taxon
 parent_type: Thing

--- a/_types/Taxon/0.3-RELEASE-2019_11_18.html
+++ b/_types/Taxon/0.3-RELEASE-2019_11_18.html
@@ -15,7 +15,7 @@ dateModified: 2019-06-14
 description: "A set of organisms asserted to represent a natural cohesive biological unit."
 hierarchy:
 - Thing
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Taxon
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Taxon
 group: biodiversity
 name: Taxon
 parent_type: Thing

--- a/_types/Taxon/0.4-DRAFT.html
+++ b/_types/Taxon/0.4-DRAFT.html
@@ -10,7 +10,7 @@ dateModified: 2020-06-09
 description: "A set of organisms asserted to represent a natural cohesive biological unit."
 hierarchy:
 - Thing
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Taxon
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Taxon
 group: biodiversity
 name: Taxon
 parent_type: Thing

--- a/_types/TaxonName/0.1-DRAFT.html
+++ b/_types/TaxonName/0.1-DRAFT.html
@@ -14,7 +14,7 @@ description: A name of a biological taxon, may it be valid (zoology) / accepted 
 hierarchy:
 - Thing
 - CreativeWork
-gh_tasks: https://github.com/BioSchemas/specifications/labels/type%3A%20Taxon
+gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Taxon
 group: biodiversity
 name: TaxonName
 parent_type: CreativeWork

--- a/_useCases/Sample.html
+++ b/_useCases/Sample.html
@@ -55,9 +55,9 @@ redirect_from: useCases/Samples/
                       <p>
                           In those cases where a single sample entity is not exposable, like the BioBank Directory use case defined 
                           during the sample hackathon (meeting notes <a href="https://docs.google.com/document/d/1xKFFLXcc6Db5wSuifOETpQSIFd73GLL2__2BNK9d4tk/edit#heading=h.aqwqtawny32k">here</a>),
-                          you should probably use a different BioSchemas profile/entity, like the DataCatalog or the DataRecord. You can find more examples on how BBMRI-ERIC directory used
-                          BioSchemas for their need in this <a href="https://github.com/BioSchemas/specifications/blob/master/DataCatalog/examples/bbmri-eric-ID-CZ_MMCI_jsonld.json">DataCatalog</a> and 
-                          <a href="https://github.com/BioSchemas/specifications/blob/master/DataRecord/examples/bbmri-eric-ID-CZ_MMCI-collection-LTS_jsonld.json">DataRecord</a> examples.
+                          you should probably use a different Bioschemas profile/entity, like the DataCatalog or the DataRecord. You can find more examples on how BBMRI-ERIC directory used
+                          Bioschemas for their need in this <a href="https://github.com/Bioschemas/specifications/blob/master/DataCatalog/examples/bbmri-eric-ID-CZ_MMCI_jsonld.json">DataCatalog</a> and 
+                          <a href="https://github.com/Bioschemas/specifications/blob/master/DataRecord/examples/bbmri-eric-ID-CZ_MMCI-collection-LTS_jsonld.json">DataRecord</a> examples.
                       </p>
 
                </section>

--- a/community/governance.html
+++ b/community/governance.html
@@ -1,5 +1,5 @@
 ---
 layout: default
 title: Governance
-redirect_to: https://github.com/BioSchemas/governance/blob/master/governance.md
+redirect_to: https://github.com/Bioschemas/governance/blob/master/governance.md
 ---

--- a/community/index.html
+++ b/community/index.html
@@ -6,7 +6,7 @@ title: Community
 <div class="outer" itemscope itemtype="http://schema.org/Organization">
     <meta itemprop="logo" content="http://bioschemas.org/images/square_logo2.png"/>
     <meta itemprop="url" content="http://bioschemas.org"/>
-    <meta itemprop="name" content="BioSchemas Community"/>
+    <meta itemprop="name" content="Bioschemas Community"/>
     <meta itemprop="email" content="enquiries@bioschemas.org"/>
 
     <h1>Community</h1>
@@ -18,9 +18,9 @@ title: Community
 
     <p>We encourage everyone to embed markup within the web pages about their resource, following the relevant <a href="/profiles/">profile</a>. Further guidance can be found in the <a href="https://bioschemas.gitbook.io/training-portal/">getting started tutorial</a>. If you do embed markup in your resource, please let us know so that we can add you to the <a href="/liveDeploys/">live deployments</a> page.</p>
 
-    <p>Profiles are developed through discussion and consensus in <a href="/groups/">Working Groups</a>, each with a dedicated focus area. Discussions take place through the <a href="http://lists.w3.org/Archives/Public/public-bioschemas/">mailing list</a>, <a href="https://github.com/BioSchemas/specifications/issues/">GitHub issues</a>, and <a href="https://join.slack.com/t/bioschemas/shared_invite/zt-58y30ewj-Ix2_s6nNLXrhHl51TtDXig">slack</a>. Please reach out to the relevant working group leads if you want to help further enhance a particular profile.</p>
+    <p>Profiles are developed through discussion and consensus in <a href="/groups/">Working Groups</a>, each with a dedicated focus area. Discussions take place through the <a href="http://lists.w3.org/Archives/Public/public-bioschemas/">mailing list</a>, <a href="https://github.com/Bioschemas/specifications/issues/">GitHub issues</a>, and <a href="https://join.slack.com/t/bioschemas/shared_invite/zt-58y30ewj-Ix2_s6nNLXrhHl51TtDXig">slack</a>. Please reach out to the relevant working group leads if you want to help further enhance a particular profile.</p>
 
-    <p>The Bioschemas Community adheres to the 5 core principles of <a href="https://open-stand.org/">OpenStand</a> (<a href="https://open-stand.org/infographic-the-5-core-principles-of-openstand/">infographic</a>). For more information on our governance approach, please see the community's <a href="https://github.com/BioSchemas/governance/blob/master/governance.md">Governance Document</a>. All interactions with regard to Bioschemas, either online or in-person, are covered by our <a href="https://github.com/BioSchemas/governance/blob/master/codeOfConduct.md">Code of Conduct</a>.
+    <p>The Bioschemas Community adheres to the 5 core principles of <a href="https://open-stand.org/">OpenStand</a> (<a href="https://open-stand.org/infographic-the-5-core-principles-of-openstand/">infographic</a>). For more information on our governance approach, please see the community's <a href="https://github.com/Bioschemas/governance/blob/master/governance.md">Governance Document</a>. All interactions with regard to Bioschemas, either online or in-person, are covered by our <a href="https://github.com/Bioschemas/governance/blob/master/codeOfConduct.md">Code of Conduct</a>.
 
     <h2 id="leadership">Steering Council</h2>
     <p>The Bioschemas Steering Council is responsible for strategic and organisational planning, high-level oversight of community activities, including the approval and monitoring of profiles, types, and working groups, and promoting Bioschemas activities, as well as protecting its public image and reputation. The Bioschemas Steeting Council currently consists of the following members:</p>

--- a/groups/index.html
+++ b/groups/index.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: BioSchemas Groups
+title: Bioschemas Groups
 ---
 
 <h1>Bioschemas Groups 

--- a/howtojoin/index.html
+++ b/howtojoin/index.html
@@ -11,7 +11,7 @@ title: How To Join
     <p><span itemprop="name">Bioschemas</span> is an open community and welcomes any organization or individual to join this community effort. If you want to be involved in Bioschemas, please
       <ul>
         <li><a href="mailto:public-bioschemas-request@w3.org?subject=subscribe">Subscribe</a> to the mailing list <i class="fas fa-envelope"></i></li>
-        <li>Get involved in discussions on <a href="https://github.com/BioSchemas/specifications/issues">GitHub</a> <i class="fab fa-github"></i></li>
+        <li>Get involved in discussions on <a href="https://github.com/Bioschemas/specifications/issues">GitHub</a> <i class="fab fa-github"></i></li>
         <!-- <li>Join our <a href="https://join.slack.com/t/bioschemas/shared_invite/enQtNDExMjk1OTg3MzE1LTQ2OWNjZGEwMGZjNjZhNGJjNmRlMTE5ZTI0NGViMjlhNmM5MzVmMmI1YWY1NGQ1M2I3MTAxY2JlNjQ4ZDc3MmI">Slack workspace</a> <i class="fab fa-slack"></i></li> -->
       </ul>
     </p>
@@ -35,9 +35,9 @@ title: How To Join
 
     <h2>GitHub</h2>
 
-    <p>We use <a href="https://github.com/BioSchemas/">GitHub</a> to collaboratively develop new specifications, and tools to support the Bioschemas community. There are several project specific repositories as well as:</p>
+    <p>We use <a href="https://github.com/Bioschemas/">GitHub</a> to collaboratively develop new specifications, and tools to support the Bioschemas community. There are several project specific repositories as well as:</p>
     <ul>
-      <li><a href="https://github.com/BioSchemas/bioschemas">Bioschemas repository</a>: for tracking tasks, ideas, issues, and opportunities</li>
-      <li><a href="https://github.com/BioSchemas/bioschemas.github.io">bioschemas.github.io</a> for managing this website</li>
+      <li><a href="https://github.com/Bioschemas/bioschemas">Bioschemas repository</a>: for tracking tasks, ideas, issues, and opportunities</li>
+      <li><a href="https://github.com/Bioschemas/bioschemas.github.io">bioschemas.github.io</a> for managing this website</li>
     </ul>
 </div>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ call-date: 2020-10-26T15:00GMT
     <div class="container-flow">
       <div class="alert alert-success" role="alert">
             <h3>Join the Bioschemas Steering Council</h3>
-            <p>We are actively seeking applications to join the Bioscheams Steering Council. For details about the role of the Steering Council please see our <a href='https://github.com/BioSchemas/governance/blob/master/governance.md'>governance document</a>.</p><p>To apply, please complete the <a href='https://docs.google.com/forms/d/1LYS75YTb7jQydMNpWUXFoVcWJZU_FWsknBw3Pmojr3M/'>application form</a> by 31 October 2020.</p>
+            <p>We are actively seeking applications to join the Bioscheams Steering Council. For details about the role of the Steering Council please see our <a href='https://github.com/Bioschemas/governance/blob/master/governance.md'>governance document</a>.</p><p>To apply, please complete the <a href='https://docs.google.com/forms/d/1LYS75YTb7jQydMNpWUXFoVcWJZU_FWsknBw3Pmojr3M/'>application form</a> by 31 October 2020.</p>
         </div>
         <div class="row">
             <div class="col-md-8">
@@ -122,7 +122,7 @@ call-date: 2020-10-26T15:00GMT
                 </section>
                 <hr>
                 <section>
-                	<a class="twitter-timeline" data-height="450" data-theme="light" data-link-color="#2BB673" href="https://twitter.com/BioSchemas?ref_src=twsrc%5Etfw">Tweets by BioSchemas</a>
+                	<a class="twitter-timeline" data-height="450" data-theme="light" data-link-color="#2BB673" href="https://twitter.com/Bioschemas?ref_src=twsrc%5Etfw">Tweets by Bioschemas</a>
                 	<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
                 </section>
             </div>

--- a/liveDeploys/elixir.html
+++ b/liveDeploys/elixir.html
@@ -141,5 +141,5 @@ description: |-
     <blockquote>
         <h6>Note:</h6>
         As we do not maintain the websites listed above we can not guarantee the list is up to date, the sites are live and feature appropriate content or the links work.
-        <p>Help us keep it updated: <a href="/howtojoin/">Join</a> the community and/or create a pull request on the <a href="https://github.com/BioSchemas/bioschemas.github.io">bioschemas github</a> community project.</p>
+        <p>Help us keep it updated: <a href="/howtojoin/">Join</a> the community and/or create a pull request on the <a href="https://github.com/Bioschemas/bioschemas.github.io">bioschemas github</a> community project.</p>
     </blockquote>

--- a/liveDeploys/index.html
+++ b/liveDeploys/index.html
@@ -130,6 +130,6 @@ description: |-
     <blockquote>
         <h6>Note:</h6>
         As we do not maintain the websites listed above we can not guarantee the list is up to date, the sites are live and feature appropriate content or the links work.
-        <p>Help us keep it updated: <a href="/howtojoin/">Join</a> the community and/or create a pull request on the <a href="https://github.com/BioSchemas/bioschemas.github.io">bioschemas github</a> community project.</p>
+        <p>Help us keep it updated: <a href="/howtojoin/">Join</a> the community and/or create a pull request on the <a href="https://github.com/Bioschemas/bioschemas.github.io">bioschemas github</a> community project.</p>
     </blockquote>
 </div>

--- a/people/index.html
+++ b/people/index.html
@@ -33,7 +33,7 @@ title: People
 {
     "@context": "http://schema.org/",
     "@type": "Organization",
-    "name": "BioSchemas Community",
+    "name": "Bioschemas Community",
     "url": "http://bioschemas.org/",
     "logo": "http://bioschemas.org/images/square_logo2.png",
     "email": "enquiries@bioschemas.org",

--- a/profiles/index.html
+++ b/profiles/index.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: BioSchemas Profiles
+title: Bioschemas Profiles
 redirect_from:
  - "/devSpecs/"
  - "/specifications/drafts/"
@@ -15,7 +15,7 @@ redirect_from:
 </h1>
 
 <p>The Bioschemas' profiles define a community agreed layer over the Schema.org vocabulary, providing additional constraints. These constraints capture (i) the information properties agreed by the community which are minimum (M), recommended (R), or optional (O), (ii) the cardinality of the property, i.e. whether it is expected to occur once or many times, and (iii) associated controlled vocabulary terms drawn from existing ontologies.</p>
-<p>These guidelines provide community best practice that lead to consisent markup of life sciences resources on the Web. Comments and discussions on the <a href="https://lists.w3.org/Archives/Public/public-bioschemas/" itemprop="email">mailing list</a> or <a href="https://github.com/BioSchemas/specifications/issues">GitHub issue tracker</a> are encouraged.</p>
+<p>These guidelines provide community best practice that lead to consisent markup of life sciences resources on the Web. Comments and discussions on the <a href="https://lists.w3.org/Archives/Public/public-bioschemas/" itemprop="email">mailing list</a> or <a href="https://github.com/Bioschemas/specifications/issues">GitHub issue tracker</a> are encouraged.</p>
 
 <br />
 
@@ -78,7 +78,7 @@ redirect_from:
 <!-- DRAFT PROFILES -->
 <section id="tab2Content" class="tabs">
    <h3>DRAFT</h3>
-   <p><em>Draft</em> profiles are actively being worked on and are likely to change. Disucssions take place on the <a href="https://lists.w3.org/Archives/Public/public-bioschemas/" itemprop="email">mailing list</a> and the <a href="https://github.com/BioSchemas/specifications/issues">GitHub issue tracker</a>.</p>
+   <p><em>Draft</em> profiles are actively being worked on and are likely to change. Disucssions take place on the <a href="https://lists.w3.org/Archives/Public/public-bioschemas/" itemprop="email">mailing list</a> and the <a href="https://github.com/Bioschemas/specifications/issues">GitHub issue tracker</a>.</p>
    <p>Draft profiles are either working towards their first release or are refinements of a previously <em>released</em> version.</p>
    <table class="bioschemas_spec_list" style="width: 100%; margin-left: auto; margin-right: auto; text-align: center;">
       <thead>

--- a/publications/index.html
+++ b/publications/index.html
@@ -162,6 +162,6 @@ Machine Learning</a>, Sebastian Böcker, Corey Broeckling, Emma Schymanski, and 
       </ul>
     </li>
   </ol>
-  <p>Please help us keep this list up to date: <a href="http://bioschemas.org/howtojoin/">Join</a> the community and/or create a pull request on the <a href="https://github.com/BioSchemas/bioschemas.github.io">bioschemas github</a> community project. </p>
+  <p>Please help us keep this list up to date: <a href="http://bioschemas.org/howtojoin/">Join</a> the community and/or create a pull request on the <a href="https://github.com/Bioschemas/bioschemas.github.io">bioschemas github</a> community project. </p>
   <br />
 </div>

--- a/software/index.html
+++ b/software/index.html
@@ -12,7 +12,7 @@ description: |-
   <p>{{page.description | markdownify}}</p>
 
   <blockquote>
-    <h6>Note:</h6>help us keep the above list updated: <a href="/howtojoin/">Join</a> the community and/or create a pull request on the <a href="https://github.com/BioSchemas/bioschemas.github.io">bioschemas github</a> community project.
+    <h6>Note:</h6>help us keep the above list updated: <a href="/howtojoin/">Join</a> the community and/or create a pull request on the <a href="https://github.com/Bioschemas/bioschemas.github.io">bioschemas github</a> community project.
     <p></p>
   </blockquote>
 
@@ -58,8 +58,8 @@ description: |-
     <p>Application to help publishing Bioschemas profiles on the Bioschemas <a href="http://bioschemas.org/specifications">website</a>.</p>
     <img align="left" alt="GoBioschemas logo" src="/images/goweb-bioschemas-logo.svg" width="200">
     <h4>Description</h4>
-    <p>GoWeb is a simple application that helps us to create the <a href="http://bioschemas.org/specifications/" target="_blank">Bioschemas website specifications</a>. It extracts content from the google spreadsheets we use to define Bioschemas profiles (dataset, protein, samples, ...). The web specifications are created using <a href="http://yaml.org/" target="_blank">YAML</a> so they are also in a <a href="https://github.com/BioSchemas/bioschemas.github.io/tree/master/_specifications" target="_blank">machine readable format</a>. The combination of Google spreadsheets and GoWeb allows us to have a simple mechanism to define Bioschemas profiles and display them in a beautiful and consistent manner.</p>
-    <p>We have created a Google Spreadsheet <a href="https://docs.google.com/spreadsheets/d/1kl92O05-_3kjYd37YK8q2eb4A1fpYvn3Mkk6HhtUBEs/edit#gid=1483018794" target="_blank">template</a> to help the community to define Bioschemas profiles. We have also described the <a href="https://github.com/BioSchemas/specifications/wiki/Bioschemas-Specification-Process" target="_blank">process</a> to create the web specifications using GoWeb.</p>
+    <p>GoWeb is a simple application that helps us to create the <a href="http://bioschemas.org/specifications/" target="_blank">Bioschemas website specifications</a>. It extracts content from the google spreadsheets we use to define Bioschemas profiles (dataset, protein, samples, ...). The web specifications are created using <a href="http://yaml.org/" target="_blank">YAML</a> so they are also in a <a href="https://github.com/Bioschemas/bioschemas.github.io/tree/master/_specifications" target="_blank">machine readable format</a>. The combination of Google spreadsheets and GoWeb allows us to have a simple mechanism to define Bioschemas profiles and display them in a beautiful and consistent manner.</p>
+    <p>We have created a Google Spreadsheet <a href="https://docs.google.com/spreadsheets/d/1kl92O05-_3kjYd37YK8q2eb4A1fpYvn3Mkk6HhtUBEs/edit#gid=1483018794" target="_blank">template</a> to help the community to define Bioschemas profiles. We have also described the <a href="https://github.com/Bioschemas/specifications/wiki/Bioschemas-Specification-Process" target="_blank">process</a> to create the web specifications using GoWeb.</p>
     <h4>People</h4>
     <ul>
       <li>
@@ -69,7 +69,7 @@ description: |-
     <h4>Links</h4>
     <ul>
       <li>
-        <a href="https://github.com/BioSchemas/bioschema-goweb">https://github.com/BioSchemas/bioschema-goweb</a>
+        <a href="https://github.com/Bioschemas/bioschema-goweb">https://github.com/Bioschemas/bioschema-goweb</a>
       </li>
     </ul>
   </div>

--- a/types/index.html
+++ b/types/index.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: BioSchemas Types
+title: Bioschemas Types
 redirect_from:
  - "/devTypes/"
  - "/types/drafts/"
@@ -14,7 +14,7 @@ redirect_from:
 
 <p><a href="https://schema.org/">Schema.org</a> provides a vocabulary of terms that can be used to describe data on the Internet. The Bioschemas community are extending that vocabulary to be able to describe life sciences resources. Here we host the types and properties that are being proposed to the Schema.org vocabulary.</p>
 
-<p>Comments and discussions on the <a href="https://lists.w3.org/Archives/Public/public-bioschemas/" itemprop="email">mailing list</a> or <a href="https://github.com/BioSchemas/specifications/issues">GitHub issue tracker</a> are encouraged.</p>
+<p>Comments and discussions on the <a href="https://lists.w3.org/Archives/Public/public-bioschemas/" itemprop="email">mailing list</a> or <a href="https://github.com/Bioschemas/specifications/issues">GitHub issue tracker</a> are encouraged.</p>
 <br />
 {% assign dep_types = site.data.type_versions | where: 'status', 'deprecated' %}
 {% assign dep_types_names = "" | split: ',' %}
@@ -68,11 +68,11 @@ redirect_from:
         <td class="spec_links">
             {% if spec.gh_tasks == '' %}
               <a>
-                <img src="/images/specs_tasks.png" alt="BioSchemas {{ spec.name }} Github Tasks or Issues" style="filter: grayscale(100%);">
+                <img src="/images/specs_tasks.png" alt="Bioschemas {{ spec.name }} Github Tasks or Issues" style="filter: grayscale(100%);">
               </a>
             {% else %}
               <a href="{{spec.gh_tasks}}" target="_blank">
-                <img src="/images/specs_tasks.png" alt="BioSchemas {{ spec.name }} Github Tasks or Issues">
+                <img src="/images/specs_tasks.png" alt="Bioschemas {{ spec.name }} Github Tasks or Issues">
               </a>
             {% endif %}
         </td>
@@ -95,7 +95,7 @@ redirect_from:
 <!-- DRAFT TYPES -->
 <section id="tab2Content" class="tabs">
    <h3>DRAFT</h3>
-   <p><em>Draft</em> types are actively being worked on and are likely to change. Disucssions take place on the <a href="https://lists.w3.org/Archives/Public/public-bioschemas/" itemprop="email">mailing list</a> and the <a href="https://github.com/BioSchemas/specifications/issues">GitHub issue tracker</a>.</p>
+   <p><em>Draft</em> types are actively being worked on and are likely to change. Disucssions take place on the <a href="https://lists.w3.org/Archives/Public/public-bioschemas/" itemprop="email">mailing list</a> and the <a href="https://github.com/Bioschemas/specifications/issues">GitHub issue tracker</a>.</p>
    <p>Draft types are either working towards their first release or are refinements of a previously <em>released</em> version.</p>
 <table class="bioschemas_spec_list" style="width: 100%; margin-left: auto; margin-right: auto; text-align: center;">
     <thead>
@@ -121,11 +121,11 @@ redirect_from:
         <td class="spec_links">
             {% if spec.gh_tasks == '' %}
               <a>
-                <img src="/images/specs_tasks.png" alt="BioSchemas {{ spec.name }} Github Tasks or Issues" style="filter: grayscale(100%);">
+                <img src="/images/specs_tasks.png" alt="Bioschemas {{ spec.name }} Github Tasks or Issues" style="filter: grayscale(100%);">
               </a>
             {% else %}
               <a href="{{spec.gh_tasks}}" target="_blank">
-                <img src="/images/specs_tasks.png" alt="BioSchemas {{ spec.name }} Github Tasks or Issues">
+                <img src="/images/specs_tasks.png" alt="Bioschemas {{ spec.name }} Github Tasks or Issues">
               </a>
             {% endif %}
         </td>
@@ -174,11 +174,11 @@ redirect_from:
         <td class="spec_links">
             {% if spec.gh_tasks == '' %}
               <a>
-                <img src="/images/specs_tasks.png" alt="BioSchemas {{ spec.name }} Github Tasks or Issues" style="filter: grayscale(100%);">
+                <img src="/images/specs_tasks.png" alt="Bioschemas {{ spec.name }} Github Tasks or Issues" style="filter: grayscale(100%);">
               </a>
             {% else %}
               <a href="{{spec.gh_tasks}}" target="_blank">
-                <img src="/images/specs_tasks.png" alt="BioSchemas {{ spec.name }} Github Tasks or Issues">
+                <img src="/images/specs_tasks.png" alt="Bioschemas {{ spec.name }} Github Tasks or Issues">
               </a>
             {% endif %}
         </td>


### PR DESCRIPTION
Follow on from the interaction with @martin-nc, I've done a search and replace to eliminate any usage of `BioSchemas` in the website; replacing them all with `Bioschemas`.

I've tested this on my local deployment and checked that the links to the repository work (at least some of them). 

@ljgarcia please can you also verify that this works for you and test some of the links.