### PR TITLE
TOC style changes

### DIFF
--- a/css/stylesheet.css
+++ b/css/stylesheet.css
@@ -1201,7 +1201,7 @@ Table of contents
 /* TOC base styling */
 
 #toc {
-    padding: 7px 15px 15px 15px;
+    padding: 15px;
     background-color: #eaf2ee;
     margin: 1.75em 0 2em;
     border-radius: 4px;

--- a/css/stylesheet.css
+++ b/css/stylesheet.css
@@ -1201,7 +1201,7 @@ Table of contents
 /* TOC base styling */
 
 #toc {
-    padding: 15px;
+    padding: 1em;
     background-color: #eaf2ee;
     margin: 1.75em 0 2em;
     border-radius: 4px;
@@ -1209,19 +1209,15 @@ Table of contents
     line-height: 1.4;
 }
 
-/* Indent the lists and reset any other padding */
-
-#toc ul {
-    padding: 0 0 0 20px;
+/* Reset any other padding on the first level */
+#toc>ul {
+    padding: 0;
 }
 
 /* Consistent vertical space between list items */
-
 #toc li, #toc ul ul li {
     margin: 8px 0 0 0;
 }
-
-
 
 /*******************************************************************************
 Style experiment


### PR DESCRIPTION
@AlasdairGray witht the title in place I forgot to adjust the padding. I also aligned the list marker with the content ones.

Before:
![Screenshot from 2021-06-03 10-02-11](https://user-images.githubusercontent.com/44875756/120611226-404cbd00-c454-11eb-8f58-8a9c273614c2.png)

After:
![Screenshot from 2021-06-03 10-13-14](https://user-images.githubusercontent.com/44875756/120611296-55295080-c454-11eb-8ae7-653bb179873a.png)

We could off course differ the indentation of the list in the TOC copared to the content to let it stand out more...