### PR TITLE
Fix broken previous link in ComputationalTools

### DIFF
--- a/_profiles/ComputationalTool/0.6-DRAFT.html
+++ b/_profiles/ComputationalTool/0.6-DRAFT.html
@@ -14,7 +14,7 @@ redirect_from:
 
 name: ComputationalTool
 
-previous_version: 0.5-DRAFT-2019_11_26
+previous_version: 0.5-DRAFT
 previous_release:
 
 status: revision


### PR DESCRIPTION
Link to 0.5-DRAFT was broken. This PR fixes the back link to previous version