### PR TITLE
Add Bioversions to live_deployment.json

### DIFF
--- a/_data/live_deployments.json
+++ b/_data/live_deployments.json
@@ -1248,14 +1248,14 @@
     },
     {
       "name": "Bioversions",
-      "keywords": ["versioning", "biomedical databases"],
       "url": "https://biopragmatics.github.io/bioversions/",
       "sitemap": "https://biopragmatics.github.io/bioversions/sitemap.xml",
       "profiles": [
         {
           "profileName": "Dataset",
-          "conformsTo": "0.4-DRAFT",
+          "conformsTo": "-",
           "exampleURL": "https://biopragmatics.github.io/bioversions/",
+          "highlight": "Aggregation site about 279 datasets. Due to the aggregation not all properties can be retrieved to comply with the Bioschemas profile."
         }
       ]
     }

--- a/_data/live_deployments.json
+++ b/_data/live_deployments.json
@@ -1245,6 +1245,19 @@
           "exampleURL": "https://bmrb.io/data_library/summary/index.php?bmrbId=30309"
         }
       ]
+    },
+    {
+      "name": "Bioversions",
+      "keywords": ["versioning", "biomedical databases"],
+      "url": "https://biopragmatics.github.io/bioversions/",
+      "sitemap": "https://biopragmatics.github.io/bioversions/sitemap.xml",
+      "profiles": [
+        {
+          "profileName": "Dataset",
+          "conformsTo": "0.4-DRAFT",
+          "exampleURL": "https://biopragmatics.github.io/bioversions/",
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
The home page of the bioversions site (https://biopragmatics.github.io/bioversions/) lists several datasets. Please let me know if this is okay.

Also, this schema doesn't fully conform to this draft, so is it valid if I remove that?