### PR TITLE
Ensembl have Gene and DataRecord deployments

### DIFF
--- a/_data/live_deployments.json
+++ b/_data/live_deployments.json
@@ -620,6 +620,16 @@
           "profileName": "DataCatalog",
           "conformsTo": "0.2",
           "exampleURL": "https://www.ensembl.org/"
+        },
+        {
+          "profileName": "DataRecord",
+          "conformsTo": "0.2",
+          "exampleURL": "https://www.ensembl.org/id/ENSG00000139618"
+        },
+        {
+          "profileName": "Gene",
+          "conformsTo": "0.7",
+          "exampleURL": "https://www.ensembl.org/id/ENSG00000139618"
         }
       ]
     },


### PR DESCRIPTION
Extends the Ensembl live deploy listing with Gene and DataRecord.

Note that the markup is visible if you inspect the rendered page in Chrome. It is not being detected by SMV or BMUSE.