### PR TITLE
Fix biogicalRole typo on some of the released types

### DIFF
--- a/_profiles/BioSample/0.1-DRAFT-2019_11_12.html
+++ b/_profiles/BioSample/0.1-DRAFT-2019_11_12.html
@@ -88,7 +88,7 @@ mapping:
   cardinality: ""
   controlled_vocab: ""
   example: ""
-- property: biogicalRole
+- property: biologicalRole
   expected_types:
   - DefinedTerm
   description: A role played by the molecular entity within a biological context.

--- a/_types/BioChemEntity/0.7-RELEASE-2019_06_19.html
+++ b/_types/BioChemEntity/0.7-RELEASE-2019_06_19.html
@@ -85,8 +85,8 @@ external: #454547;
                         A similar molecular entity, e.g., obtained by fingerprint similarity algorithm.
                        </td>
                      </tr>
-                     <tr id="biogicalRole">
-                       <th style="color: #0B794B;">biogicalRole</th>
+                     <tr id="biologicalRole">
+                       <th style="color: #0B794B;">biologicalRole</th>
                        <td>
                          <a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a>
                        </td>

--- a/_types/BioSample/0.1-RELEASE-2019_06_19.html
+++ b/_types/BioSample/0.1-RELEASE-2019_06_19.html
@@ -172,8 +172,8 @@ external: #454547;
                         A similar molecular entity, e.g., obtained by fingerprint similarity algorithm.
                        </td>
                      </tr>
-                     <tr id="biogicalRole">
-                       <th style="color: #0B794B;">biogicalRole</th>
+                     <tr id="biologicalRole">
+                       <th style="color: #0B794B;">biologicalRole</th>
                        <td>
                          <a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a>
                        </td>

--- a/_types/ChemicalSubstance/0.2-RELEASE-2019_06_19.html
+++ b/_types/ChemicalSubstance/0.2-RELEASE-2019_06_19.html
@@ -116,8 +116,8 @@ external: #454547;
                         A similar molecular entity, e.g., obtained by fingerprint similarity algorithm.
                        </td>
                      </tr>
-                     <tr id="biogicalRole">
-                       <th style="color: #0B794B;">biogicalRole</th>
+                     <tr id="biologicalRole">
+                       <th style="color: #0B794B;">biologicalRole</th>
                        <td>
                          <a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a>
                        </td>

--- a/_types/Gene/0.2-RELEASE-2019_06_19.html
+++ b/_types/Gene/0.2-RELEASE-2019_06_19.html
@@ -135,8 +135,8 @@ external: #454547;
                         A similar molecular entity, e.g., obtained by fingerprint similarity algorithm.
                        </td>
                      </tr>
-                     <tr id="biogicalRole">
-                       <th style="color: #0B794B;">biogicalRole</th>
+                     <tr id="biologicalRole">
+                       <th style="color: #0B794B;">biologicalRole</th>
                        <td>
                          <a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a>
                        </td>

--- a/_types/MolecularEntity/0.2-RELEASE-2019_06_23.html
+++ b/_types/MolecularEntity/0.2-RELEASE-2019_06_23.html
@@ -170,8 +170,8 @@ external: #454547;
                         A similar molecular entity, e.g., obtained by fingerprint similarity algorithm.
                        </td>
                      </tr>
-                     <tr id="biogicalRole">
-                       <th style="color: #0B794B;">biogicalRole</th>
+                     <tr id="biologicalRole">
+                       <th style="color: #0B794B;">biologicalRole</th>
                        <td>
                          <a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a>
                        </td>

--- a/_types/Protein/0.2-RELEASE-2019_06_19.html
+++ b/_types/Protein/0.2-RELEASE-2019_06_19.html
@@ -96,8 +96,8 @@ external: #454547;
                         A similar molecular entity, e.g., obtained by fingerprint similarity algorithm.
                        </td>
                      </tr>
-                     <tr id="biogicalRole">
-                       <th style="color: #0B794B;">biogicalRole</th>
+                     <tr id="biologicalRole">
+                       <th style="color: #0B794B;">biologicalRole</th>
                        <td>
                          <a style="color: #0000CC;" href="http://schema.org/DefinedTerm">DefinedTerm</a>
                        </td>


### PR DESCRIPTION
Fixes [Issue 484](https://github.com/BioSchemas/specifications/issues/484)

As this is a typo, the Steering Council have agreed that this should just be corrected without updating any version numbers. Note that the typo was not included in the version that went to Schema.org.