### PR TITLE
Fix Missing Redirects for DNA and RNA types

### DIFF
--- a/_types/DNA/0.2-DRAFT-2019_06_20.html
+++ b/_types/DNA/0.2-DRAFT-2019_06_20.html
@@ -4,10 +4,13 @@ redirect_from:
 - "devTypes/DNA/specification/"
 - "/devTypes/DNA/"
 - "/DNA"
+- "/DNA/"
 - "/types/DNA"
+- "/types/DNA/"
+
 
 previous_version: '0.1-DRAFT-2018_11_13'
-previous_release: 
+previous_release:
 
 dateModified: 2019-06-20
 description: "DNA"

--- a/_types/RNA/0.1-DRAFT-2019_06_21.html
+++ b/_types/RNA/0.1-DRAFT-2019_06_21.html
@@ -4,10 +4,12 @@ redirect_from:
 - "devTypes/RNA/specification/"
 - "/devTypes/RNA/"
 - "/RNA"
+- "/RNA/"
 - "/types/RNA"
+- "/types/RNA/"
 
-previous_version: 
-previous_release: 
+previous_version:
+previous_release:
 
 
 dateModified: 2019-06-21


### PR DESCRIPTION
[Issue 500](https://github.com/BioSchemas/specifications/issues/500) identified problems with links from Protein profile to DNA and RNA types.

Problem relates to missing redirects which are fixed in this PR.