### PR TITLE
Splash news about inclusion in schema.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,12 +19,13 @@ call-date: 2021-06-28T15:00UTC
 
 
     <div class="container-flow">
-      <!--
+
         <div class="alert alert-success" role="alert">
-            <h3>Join the Bioschemas Steering Council</h3>
-            <p>We are actively seeking applications to join the Bioscheams Steering Council. For details about the role of the Steering Council please see our <a href='https://github.com/Bioschemas/governance/blob/master/governance.md'>governance document</a>.</p><p>To apply, please complete the <a href='https://docs.google.com/forms/d/1LYS75YTb7jQydMNpWUXFoVcWJZU_FWsknBw3Pmojr3M/'>application form</a> by <del>31 October 2020</del> 16 November 2020.</p>
+            <h3>Bioschemas Types Included into Schema.org!</h3>
+            <p>As part of the <a href="https://schema.org/docs/releases.html#v13.0">version 13.0</a> release of the Schema.org vocabulary, the following Bioschemas types have been included into the pending area: <a href="https://schema.org/BioChemEntity">BioChemEntity</a>, <a href="https://schema.org/ChemicalSubstance">ChemicalSubstance</a>, <a href="https://schema.org/Gene">Gene</a>, <a href="https://schema.org/MolecularEntity">MolecularEntity</a>, <a href="https://schema.org/Protein">Protein</a>, <a href="https://schema.org/Taxon">Taxon</a>.
+            </p>
         </div>
-      -->
+
         <div class="row">
             <div class="col-md-8">
                 <h1>What is Bioschemas?</h1>


### PR DESCRIPTION
This PR adds an announcement to the top of the home page stating that Bioschemas types have been included into Schema.org v13.
![Screen Shot 2021-07-01 at 11 35 31](https://user-images.githubusercontent.com/1141265/124125286-58265980-da71-11eb-916e-ee1b9934a6ba.png)
