### PR TITLE
Add Orphanet to the list of live deploys

### DIFF
--- a/_data/live_deployments.json
+++ b/_data/live_deployments.json
@@ -1182,8 +1182,7 @@
     },
     {
       "name": "Orphanet",
-      "description": "The portal for rare diseases and orphan drugs
-",
+      "description": "The portal for rare diseases and orphan drugs",
       "keywords": ["CDR"],
       "url": "https://www.orpha.net/",
       "nodes": "FR",

--- a/_data/live_deployments.json
+++ b/_data/live_deployments.json
@@ -1179,6 +1179,23 @@
           "exampleURL": "https://corkoakdb.org/gene/13014"
         }
       ]
+    },
+    {
+      "name": "Orphanet",
+      "description": "The portal for rare diseases and orphan drugs
+",
+      "keywords": ["CDR"],
+      "url": "https://www.orpha.net/",
+      "nodes": "FR",
+      "sitemap": "https://www.orpha.net/consor/cgi-bin/html/orphanet-googlemap.xml",
+      "profiles": [
+        {
+          "profileName": "Disease",
+          "conformsTo": "0.1-DRAFT",
+          "exampleURL": "https://www.orpha.net/consor/cgi-bin/OC_Exp.php?Expert=141189&lng=en",
+          "highlight": "Over 6,000 diseases"
+        }
+      ]
     }
   ]
 }

--- a/_data/live_deployments_schema.json
+++ b/_data/live_deployments_schema.json
@@ -45,6 +45,7 @@
         "DataCatalog",
         "DataRecord",
         "Dataset",
+        "Disease",
         "Event",
         "FormalParameter",
         "Gene",

--- a/_profiles/Disease/0.1-DRAFT.html
+++ b/_profiles/Disease/0.1-DRAFT.html
@@ -13,7 +13,7 @@ group: diseases
 use_cases_url: /useCases/Disease/
 cross_walk_url: https://docs.google.com/spreadsheets/d/1hGKPatus04Oz1OmM6KrNFobFQ2TGOZ8oQlUbTRn4obM/
 gh_tasks: https://github.com/Bioschemas/specifications/labels/type%3A%20Disease
-live_deploy: ''
+live_deploy: /liveDeploys/
 
 parent_type: MedicalCondition
 hierarchy:


### PR DESCRIPTION
Orhpanet have a deployment of the Disease profile. Needed to extend the JSON-Schema to include Disease as a valid profile name. Also updated the Disease profile to show that there is a live deployment.