### PR TITLE
Remove ELIXIR-PT from Live Deploys list

### DIFF
--- a/_data/live_deployments.json
+++ b/_data/live_deployments.json
@@ -281,18 +281,6 @@
       ]
     },
     {
-      "name": "ELIXIR Portugal",
-      "url": "http://elixir-portugal.org/",
-      "nodes": "PT",
-      "profiles": [
-        {
-          "profileName": "Event",
-          "conformsTo": "0.1",
-          "exampleURL": "http://elixir-portugal.org/event/embo-practical-course-tree-building-advanced-concepts-and-practice-phylogenetic-analysis"
-        }
-      ]
-    },
-    {
       "name": "SIB",
       "url": "https://www.sib.swiss/",
       "nodes": "CH",


### PR DESCRIPTION
The page that we have listed is no longer available. The replacement page no longer has markup embedded, so we need to remove from the live deploy list.

I have checked with E-PT and not had a response back about whether they will reenable the markup.

This fixes issue https://github.com/BioSchemas/specifications/issues/525