### PR TITLE
Add Matus Kalas

### DIFF
--- a/_groups/Tools.md
+++ b/_groups/Tools.md
@@ -48,4 +48,5 @@ members:
     - RobertoPreste
     - RafaelJimenez
     - AlbanGaignard
+    - MatusKalas
 ---

--- a/_people/MatusKalas.md
+++ b/_people/MatusKalas.md
@@ -1,0 +1,11 @@
+---
+layout: person-details
+id: MatusKalas
+collection: people
+first-name: Matúš
+last-name: Kalaš
+affiliation: University of Bergen, Bergen, Hordaland, Norway / ELIXIR-NO
+homepage: https://www.uib.no/en/persons/Matus.Kalas
+github_username: matuskalas
+orcid:  0000-0002-1509-4981
+---


### PR DESCRIPTION
Add Matus Kalas to the list of Bioschemas people and list on the Tools group.