### PR TITLE
Fix broken links to related communities page

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -49,7 +49,7 @@
                 <a class="dropdown-item" href="/people/">People</a>
                 <a class="dropdown-item" href="/groups/">Groups</a>
                 <a class="dropdown-item" href="/community/champions.html">Champions</a>
-                <a class="dropdown-item" href="/community/related/">Related Communities</a>
+                <a class="dropdown-item" href="/community/related">Related Communities</a>
             </div>
         </div>
         <div class="btn-group" role="group">

--- a/index.html
+++ b/index.html
@@ -36,14 +36,14 @@ call-date: 2021-06-28T15:00UTC
                   <li>Defining usage <a href="/profiles">profiles</a> over the Schema.org types that identify the essential properties to use in describing a resource.</li>
                 </ol>
                 <h3>Endorsement of Bioschemas</h3>
-                <p>Including Bioschemas markup within a web resource is a simple first step to making your data Findable, c.f. the <a href="https://en.wikipedia.org/wiki/FAIR_data#Findable">FAIR Principles</a>. In particular, search engines index markup from webpages to populate their registries, e.g. <a href="https://datasetsearch.research.google.com/">Google Dataset Search</a>.</p> 
+                <p>Including Bioschemas markup within a web resource is a simple first step to making your data Findable, c.f. the <a href="https://en.wikipedia.org/wiki/FAIR_data#Findable">FAIR Principles</a>. In particular, search engines index markup from webpages to populate their registries, e.g. <a href="https://datasetsearch.research.google.com/">Google Dataset Search</a>.</p>
                 <p>Use of Bioschemas to make resources more discoverable has been endorsed by the European Research Council in their <a href="https://erc.europa.eu/sites/default/files/document/file/ERC_info_document-Open_Research_Data_and_Data_Management_Plans.pdf">Open Research Data and Data Management Plans</a> policy ('metadata' section, page 11). Including Bioschemas markup in a resource's metadata means that you meet some of the Findability criteria of the FAIR Data Principles.</p>
                 <p>Bioscheams is a flagship policy of <a href="https://elixir-europe.org/">ELIXIR</a> (the European life-sciences Infrastructure for biological Information), and a key component of their <a href="https://elixir-europe.org/about-us/what-we-do/elixir-programme">2019-2023 Scientific Programme</a>.</p>
                 <p>The use of Bioschemas markup is also recommended by the <a href="https://www.biocuration.org/curate-now/">International Society for Biocuration</a> in order to help make resources more discoverable.</p>
                 <h3>Bioschemas Community</h3>
                 <p>
                 Bioschemas started as a community effort in November 2015. It operates as an open community initiative with <a href="/people/">representatives</a> from a wide variety of institutions. You are welcome to <a href="/howtojoin/">join the community</a>.</p>
-                <p>For details about related community efforts, please see our <a href="/community/related/">related communities page</a>.</p>
+                <p>For details about related community efforts, please see our <a href="/community/related">related communities page</a>.</p>
 
                 <h2>Schema.org</h2>
                 <p>


### PR DESCRIPTION
Minor fix to ensure links to the related communities page work. 

The trailing `/` meant that the page could not be found.