### PR TITLE
Enable /liveDeploys/ to land on the page

### DIFF
--- a/pages/liveDeploys.html
+++ b/pages/liveDeploys.html
@@ -2,6 +2,8 @@
 layout: default
 title: Live Deploys
 permalink: "/:basename:output_ext"
+redirct_from:
+- "/:basename:output_ext/"
 exampleHoverText: "View example page"
 schemaHoverText: "Visualise on the Schema.org Markup Validation Tool (SMV)"
 bmuseHoverText: "Retrieve using Bioschemas Scraping service"


### PR DESCRIPTION
I've noticed that https://bioschemas.org/liveDeploys/ is ending up on a 404 page. I think this is the fix we need, but can you check and fix if it isn't.