### PR TITLE
Fix URL used by Schema.org validator

### DIFF
--- a/liveDeploys/index.html
+++ b/liveDeploys/index.html
@@ -111,7 +111,7 @@ bmuseHoverText: "Retrieve using Bioschemas Scraping service"
                 {% if profile.exampleURL != nil %}
                 <div class="google-sdtt-button">
                     <span class="tooltiptext">{{page.schemaHoverText}}</span>
-                    <a href="https://validator.schema.org/?url={{profile.exampleURL}}" class="btn btn-bioschema btn-block" target="_blank">SMV</a>
+                    <a href="https://validator.schema.org/#url={{profile.exampleURL}}" class="btn btn-bioschema btn-block" target="_blank">SMV</a>
                 </div>
                 {% endif %}
               </div>
@@ -210,7 +210,7 @@ bmuseHoverText: "Retrieve using Bioschemas Scraping service"
                   <div class="collapse collapse{{profile.name}}">
                   <div class="google-sdtt-button">
                       <span class="tooltiptext">{{page.schemaHoverText}}</span>
-                      <a href="https://validator.schema.org/?url={{live.exampleURL}}" class="btn btn-bioschema btn-block" target="_blank">SMV</a>
+                      <a href="https://validator.schema.org/#url={{live.exampleURL}}" class="btn btn-bioschema btn-block" target="_blank">SMV</a>
                   </div>
                   </div>
                   {% endif %}
@@ -358,7 +358,7 @@ bmuseHoverText: "Retrieve using Bioschemas Scraping service"
                     {% if profile.exampleURL != nil %}
                     <div class="google-sdtt-button">
                         <span class="tooltiptext">{{page.schemaHoverText}}</span>
-                        <a href="https://validator.schema.org/?url={{profile.exampleURL}}" class="btn btn-bioschema btn-block" target="_blank">SMV</a>
+                        <a href="https://validator.schema.org/#url={{profile.exampleURL}}" class="btn btn-bioschema btn-block" target="_blank">SMV</a>
                     </div>
                     {% endif %}
                   </div>


### PR DESCRIPTION
While the `?` in the URL pattern worked, it ended up with a strange duplication of the URL pattern in the service used. This PR is a minor change which hopefully makes our calls conformant with the expected call pattern.