### PR TITLE
Prepared 0.4-DRAFT of Dataset Profile

### DIFF
--- a/_data/profile_versions.yaml
+++ b/_data/profile_versions.yaml
@@ -57,7 +57,7 @@ DataRecord:
 
 Dataset:
     name: "Dataset"
-    latest_publication:
+    latest_publication: "0.4-DRAFT"
     latest_release: "0.3-RELEASE-2019_06_14"
     status: "active"
 

--- a/_profiles/Dataset/0.3-RELEASE-2019_06_14.html
+++ b/_profiles/Dataset/0.3-RELEASE-2019_06_14.html
@@ -1,9 +1,5 @@
 ---
 redirect_from:
- - "devSpecs/Dataset/specification"
- - "devSpecs/Dataset/specification/"
- - "/devSpecs/Dataset/"
- - "/specifications/drafts/Dataset"
  - "/specifications/Dataset"
  - '/profiles/Dataset/'
 

--- a/_profiles/Dataset/0.4-DRAFT.html
+++ b/_profiles/Dataset/0.4-DRAFT.html
@@ -1,0 +1,500 @@
+---
+redirect_from:
+ - "devSpecs/Dataset/specification"
+ - "devSpecs/Dataset/specification/"
+ - "/devSpecs/Dataset/"
+ - "/specifications/drafts/Dataset"
+
+name: Dataset
+
+previous_version: '0.3-RELEASE-2019_06_14'
+previous_release: '0.3-RELEASE-2019_06_14'
+
+status: revision #release
+spec_type: Profile
+group: data
+use_cases_url: /useCases/Dataset/
+cross_walk_url: https://docs.google.com/spreadsheets/d/1IUw5tdUvzTs3ogxgBNYTtUrVtlO2Czv6yiavyNfct8w/edit#gid=1483018794
+gh_tasks: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Dataset
+live_deploy: /liveDeploys/
+
+
+parent_type: Dataset
+hierarchy:
+- Thing
+- CreativeWork
+- Dataset
+
+# spec_info content generated using GOWeb
+# DO NOT MANUALLY EDIT THE CONTENT
+spec_info:
+  title: Dataset
+  subtitle: ""
+  description: 'A guide for how to describe datasets in the life-sciences using Schema.org-like
+    annotation.<h3>Summary of Changes</h3><ul><li>Many: Other  <a href="https://github.com/BioSchemas/specifications/issues/473">#473</a>
+    – Updated properties used in the profile to be aligned with schema.org v12.0</li><li>keywords:
+    Other  <a href="https://github.com/BioSchemas/specifications/issues/311">#311</a> – Updated
+    guidance</li><li>maintainer: Added – New property in schema.org that is of particular
+    relevance for datasets</li><li>identifier: Other <a href="https://github.com/BioSchemas/specifications/issues/310">#310</a> – Updated guidance and example</li><li>alternateName: Added  <a href="https://github.com/BioSchemas/specifications/issues/312">#312</a>
+    – Adding terms used by other recommendations such as Google or FigShare as optional</li><li>hasPart:
+    Added  <a href="https://github.com/BioSchemas/specifications/issues/312">#312</a> – Adding
+    terms used by other recommendations such as Google or FigShare as optional</li><li>isPartOf:
+    Added  <a href="https://github.com/BioSchemas/specifications/issues/312">#312</a> – Adding
+    terms used by other recommendations such as Google or FigShare as optional</li><li>license:
+    Marginality Increase – Licenses are required to know what terms the dataset can
+    be used under</li><li>isAccessibleForFree: Added  <a href="https://github.com/BioSchemas/specifications/issues/312">#312</a>
+    – Adding terms used by other recommendations such as Google or FigShare as optional</li><li>dateCreated:
+    Added  <a href="https://github.com/BioSchemas/specifications/issues/312">#312</a> – Adding
+    terms used by other recommendations such as Google or FigShare as optional</li><li>dateModified:
+    Added  <a href="https://github.com/BioSchemas/specifications/issues/312">#312</a> – Adding
+    terms used by other recommendations such as Google or FigShare as optional</li><li>datePublished:
+    Added  <a href="https://github.com/BioSchemas/specifications/issues/312">#312</a> – Adding
+    terms used by other recommendations such as Google or FigShare as optional</li><li>publisher:
+    Added  <a href="https://github.com/BioSchemas/specifications/issues/312">#312</a> – Adding
+    terms used by other recommendations such as Google or FigShare as optional</li><li>isBasedOn:
+    Added  <a href="https://github.com/BioSchemas/specifications/issues/477">#477</a> – Link a
+    Dataset to a Study that produced it</li></ul>'
+  version: 0.4-DRAFT
+  version_date: 20210330T211142
+  official_type: http://schema.org/Dataset
+  full_example: https://github.com/BioSchemas/specifications/tree/master/Dataset/examples/
+mapping:
+- property: alternateName
+  expected_types:
+  - Text
+  description: An alias for the item.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Recommended
+  cardinality: MANY
+  controlled_vocab: ""
+  example: |-
+    {
+    "@type": "Dataset",
+     "alternateName": "MetaboLights dataset",
+      "alternateName": "Automated Label-free Quantification of Metabolites from Liquid Chromatography",
+      "alternateName": "Mass Spectrometry Data (Plasma) Automated Label-free Quantification of Metabolites from Liquid Chromatography",
+      "alternateName": “Mass Spectrometry Data (Plasma)"
+    }
+- property: citation
+  expected_types:
+  - CreativeWork
+  - Text
+  description: A citation or reference to another creative work, such as another publication,
+    web page, scholarly article, etc.
+  type: ""
+  type_url: ""
+  bsc_description: A citation for a publication that describes the dataset.
+  marginality: Recommended
+  cardinality: MANY
+  controlled_vocab: ""
+  example: |-
+    {
+    "@type": "Dataset",
+    "citation": {
+        "@type": "ScholarlyArticle",
+        "headline": "Automated Label-free Quantification of Metabolites from Liquid Chromatographyâ€“Mass Spectrometry Data",
+        "identifier": [
+          "http://doi.org/10.1074/mcp.M113.031278",
+          "https://www.ncbi.nlm.nih.gov/pubmed/24176773"
+        ],
+        "datePublished": "2014-01"
+      }
+    }
+- property: creator
+  expected_types:
+  - Organization
+  - Person
+  description: The creator/author of this CreativeWork. This is the same as the Author
+    property for CreativeWork.
+  type: ""
+  type_url: ""
+  bsc_description: The name of the dataset creator (person or organization).
+  marginality: Recommended
+  cardinality: MANY
+  controlled_vocab: ""
+  example: |-
+    {
+    "@type": "Dataset",
+    "creator": {
+        "@type": "Person",
+        "familyName": "Kohlbacher",
+        "givenName": "Oliver",
+        "email": "oliver.kohlbacher@uni-tuebingen.de",
+        "affiliation": "Wilhelm Schickard Institute for Computer Science, University of Tubingen"
+      }
+    }
+- property: dateCreated
+  expected_types:
+  - Date
+  - DateTime
+  description: The date on which the CreativeWork was created or the item was added
+    to a DataFeed.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: ""
+  controlled_vocab: ""
+  example: ""
+- property: dateModified
+  expected_types:
+  - Date
+  - DateTime
+  description: The date on which the CreativeWork was most recently modified or when
+    the item's entry was modified within a DataFeed.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: ""
+  controlled_vocab: ""
+  example: ""
+- property: datePublished
+  expected_types:
+  - Date
+  description: Date of first broadcast/publication.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: ""
+  controlled_vocab: ""
+  example: ""
+- property: description
+  expected_types:
+  - Text
+  description: A description of the item.
+  type: ""
+  type_url: ""
+  bsc_description: A short summary describing a dataset.
+  marginality: Minimum
+  cardinality: ONE
+  controlled_vocab: ""
+  example: |-
+    {
+    "@type": "Dataset",
+     "description": "Liquid chromatography coupled to mass spectrometry (LC-MS) has become a standard technology in metabolomics. In particular, label-free quantification based on LC-MS ..."
+    }
+- property: distribution
+  expected_types:
+  - DataDownload
+  description: A downloadable form of this dataset, at a specific location, in a specific
+    format.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Recommended
+  cardinality: ONE
+  controlled_vocab: ""
+  example: |-
+    {
+    "@type": "Dataset",
+    "distribution": [
+        {
+          "@type": "DataDownload",
+          "name": "UniParc XML",
+          "fileFormat": "xml",
+          "contentURL": "ftp://ftp.uniprot.org/pub/databases/uniprot/current_release/uniparc/uniparc_all.xml.gz"
+        },
+        {
+          "@type": "DataDownload",
+          "name": "UniParc FASTA",
+          "fileFormat": "fasta",
+          "contentURL": "ftp://ftp.uniprot.org/pub/databases/uniprot/current_release/uniparc/uniparc_active.fasta.gz"
+        }
+    ]
+    }
+- property: hasPart
+  expected_types:
+  - CreativeWork
+  - Trip
+  description: "Indicates an item or CreativeWork that is part of this item, or CreativeWork
+    (in some sense). \nInverse property: [isPartOf](https://schema.org/isPartOf)"
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: ""
+  controlled_vocab: ""
+  example: ""
+- property: identifier
+  expected_types:
+  - PropertyValue
+  - Text
+  - URL
+  description: The identifier property represents any kind of identifier for any kind
+    of [Thing](https://schema.org/Thing), such as ISBNs, GTIN codes, UUIDs etc. Schema.org
+    provides dedicated properties for representing many of these, either as textual
+    strings or as URL (URI) links. See [background notes](http://schema.org/docs/datamodel.html#identifierBg)
+    for more details.
+  type: ""
+  type_url: ""
+  bsc_description: CURIEs that can be resolved using [Identifiers.org](https://identifiers.org/)
+    should be used.
+  marginality: Minimum
+  cardinality: MANY
+  controlled_vocab: ""
+  example: |-
+    {
+    "@type": "Dataset",
+    "identifier": "metabolights:MTBLS234"
+    }
+- property: includedInDataCatalog
+  expected_types:
+  - DataCatalog
+  description: |-
+    A data catalog which contains this dataset. Supersedes [includedDataCatalog](https://schema.org/includedDataCatalog), [catalog](https://schema.org/catalog).
+    Inverse property: [dataset](https://schema.org/dataset)
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Recommended
+  cardinality: MANY
+  controlled_vocab: ""
+  example: |-
+    {
+    "@type": "Dataset",
+    "includedinDataCatalog": {
+        "@type": "DataCatalog",
+        "name": "EMBL-EBI Metabolights",
+        "url": "http://www.ebi.ac.uk/metabolights"
+      }
+    }
+- property: isAccessibleForFree
+  expected_types:
+  - Boolean
+  description: A flag to signal that the item, event, or place is accessible for free.
+    Supersedes [free](https://schema.org/free).
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: ""
+  controlled_vocab: ""
+  example: ""
+- property: isBasedOn
+  expected_types:
+  - CreativeWork
+  - Product
+  - URL
+  description: "A resource that was used in the creation of this resource. This term
+    can be repeated for multiple sources. For example, http://example.com/great-multiplication-intro.html.
+    \nSupersedes isBasedOnUrl."
+  type: ""
+  type_url: ""
+  bsc_description: Use to link a Dataset to the Study that it was generated from.
+  marginality: Recommended
+  cardinality: MANY
+  controlled_vocab: ""
+  example: |-
+    {
+      "isBasedOn": "https://www.ebi.ac.uk/metabolights/MTBLS235/"
+    }
+- property: isPartOf
+  expected_types:
+  - CreativeWork
+  - URL
+  description: 'Indicates an item or CreativeWork that this item, or CreativeWork
+    (in some sense), is part of. Inverse property: [hasPart](https://schema.org/hasPart)'
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: ""
+  controlled_vocab: ""
+  example: ""
+- property: keywords
+  expected_types:
+  - DefinedTerm
+  - Text
+  - URL
+  description: Keywords or tags used to describe this content. Multiple entries in
+    a keywords list are typically delimited by commas.
+  type: ""
+  type_url: ""
+  bsc_description: Keywords should be drawn from a controlled vocabulary, e.g. [EDAM](https://edamontology.org/),
+    and supplied as a DefinedTerm list.
+  marginality: Minimum
+  cardinality: ONE
+  controlled_vocab: ""
+  example: "{\n\"@type\": \"Dataset\",\n\"keywords\": [\n    {\n        \"@type\":
+    \"DefinedTerm\", \n        \"@id\": \"http://edamontology.org/data_2536\", \n
+    \       \"name\": \"Mass spectrometry\"\n    },\n    {\n        \"@type\": \"DefinedTerm\",
+    \n        \"@id\": \"http://edamontology.org/data_1460\", \n        \"name\":
+    \"Protein structure\"\n    }\n  ]\n}"
+- property: license
+  expected_types:
+  - CreativeWork
+  - URL
+  description: A license document that applies to this content, typically indicated
+    by URL.
+  type: ""
+  type_url: ""
+  bsc_description: A license under which the dataset is distributed.
+  marginality: Minimum
+  cardinality: ONE
+  controlled_vocab: ""
+  example: |-
+    {
+    "@type": "Dataset",
+    "license": "http://www.ebi.ac.uk/about/terms-of-use"
+    }
+- property: maintainer
+  expected_types:
+  - Organization
+  - Person
+  description: A maintainer of a [Dataset](https://schema.org/Dataset), software package
+    ([SoftwareApplication](https://schema.org/SoftwareApplication)), or other [Project](https://schema.org/Project).
+    A maintainer is a [Person](https://schema.org/Person) or [Organization](https://schema.org/Organization)
+    that manages contributions to, and/or publication of, some (typically complex)
+    artifact. It is common for distributions of software and data to be based on "upstream"
+    sources. When [maintainer](https://schema.org/maintainer) is applied to a specific
+    version of something e.g. a particular version or packaging of a [Dataset](https://schema.org/Dataset),
+    it is always possible that the upstream source has a different maintainer. The
+    [isBasedOn](https://schema.org/isBasedOn) property can be used to indicate such
+    relationships between datasets to make the different maintenance roles clear.
+    Similarly in the case of software, a package may have dedicated maintainers working
+    on integration into software distributions such as Ubuntu, as well as upstream
+    maintainers of the underlying work.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: MANY
+  controlled_vocab: ""
+  example: ""
+- property: measurementTechnique
+  expected_types:
+  - Text
+  - URL
+  description: |-
+    A technique or technology used in a [Dataset](https://schema.org/Dataset) (or [DataDownload](https://schema.org/DataDownload), [DataCatalog](https://schema.org/DataCatalog)), corresponding to the method used for measuring the corresponding variable(s) (described using [variableMeasured](https://schema.org/variableMeasured)). This is oriented towards scientific and scholarly dataset publication but may have broader applicability; it is not intended as a full representation of measurement, but rather as a high level summary for dataset discovery.
+
+    For example, if [variableMeasured](https://schema.org/variableMeasured) is: molecule concentration, [measurementTechnique](https://schema.org/measurementTechnique) could be: "mass spectrometry" or "nmr spectroscopy" or "colorimetry" or "immunofluorescence".
+
+    If the [variableMeasured](https://schema.org/variableMeasured) is "depression rating", the [measurementTechnique](https://schema.org/measurementTechnique) could be "Zung Scale" or "HAM-D" or "Beck Depression Inventory".
+
+    If there are several [variableMeasured](https://schema.org/variableMeasured) properties recorded for some given data object, use a [PropertyValue](https://schema.org/PropertyValue) for each [variableMeasured](https://schema.org/variableMeasured) and attach the corresponding [measurementTechnique](https://schema.org/measurementTechnique).
+  type: pending
+  type_url: ""
+  bsc_description: ""
+  marginality: Recommended
+  cardinality: MANY
+  controlled_vocab: ""
+  example: |-
+    {
+    "@type": "Dataset",
+    "measurementTechnique": "mass spectrometry"
+    }
+- property: name
+  expected_types:
+  - Text
+  description: The name of the item.
+  type: ""
+  type_url: ""
+  bsc_description: A descriptive name of the dataset.
+  marginality: Minimum
+  cardinality: ONE
+  controlled_vocab: ""
+  example: |-
+    {
+    "@type": "Dataset",
+    "name": "Automated Label-free Quantification of Metabolites from Liquid Chromatography–Mass Spectrometry Data (Simulated)"
+    }
+- property: publisher
+  expected_types:
+  - Organization
+  - Person
+  description: The publisher of the creative work.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: ""
+  controlled_vocab: ""
+  example: ""
+- property: sameAs
+  expected_types:
+  - URL
+  description: URL of a reference Web page that unambiguously indicates the item's
+    identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official
+    website.
+  type: ""
+  type_url: ""
+  bsc_description: ""
+  marginality: Optional
+  cardinality: ""
+  controlled_vocab: ""
+  example: ""
+- property: url
+  expected_types:
+  - URL
+  description: URL of the item.
+  type: ""
+  type_url: ""
+  bsc_description: The location of a page describing the dataset.
+  marginality: Minimum
+  cardinality: ONE
+  controlled_vocab: ""
+  example: |-
+    {
+    "@type": "Dataset",
+    "url": "http://www.ebi.ac.uk/metabolights/MTBLS234"
+    }
+- property: variableMeasured
+  expected_types:
+  - PropertyValue
+  - Text
+  description: The variableMeasured property can indicate (repeated as necessary)
+    the variables that are measured in some dataset, either described as text or as
+    pairs of identifier and description using PropertyValue.
+  type: pending
+  type_url: ""
+  bsc_description: What does the dataset measure? (e.g., temperature, pressure).
+  marginality: Recommended
+  cardinality: MANY
+  controlled_vocab: ""
+  example: |-
+    {
+    "@type": "Dataset",
+    "variablesMeasured": "metabolite concentration"
+    }
+- property: version
+  expected_types:
+  - Number
+  - Text
+  description: The version of the CreativeWork embodied by a specified resource.
+  type: ""
+  type_url: ""
+  bsc_description: The version number for this dataset.
+  marginality: Recommended
+  cardinality: ONE
+  controlled_vocab: ""
+  example: |-
+    {
+    "@type": "Dataset",
+    "version": "8.0.1 c"
+    }
+
+---
+<!DOCTYPE HTML>
+<html>
+   {% include head.html %}
+   <body>
+      {% include header.html %}
+      {% include navbar.html %}
+      <div class="page-content">
+         <div class="wrapper">
+            <div id="main-content-wrapper" class="outer">
+               <section id="main_content" class="inner">
+                  {% include profile_start.html %}
+                  {% include specification_table.html %}
+               </section>
+            </div>
+         </div>
+      </div>
+      {% include footer.html %}
+   </body>
+</html>

--- a/_profiles/Dataset/0.4-DRAFT.html
+++ b/_profiles/Dataset/0.4-DRAFT.html
@@ -6,6 +6,7 @@ redirect_from:
  - "/specifications/drafts/Dataset"
 
 name: Dataset
+schema_version: '12.0'
 
 previous_version: '0.3-RELEASE-2019_06_14'
 previous_release: '0.3-RELEASE-2019_06_14'


### PR DESCRIPTION
Resolves various issues that had been created for the Dataset Profile. Crucially this updates the base schema.org version to V12.0 and brings the profile back inline with Google's Dataset search profile.


Many: Other [#311](https://github.com/BioSchemas/specifications/issues/473) – Updated properties used in the profile to be aligned with schema.org v12.0
keywords: Other [#311](https://github.com/BioSchemas/specifications/issues/311) – Updated guidance
maintainer: Added – New property in schema.org that is of particular relevance for datasets
identifier: Other [#311](https://github.com/BioSchemas/specifications/issues/310) – Updated guidance and example
alternateName: Added  [#312](https://github.com/BioSchemas/specifications/issues/312) – Adding terms used by other recommendations such as Google or FigShare as optional
hasPart: Added  [#312](https://github.com/BioSchemas/specifications/issues/312) – Adding terms used by other recommendations such as Google or FigShare as optional
isPartOf: Added  [#312](https://github.com/BioSchemas/specifications/issues/312) – Adding terms used by other recommendations such as Google or FigShare as optional
license: Marginality Increase – Licenses are required to know what terms the dataset can be used under
isAccessibleForFree: Added  [#312](https://github.com/BioSchemas/specifications/issues/312) – Adding terms used by other recommendations such as Google or FigShare as optional
dateCreated: Added  [#312](https://github.com/BioSchemas/specifications/issues/312) – Adding terms used by other recommendations such as Google or FigShare as optional
dateModified: Added  [#312](https://github.com/BioSchemas/specifications/issues/312) – Adding terms used by other recommendations such as Google or FigShare as optional
datePublished: Added  [#312](https://github.com/BioSchemas/specifications/issues/312) – Adding terms used by other recommendations such as Google or FigShare as optional
publisher: Added  [#312](https://github.com/BioSchemas/specifications/issues/312) – Adding terms used by other recommendations such as Google or FigShare as optional
isBasedOn: Added [#477](https://github.com/BioSchemas/specifications/issues/477) – Link a Dataset to a Study that produced it

The purpose of this PR is to get this on the website so that the community can review and comment on this before trying to push this for release.