### PR TITLE
Fix https://github.com/BioSchemas/specifications/issues/536

### DIFF
--- a/_types/ComputationalWorkflow/1.0-RELEASE.html
+++ b/_types/ComputationalWorkflow/1.0-RELEASE.html
@@ -2,14 +2,20 @@
 redirect_from:
 - "devTypes/Workflow/specification"
 - "devTypes/Workflow/specification/"
+- "/devTypes/Workflow"
 - "/devTypes/Workflow/"
 - "/Workflow"
+- "/Workflow/"
 - "/types/Workflow"
+- "/types/Workflow/"
 - "devTypes/ComputationalWorkflow/specification"
 - "devTypes/ComputationalWorkflow/specification/"
+- "/devTypes/ComputationalWorkflow"
 - "/devTypes/ComputationalWorkflow/"
 - "/ComputationalWorkflow"
+- "/ComputationalWorkflow/"
 - "/types/ComputationalWorkflow"
+- "/types/ComputationalWorkflow/"
 
 previous_version: "0.1-DRAFT-2020_07_21"
 previous_release:

--- a/_types/FormalParameter/1.0-RELEASE.html
+++ b/_types/FormalParameter/1.0-RELEASE.html
@@ -3,8 +3,11 @@ redirect_from:
 - "devTypes/FormalParameter/specification"
 - "devTypes/FormalParameter/specification/"
 - "/devTypes/FormalParameter/"
+- "/devTypes/FormalParameter"
 - "/FormalParameter"
+- "/FormalParameter/"
 - "/types/FormalParameter"
+- "/types/FormalParameter/"
 
 previous_version: "0.1-DRAFT-2020_07_21"
 previous_release:


### PR DESCRIPTION
@alaninmcr the Jekyl redirect requires both the trailing `/` and non-trailing `/` forms to be included. This should hopefully fix the problem.

As you say, local testing works but not on the server so we won't know for sure until this is deployed.