### PR TITLE
Deprecate DataRecord

### DIFF
--- a/_data/profile_versions.yaml
+++ b/_data/profile_versions.yaml
@@ -52,7 +52,8 @@ DataRecord:
     name: "DataRecord"
     latest_publication: "0.2-DRAFT-2019_06_14"
     latest_release:
-    status: "active"
+    status: "deprecated"
+    deprecated_date: "2021-02-22"
 
 Dataset:
     name: "Dataset"

--- a/_data/type_versions.yaml
+++ b/_data/type_versions.yaml
@@ -34,7 +34,8 @@ DataRecord:
     name: "DataRecord"
     latest_publication: "0.3-DRAFT-2019_06_20"
     latest_release:
-    status: "active"
+    status: "deprecated"
+    deprecated_date: "2021-02-22"
 
 DNA:
     name: "DNA"

--- a/_includes/type_start.html
+++ b/_includes/type_start.html
@@ -1,7 +1,7 @@
 {% if page.status == 'release' %}
 <h1>{{page.name}} (Type)</h1>
 {% elsif site.data.type_versions[page.name].status == "deprecated"%}
-<h1>{{current_name}} <u>DEPRECATED</u> Profile</h1>
+<h1>{{page.name}} <u>DEPRECATED</u> Type</h1>
 {% else %}
 <h1>{{page.name}} <u>DRAFT</u> Type</h1>
 {% endif %}

--- a/profiles/index.html
+++ b/profiles/index.html
@@ -112,7 +112,12 @@ redirect_from:
 
 <section id="tab3Content" class="tabs">
    <h3>DEPRECATED</h3>
-   <p><em>Deprecated</em> means that the group developing it have suspended work; we would be delighted for you to continue it. Please email <a href="mailto:public-bioschemas@w3.org" itemprop="email">public-bioschemas@w3.org</a> to discuss.</p>
+   <p>A profile can be <em>deprecated</em> because:</p>
+   <ul>
+     <li>The working group decided that the profile is no longer required, e.g. the work undertaken was deemed unsatisfactory, or failed to accomplish the desired objective(s), or has been superceded by some other activity; or</li>
+     <li>The working group developing it have suspended work.</li>
+   </ul>
+  <p>If you would like to continue work on one of these profiles then please email the community <a href="mailto:public-bioschemas@w3.org" itemprop="email">public-bioschemas@w3.org</a> to discuss.</p>
    <table class="bioschemas_spec_list" style="width: 100%; margin-left: auto; margin-right: auto; text-align: center;">
       <thead>
       <tr>

--- a/types/index.html
+++ b/types/index.html
@@ -80,9 +80,6 @@ redirect_from:
 
       {% endif %}
       {% endif %}
-      {% else %}
-      <p>NNN{{spec.name}}NNN</p>
-
       {% endif %}
       {% endfor %}
 

--- a/types/index.html
+++ b/types/index.html
@@ -34,10 +34,9 @@ redirect_from:
 <label for="tab1">RELEASE</label>
 <input id="tab2" type="radio" name="tabs">
 <label for="tab2">DRAFT</label>
-<!--
 <input id="tab3" type="radio" name="tabs">
 <label for="tab3">DEPRECATED</label>
- -->
+
 
 
 <!-- RELEASED TYPES -->
@@ -147,9 +146,9 @@ redirect_from:
 
 
 <!-- DEPRECATED TYPES -->
-<!-- WONT WORK AS TAB COMMENTSED OUT ABIOVE -->
 <section id="tab3Content" class="tabs">
    <h3>DEPRECATED</h3>
+   <p><em>Deprecated</em> means that the group developing it have suspended work; we would be delighted for you to continue it. Please email <a href="mailto:public-bioschemas@w3.org" itemprop="email">public-bioschemas@w3.org</a> to discuss.</p>
 <table class="bioschemas_spec_list" style="width: 100%; margin-left: auto; margin-right: auto; text-align: center;">
     <thead>
     <tr>

--- a/types/index.html
+++ b/types/index.html
@@ -133,9 +133,6 @@ redirect_from:
 
       {% endif %}
       {% endif %}
-      {% else %}
-      <p>NNN{{spec.name}}NNN</p>
-
       {% endif %}
       {% endfor %}
 
@@ -186,9 +183,6 @@ redirect_from:
 
       {% endif %}
       {% endif %}
-      {% else %}
-      <p>NNN{{spec.name}}NNN</p>
-
       {% endif %}
       {% endfor %}
 

--- a/types/index.html
+++ b/types/index.html
@@ -145,7 +145,12 @@ redirect_from:
 <!-- DEPRECATED TYPES -->
 <section id="tab3Content" class="tabs">
    <h3>DEPRECATED</h3>
-   <p><em>Deprecated</em> means that the group developing it have suspended work; we would be delighted for you to continue it. Please email <a href="mailto:public-bioschemas@w3.org" itemprop="email">public-bioschemas@w3.org</a> to discuss.</p>
+   <p>A type can be <em>deprecated</em> because:</p>
+   <ul>
+     <li>The working group decided that the type is no longer required, e.g. the work undertaken was deemed unsatisfactory, or failed to accomplish the desired objective(s), or has been superceded by some other activity; or</li>
+     <li>The working group developing it have suspended work.</li>
+   </ul>
+  <p>If you would like to continue work on one of these types then please email the community <a href="mailto:public-bioschemas@w3.org" itemprop="email">public-bioschemas@w3.org</a> to discuss.</p>
 <table class="bioschemas_spec_list" style="width: 100%; margin-left: auto; margin-right: auto; text-align: center;">
     <thead>
     <tr>


### PR DESCRIPTION
Mark DataRecord as deprecated.

Update website logic to display deprecated types.

Updated deprecation text to match text in governance document.

Closes issues:
- https://github.com/BioSchemas/specifications/issues/483
- https://github.com/BioSchemas/specifications/issues/475
- https://github.com/BioSchemas/specifications/issues/450
- https://github.com/BioSchemas/specifications/issues/307
- https://github.com/BioSchemas/specifications/issues/217
- https://github.com/BioSchemas/specifications/issues/176