### PR TITLE
Enable link to live deploys

### DIFF
--- a/_profiles/ChemicalSubstance/0.4-RELEASE.html
+++ b/_profiles/ChemicalSubstance/0.4-RELEASE.html
@@ -17,7 +17,7 @@ group: chemicals
 use_cases_url: '/useCases/ChemicalSubstance/'
 cross_walk_url: 'https://docs.google.com/spreadsheets/d/1rf-tiNFfRq-Sjt_gbnyK_rs1ofcVOqdHDh9Wp-RdiRI/edit#gid=1483018794'
 gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Chemistry
-live_deploy: ''
+live_deploy: /liveDeploys/
 
 parent_type: Thing
 hierarchy:


### PR DESCRIPTION
Changed setting so that the link for live deploys takes you to the live deploy page.