### PR TITLE
Remove empty section

### DIFF
--- a/tutorials/howto/howto_add_markup.md
+++ b/tutorials/howto/howto_add_markup.md
@@ -82,6 +82,3 @@ If your resource involves more than one profile, you first need to define the st
 
 Now, focus on a particular profile, have at hand the [corresponding specification page on Bioschemas](/specifications/) as well as your resource, i.e., your web pages. Do a manual exercise mapping elements to properties. This will help you have a clearer idea on what you want to achieve once you go and use gimme-my-jsonld (see next section). You might need more than one iteration here as you can face multiple option at the beginning, choose that one that gives more benefits. Keep in mind your goal by adding this mark up to your resource.
 
-## Getting JSON-LD with gimme-my-jsonld
-
-In progress


### PR DESCRIPTION
It was highlighted to me that the [How to Add Markup](https://bioschemas.org/tutorials/howto/howto_add_markup) tutorial is incomplete and that the final section leaves an unfinished feel to the tutorial.

@aurel-l is down to check this tutorial in [Issue 488](https://github.com/BioSchemas/specifications/issues/488).

For now I've removed the section, but what is needed is a pointer to the [How to check your Bioschemas deployment](https://bioschemas.org/tutorials/howto/howto_check_deploy) tutorial. But before that there needs to be content on how to add your markup.