### PR TITLE
Add standard properties to all profiles

### DIFF
--- a/_includes/specification-table.html
+++ b/_includes/specification-table.html
@@ -5,11 +5,12 @@
 {%- assign mapping_examples = mapping_examples | push: prop %}
 {%- endif %}
 {%- endfor %}
-{%- unless mapping_examples.size < 1 %} <div class="d-inline-block" data-bs-toggle="tooltip" data-bs-placement="top" title="View all examples">
-<button type="button" class="btn btn-primary" data-bs-target="#exampleModal" data-bs-toggle="modal">
-    Examples
-</button>
-</div>
+{%- unless mapping_examples.size < 1 %} 
+<span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" title="View all examples">
+    <button type="button" class="btn btn-primary" data-bs-target="#exampleModal" data-bs-toggle="modal">
+        Examples
+    </button>
+</span>
 <div class="modal fade" id="exampleModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-xl">
         <div class="modal-content">
@@ -24,7 +25,7 @@
 //Property: {{prop.property}}
 {{prop.example}}
 {% endfor %}{% endhighlight %}
-                    <button type="button" data-bs-placement="top" data-bs-toggle="tooltip" title="Copy to clipboard" class="btn btn-primary btn-copy" data-clipboard-target="#bundle-property-examples"><i class="fas fa-copy"></i></button>
+                    <button type="button" data-bs-toggle="tooltip" title="Copy to clipboard" class="btn btn-primary btn-copy" data-clipboard-target="#bundle-property-examples"><i class="fas fa-copy"></i></button>
                 </div>
             </div>
             <div class="modal-footer">
@@ -117,11 +118,11 @@
             <td class="example-column">
                 <!-- Example modal starts here -->
                 {%- unless prop.example == "" %}
-                <div class="d-inline-block" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" title="View <strong>&#8810{{prop.property}}&#8811</strong> example">
+                <span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" data-bs-html="true" title="View <strong>&#8810{{prop.property}}&#8811</strong> example">
                     <button type="button" class="btn btn-primary" data-bs-target="#myModal{{prop.property}}" data-bs-toggle="modal">
                         <i class="fas fa-file-code"></i>
                     </button>
-                </div>
+                </span>
                 <!-- Modal -->
                 </div>
                 <div class="modal fade" id="myModal{{prop.property}}" tabindex="-1" aria-labelledby="myModal{{prop.property}}" aria-hidden="true">
@@ -135,7 +136,7 @@
                             <div class="modal-body">
                                 <div id="{{current_mg}}-example-num-{{forloop.index}}" class="example-code">
                                     {% highlight javascript %}{{prop.example}}{% endhighlight %}
-                                    <button type="button" data-bs-placement="top" data-bs-toggle="tooltip" title="Copy to clipboard" class="btn btn-primary btn-copy" data-clipboard-target="#{{current_mg}}-example-num-{{forloop.index}}"><i class="fas fa-copy"></i></button>
+                                    <button type="button" data-bs-toggle="tooltip" title="Copy to clipboard" class="btn btn-primary btn-copy" data-clipboard-target="#{{current_mg}}-example-num-{{forloop.index}}"><i class="fas fa-copy"></i></button>
                                 </div>
                             </div>
                             <div class="modal-footer">

--- a/_includes/specification-table.html
+++ b/_includes/specification-table.html
@@ -50,13 +50,16 @@
         {%- assign marginality_list = "Minimum,Recommended,Optional" | split: ',' %}
         {%- for current_mg in marginality_list %}
         {%- assign props_list = page.mapping | where: 'marginality', current_mg | sort: 'property' %}
-        {%- if props_list.size > 0%}
+        {%- if props_list.size > 0 or current_mg == 'Minimum' %}
         <tr class="cardinality">
             <td colspan="6">
                 Marginality: <b>{{current_mg}}.</b>
             </td>
         </tr>
         {%- endif%}
+        {% if current_mg == "Minimum" %}
+          {% include standard-properties.html %}
+        {% endif %}
         {%- for prop in props_list %}
         <tr>
             {%- if prop.type == "bioschemas" %}
@@ -132,7 +135,7 @@
                             <div class="modal-body">
                                 <div id="{{current_mg}}-example-num-{{forloop.index}}" class="example-code">
                                     {% highlight javascript %}{{prop.example}}{% endhighlight %}
-                                    <button type="button" data-bs-placement="top" data-bs-toggle="tooltip" title="Copy to clipboard" class="btn btn-primary btn-copy" data-clipboard-target="#{{current_mg}}-example-num-{{forloop.index}}"><i class="fas fa-copy"></i></button> 
+                                    <button type="button" data-bs-placement="top" data-bs-toggle="tooltip" title="Copy to clipboard" class="btn btn-primary btn-copy" data-clipboard-target="#{{current_mg}}-example-num-{{forloop.index}}"><i class="fas fa-copy"></i></button>
                                 </div>
                             </div>
                             <div class="modal-footer">

--- a/_includes/standard-properties.html
+++ b/_includes/standard-properties.html
@@ -1,159 +1,167 @@
 <tr>
-  <td class="property-column">@context</td>
-  <td>URL</td>
-  <td class="description-column">Used to provide the context (namespaces) for the JSON-LD file. <br/>Not needed in other serialisations.</td>
-  <td>ONE</td>
-  <td class="control-vocabulary-column"></td>
-  <td class="example-column">
-      <!-- Example modal starts here -->
-      <div class="example-button">
-          <span class="tooltiptext">View <strong>&#8810@context&#8811</strong> example</span>
-          <button type="button" class="btn btn-bioschema" data-toggle="modal" data-target="#myModalContext"><i class="fas fa-file-code"></i></button>
-      </div>
-      <!-- Modal -->
-      <div id="myModalContext" class="modal fade" role="dialog">
-          <div class="modal-dialog modal-large">
-
-              <!-- Modal content-->
-              <div class="modal-content">
-              <div class="modal-header">
-                  <span class="modal-title">Property <strong>&#8810@context&#8811</strong> example</span>
-                  <button type="button" class="close" data-dismiss="modal">&times;</button>
-              </div>
-              <div class="modal-body">
-                  <div id="{{current_mg}}-example-num-{{forloop.index}}" class="example-code">
-                  {% highlight javascript %}
-                  {
-                    "@context": "https://schema.org/"
-                  }{% endhighlight %}
-                  <button type="button" class="btn btn-primary btn-copy" data-clipboard-target="#{{current_mg}}-example-num-{{forloop.index}}"><i class="fas fa-copy"></i></button>
-                  </div>
-              </div>
-              <div class="modal-footer">
-                  <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-              </div>
-              </div>
-          </div>
-      </div>
-  </td>
+    <td class="property-column">@context</td>
+    <td>URL</td>
+    <td class="description-column">Used to provide the context (namespaces) for the JSON-LD file. <br />Not needed in other serialisations.</td>
+    <td>ONE</td>
+    <td class="control-vocabulary-column"></td>
+    <td class="example-column">
+        <!-- Example modal starts here -->
+        <div class="d-inline-block" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" title="View <strong>&#8810@context&#8811</strong> example">
+            <button type="button" class="btn btn-primary" data-bs-target="#myModalContext" data-bs-toggle="modal">
+                <i class="fas fa-file-code"></i>
+            </button>
+        </div>
+        <!-- Modal -->
+        </div>
+        <div class="modal fade" id="myModalContext" tabindex="-1" aria-labelledby="myModalContext" aria-hidden="true">
+            <div class="modal-dialog modal-xl">
+                <!-- Modal content-->
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="exampleModalLabel">Property <strong>&#8810@context&#8811</strong> example</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div id="{{current_mg}}-example-num-{{forloop.index}}" class="example-code">
+{%- highlight javascript %}
+{
+    "@context": "https://schema.org/"
+}
+{%- endhighlight %}
+                            <button type="button" data-bs-placement="top" data-bs-toggle="tooltip" title="Copy to clipboard" class="btn btn-primary btn-copy" data-clipboard-target="#{{current_mg}}-example-num-{{forloop.index}}"><i class="fas fa-copy"></i></button>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Close</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </td>
 </tr>
 <tr>
-  <td class="property-column">@type</td>
-  <td>Text</td>
-  <td class="description-column">Schema.org/Bioschemas class for the resource declared using JSON-LD syntax. For other serialisations please use the appropriate mechanism.<br/>While it is permissible to provide multiple types, it is preferred to use a single type.</td>
-  <td>MANY</td>
-  <td class="control-vocabulary-column">Schema.org, Bioschemas</td>
-  <td class="example-column">
-      <!-- Example modal starts here -->
-      <div class="example-button">
-          <span class="tooltiptext">View <strong>&#8810@type&#8811</strong> example</span>
-          <button type="button" class="btn btn-bioschema" data-toggle="modal" data-target="#myModalid"><i class="fas fa-file-code"></i></button>
-      </div>
-      <!-- Modal -->
-      <div id="myModalid" class="modal fade" role="dialog">
-          <div class="modal-dialog modal-large">
-
-              <!-- Modal content-->
-              <div class="modal-content">
-              <div class="modal-header">
-                  <span class="modal-title">Property <strong>&#8810@type&#8811</strong> example</span>
-                  <button type="button" class="close" data-dismiss="modal">&times;</button>
-              </div>
-              <div class="modal-body">
-                  <div id="{{current_mg}}-example-num-{{forloop.index}}" class="example-code">
-                  {% highlight javascript %}
-                  {
-                    "@type": "{{page.parent_type}}"
-                  }{% endhighlight %}
-                  <button type="button" class="btn btn-primary btn-copy" data-clipboard-target="#{{current_mg}}-example-num-{{forloop.index}}"><i class="fas fa-copy"></i></button>
-                  </div>
-              </div>
-              <div class="modal-footer">
-                  <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-              </div>
-              </div>
-          </div>
-      </div>
-  </td>
+    <td class="property-column">@type</td>
+    <td>Text</td>
+    <td class="description-column">Schema.org/Bioschemas class for the resource declared using JSON-LD syntax. For other serialisations please use the appropriate mechanism.<br />While it is permissible to provide multiple types, it is preferred to use a single type.</td>
+    <td>MANY</td>
+    <td class="control-vocabulary-column">Schema.org, Bioschemas</td>
+    <td class="example-column">
+        <!-- Example modal starts here -->
+        <div class="d-inline-block" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" title="View <strong>&#8810@type&#8811</strong> example">
+            <button type="button" class="btn btn-primary" data-bs-target="#myModalType" data-bs-toggle="modal">
+                <i class="fas fa-file-code"></i>
+            </button>
+        </div>
+        <!-- Modal -->
+        </div>
+        <div class="modal fade" id="myModalType" tabindex="-1" aria-labelledby="myModalType" aria-hidden="true">
+            <div class="modal-dialog modal-xl">
+                <!-- Modal content-->
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="exampleModalLabel">Property <strong>&#8810@type&#8811</strong> example</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div id="{{current_mg}}-example-num-{{forloop.index}}" class="example-code">
+{%- highlight javascript %}
+{
+    "@type": "{{page.parent_type}}"
+}
+{%- endhighlight %}
+                            <button type="button" data-bs-placement="top" data-bs-toggle="tooltip" title="Copy to clipboard" class="btn btn-primary btn-copy" data-clipboard-target="#{{current_mg}}-example-num-{{forloop.index}}"><i class="fas fa-copy"></i></button>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Close</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </td>
 </tr>
 <tr>
-  <td class="property-column">@id</td>
-  <td>IRI</td>
-  <td class="description-column">Used to distinguish the resource being described in JSON-LD. For other serialisations use the appropriate approach.</td>
-  <td>ONE</td>
-  <td class="control-vocabulary-column"></td>
-  <td class="example-column">
-      <!-- Example modal starts here -->
-      <div class="example-button">
-          <span class="tooltiptext">View <strong>&#8810@id&#8811</strong> example</span>
-          <button type="button" class="btn btn-bioschema" data-toggle="modal" data-target="#myModalType"><i class="fas fa-file-code"></i></button>
-      </div>
-      <!-- Modal -->
-      <div id="myModalType" class="modal fade" role="dialog">
-          <div class="modal-dialog modal-large">
-
-              <!-- Modal content-->
-              <div class="modal-content">
-              <div class="modal-header">
-                  <span class="modal-title">Property <strong>&#8810@id&#8811</strong> example</span>
-                  <button type="button" class="close" data-dismiss="modal">&times;</button>
-              </div>
-              <div class="modal-body">
-                  <div id="{{current_mg}}-example-num-{{forloop.index}}" class="example-code">
-                  {% highlight javascript %}
-                  {
-                    "@id": "http://example.com/entity/A12345"
-                  }{% endhighlight %}
-                  <button type="button" class="btn btn-primary btn-copy" data-clipboard-target="#{{current_mg}}-example-num-{{forloop.index}}"><i class="fas fa-copy"></i></button>
-                  </div>
-              </div>
-              <div class="modal-footer">
-                  <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-              </div>
-              </div>
-          </div>
-      </div>
-  </td>
+    <td class="property-column">@id</td>
+    <td>IRI</td>
+    <td class="description-column">Used to distinguish the resource being described in JSON-LD. For other serialisations use the appropriate approach.</td>
+    <td>ONE</td>
+    <td class="control-vocabulary-column"></td>
+    <td class="example-column">
+        <!-- Example modal starts here -->
+        <div class="d-inline-block" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" title="View <strong>&#8810@id&#8811</strong> example">
+            <button type="button" class="btn btn-primary" data-bs-target="#myModalid" data-bs-toggle="modal">
+                <i class="fas fa-file-code"></i>
+            </button>
+        </div>
+        <!-- Modal -->
+        </div>
+        <div class="modal fade" id="myModalid" tabindex="-1" aria-labelledby="myModalid" aria-hidden="true">
+            <div class="modal-dialog modal-xl">
+                <!-- Modal content-->
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="exampleModalLabel">Property <strong>&#8810@id&#8811</strong> example</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div id="{{current_mg}}-example-num-{{forloop.index}}" class="example-code">
+{%- highlight javascript %}
+{
+    "@id": "http://example.com/entity/A12345"
+}
+{%- endhighlight %}
+                            <button type="button" data-bs-placement="top" data-bs-toggle="tooltip" title="Copy to clipboard" class="btn btn-primary btn-copy" data-clipboard-target="#{{current_mg}}-example-num-{{forloop.index}}"><i class="fas fa-copy"></i></button>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Close</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </td>
 </tr>
 <tr>
-  <td class="property-column">dct:conformsTo</td>
-  <td>IRI</td>
-  <td class="description-column">Used to state the Bioschemas profile that the markup relates to. The versioned URL of the profile must be used.<br/>Note that we use a CURIE in the table here but the full URL for Dublin Core terms must be used in the markup (http://purl.org/dc/terms/conformsTo), see example.</td>
-  <td>ONE</td>
-  <td class="control-vocabulary-column">Bioschemas profile versioned URL</td>
-  <td class="example-column">
-      <!-- Example modal starts here -->
-      <div class="example-button">
-          <span class="tooltiptext">View <strong>&#8810dct:conformsTo&#8811</strong> example</span>
-          <button type="button" class="btn btn-bioschema" data-toggle="modal" data-target="#myModalconformsTo"><i class="fas fa-file-code"></i></button>
-      </div>
-      <!-- Modal -->
-      <div id="myModalconformsTo" class="modal fade" role="dialog">
-          <div class="modal-dialog modal-large">
-
-              <!-- Modal content-->
-              <div class="modal-content">
-              <div class="modal-header">
-                  <span class="modal-title">Property <strong>&#8810dct:conformsTo&#8811</strong> example</span>
-                  <button type="button" class="close" data-dismiss="modal">&times;</button>
-              </div>
-              <div class="modal-body">
-                  <div id="{{current_mg}}-example-num-{{forloop.index}}" class="example-code">
-                  {% highlight javascript %}
-                  {
-                    "http://purl.org/dc/terms/conformsTo": {
-                      "@id": "https://bioschemas.org{{page.url}}",
-                      "@type": "CreativeWork"
-                    }
-                  }{% endhighlight %}
-                  <button type="button" class="btn btn-primary btn-copy" data-clipboard-target="#{{current_mg}}-example-num-{{forloop.index}}"><i class="fas fa-copy"></i></button>
-                  </div>
-              </div>
-              <div class="modal-footer">
-                  <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-              </div>
-              </div>
-          </div>
-      </div>
-  </td>
+    <td class="property-column">dct:conformsTo</td>
+    <td>IRI</td>
+    <td class="description-column">Used to state the Bioschemas profile that the markup relates to. The versioned URL of the profile must be used.<br />Note that we use a CURIE in the table here but the full URL for Dublin Core terms must be used in the markup (http://purl.org/dc/terms/conformsTo), see example.</td>
+    <td>ONE</td>
+    <td class="control-vocabulary-column">Bioschemas profile versioned URL</td>
+    <td class="example-column">
+        <!-- Example modal starts here -->
+        <div class="d-inline-block" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" title="View <strong>&#8810dct:conformsTo&#8811</strong> example">
+            <button type="button" class="btn btn-primary" data-bs-target="#myModalconformsTo" data-bs-toggle="modal">
+                <i class="fas fa-file-code"></i>
+            </button>
+        </div>
+        <!-- Modal -->
+        </div>
+        <div class="modal fade" id="myModalconformsTo" tabindex="-1" aria-labelledby="myModalconformsTo" aria-hidden="true">
+            <div class="modal-dialog modal-xl">
+                <!-- Modal content-->
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="exampleModalLabel">Property <strong>&#8810dct:conformsTo&#8811</strong> example</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div id="{{current_mg}}-example-num-{{forloop.index}}" class="example-code">
+{%- highlight javascript %}
+{
+    "http://purl.org/dc/terms/conformsTo": {
+        "@id": "https://bioschemas.org{{page.url}}",
+        "@type": "CreativeWork"
+    }
+}
+{%- endhighlight %}
+                            <button type="button" data-bs-placement="top" data-bs-toggle="tooltip" title="Copy to clipboard" class="btn btn-primary btn-copy" data-clipboard-target="#{{current_mg}}-example-num-{{forloop.index}}"><i class="fas fa-copy"></i></button>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Close</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </td>
 </tr>

--- a/_includes/standard-properties.html
+++ b/_includes/standard-properties.html
@@ -1,6 +1,6 @@
 <tr>
-    <td class="property-column">@context</td>
-    <td>URL</td>
+    <td class="property-column"><a href="https://www.w3.org/TR/json-ld/#dfn-context" target="_blank" class="external" rel="noopener">@context</a></td>
+    <td><a href="http://schema.org/URL" target="_blank" rel="noopener">URL</a></td>
     <td class="description-column">Used to provide the context (namespaces) for the JSON-LD file. <br />Not needed in other serialisations.</td>
     <td>ONE</td>
     <td class="control-vocabulary-column"></td>
@@ -40,8 +40,8 @@
     </td>
 </tr>
 <tr>
-    <td class="property-column">@type</td>
-    <td>Text</td>
+    <td class="property-column"><a href="https://www.w3.org/TR/json-ld/#specifying-the-type" target="_blank" class="external" rel="noopener">@type</a></td>
+    <td><a href="http://schema.org/Text" target="_blank" rel="noopener">Text</a></td>
     <td class="description-column">Schema.org/Bioschemas class for the resource declared using JSON-LD syntax. For other serialisations please use the appropriate mechanism.<br />While it is permissible to provide multiple types, it is preferred to use a single type.</td>
     <td>MANY</td>
     <td class="control-vocabulary-column">Schema.org, Bioschemas</td>
@@ -81,8 +81,8 @@
     </td>
 </tr>
 <tr>
-    <td class="property-column">@id</td>
-    <td>IRI</td>
+    <td class="property-column"><a href="https://www.w3.org/TR/json-ld/#node-identifiers" target="_blank" class="external" rel="noopener">@id</a></td>
+    <td><a href="https://datatracker.ietf.org/doc/html/rfc3987#section-2" target="_blank" class="external" rel="noopener">IRI</a></td>
     <td class="description-column">Used to distinguish the resource being described in JSON-LD. For other serialisations use the appropriate approach.</td>
     <td>ONE</td>
     <td class="control-vocabulary-column"></td>
@@ -122,8 +122,8 @@
     </td>
 </tr>
 <tr>
-    <td class="property-column">dct:conformsTo</td>
-    <td>IRI</td>
+    <td class="property-column"><a href="http://purl.org/dc/terms/conformsTo" target="_blank" class="external" rel="noopener">dct:conformsTo</a></td>
+    <td><a href="https://datatracker.ietf.org/doc/html/rfc3987#section-2" target="_blank" class="external" rel="noopener">IRI</a></td>
     <td class="description-column">Used to state the Bioschemas profile that the markup relates to. The versioned URL of the profile must be used.<br />Note that we use a CURIE in the table here but the full URL for Dublin Core terms must be used in the markup (http://purl.org/dc/terms/conformsTo), see example.</td>
     <td>ONE</td>
     <td class="control-vocabulary-column">Bioschemas profile versioned URL</td>

--- a/_includes/standard-properties.html
+++ b/_includes/standard-properties.html
@@ -6,11 +6,11 @@
     <td class="control-vocabulary-column"></td>
     <td class="example-column">
         <!-- Example modal starts here -->
-        <div class="d-inline-block" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" title="View <strong>&#8810@context&#8811</strong> example">
+        <span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" data-bs-html="true" title="View <strong>&#8810@context&#8811</strong> example">
             <button type="button" class="btn btn-primary" data-bs-target="#myModalContext" data-bs-toggle="modal">
                 <i class="fas fa-file-code"></i>
             </button>
-        </div>
+        </span>
         <!-- Modal -->
         </div>
         <div class="modal fade" id="myModalContext" tabindex="-1" aria-labelledby="myModalContext" aria-hidden="true">
@@ -28,7 +28,7 @@
     "@context": "https://schema.org/"
 }
 {%- endhighlight %}
-                            <button type="button" data-bs-placement="top" data-bs-toggle="tooltip" title="Copy to clipboard" class="btn btn-primary btn-copy" data-clipboard-target="#{{current_mg}}-example-num-{{forloop.index}}"><i class="fas fa-copy"></i></button>
+                            <button type="button" data-bs-toggle="tooltip" title="Copy to clipboard" class="btn btn-primary btn-copy" data-clipboard-target="#{{current_mg}}-example-num-{{forloop.index}}"><i class="fas fa-copy"></i></button>
                         </div>
                     </div>
                     <div class="modal-footer">
@@ -47,11 +47,11 @@
     <td class="control-vocabulary-column">Schema.org, Bioschemas</td>
     <td class="example-column">
         <!-- Example modal starts here -->
-        <div class="d-inline-block" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" title="View <strong>&#8810@type&#8811</strong> example">
+        <span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" data-bs-html="true" title="View <strong>&#8810@type&#8811</strong> example">
             <button type="button" class="btn btn-primary" data-bs-target="#myModalType" data-bs-toggle="modal">
                 <i class="fas fa-file-code"></i>
             </button>
-        </div>
+        </span>
         <!-- Modal -->
         </div>
         <div class="modal fade" id="myModalType" tabindex="-1" aria-labelledby="myModalType" aria-hidden="true">
@@ -69,7 +69,7 @@
     "@type": "{{page.parent_type}}"
 }
 {%- endhighlight %}
-                            <button type="button" data-bs-placement="top" data-bs-toggle="tooltip" title="Copy to clipboard" class="btn btn-primary btn-copy" data-clipboard-target="#{{current_mg}}-example-num-{{forloop.index}}"><i class="fas fa-copy"></i></button>
+                            <button type="button" data-bs-toggle="tooltip" title="Copy to clipboard" class="btn btn-primary btn-copy" data-clipboard-target="#{{current_mg}}-example-num-{{forloop.index}}"><i class="fas fa-copy"></i></button>
                         </div>
                     </div>
                     <div class="modal-footer">
@@ -88,11 +88,11 @@
     <td class="control-vocabulary-column"></td>
     <td class="example-column">
         <!-- Example modal starts here -->
-        <div class="d-inline-block" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" title="View <strong>&#8810@id&#8811</strong> example">
+        <span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" data-bs-html="true" title="View <strong>&#8810@id&#8811</strong> example">
             <button type="button" class="btn btn-primary" data-bs-target="#myModalid" data-bs-toggle="modal">
                 <i class="fas fa-file-code"></i>
             </button>
-        </div>
+        </span>
         <!-- Modal -->
         </div>
         <div class="modal fade" id="myModalid" tabindex="-1" aria-labelledby="myModalid" aria-hidden="true">
@@ -110,7 +110,7 @@
     "@id": "http://example.com/entity/A12345"
 }
 {%- endhighlight %}
-                            <button type="button" data-bs-placement="top" data-bs-toggle="tooltip" title="Copy to clipboard" class="btn btn-primary btn-copy" data-clipboard-target="#{{current_mg}}-example-num-{{forloop.index}}"><i class="fas fa-copy"></i></button>
+                            <button type="button" data-bs-toggle="tooltip" title="Copy to clipboard" class="btn btn-primary btn-copy" data-clipboard-target="#{{current_mg}}-example-num-{{forloop.index}}"><i class="fas fa-copy"></i></button>
                         </div>
                     </div>
                     <div class="modal-footer">
@@ -129,11 +129,11 @@
     <td class="control-vocabulary-column">Bioschemas profile versioned URL</td>
     <td class="example-column">
         <!-- Example modal starts here -->
-        <div class="d-inline-block" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" title="View <strong>&#8810dct:conformsTo&#8811</strong> example">
+        <span class="d-inline-block" tabindex="0" data-bs-toggle="tooltip" data-bs-html="true" title="View <strong>&#8810dct:conformsTo&#8811</strong> example">
             <button type="button" class="btn btn-primary" data-bs-target="#myModalconformsTo" data-bs-toggle="modal">
                 <i class="fas fa-file-code"></i>
             </button>
-        </div>
+        </span>
         <!-- Modal -->
         </div>
         <div class="modal fade" id="myModalconformsTo" tabindex="-1" aria-labelledby="myModalconformsTo" aria-hidden="true">
@@ -154,7 +154,7 @@
     }
 }
 {%- endhighlight %}
-                            <button type="button" data-bs-placement="top" data-bs-toggle="tooltip" title="Copy to clipboard" class="btn btn-primary btn-copy" data-clipboard-target="#{{current_mg}}-example-num-{{forloop.index}}"><i class="fas fa-copy"></i></button>
+                            <button type="button" data-bs-toggle="tooltip" title="Copy to clipboard" class="btn btn-primary btn-copy" data-clipboard-target="#{{current_mg}}-example-num-{{forloop.index}}"><i class="fas fa-copy"></i></button>
                         </div>
                     </div>
                     <div class="modal-footer">

--- a/_includes/standard-properties.html
+++ b/_includes/standard-properties.html
@@ -1,0 +1,159 @@
+<tr>
+  <td class="property-column">@context</td>
+  <td>URL</td>
+  <td class="description-column">Used to provide the context (namespaces) for the JSON-LD file. <br/>Not needed in other serialisations.</td>
+  <td>ONE</td>
+  <td class="control-vocabulary-column"></td>
+  <td class="example-column">
+      <!-- Example modal starts here -->
+      <div class="example-button">
+          <span class="tooltiptext">View <strong>&#8810@context&#8811</strong> example</span>
+          <button type="button" class="btn btn-bioschema" data-toggle="modal" data-target="#myModalContext"><i class="fas fa-file-code"></i></button>
+      </div>
+      <!-- Modal -->
+      <div id="myModalContext" class="modal fade" role="dialog">
+          <div class="modal-dialog modal-large">
+
+              <!-- Modal content-->
+              <div class="modal-content">
+              <div class="modal-header">
+                  <span class="modal-title">Property <strong>&#8810@context&#8811</strong> example</span>
+                  <button type="button" class="close" data-dismiss="modal">&times;</button>
+              </div>
+              <div class="modal-body">
+                  <div id="{{current_mg}}-example-num-{{forloop.index}}" class="example-code">
+                  {% highlight javascript %}
+                  {
+                    "@context": "https://schema.org/"
+                  }{% endhighlight %}
+                  <button type="button" class="btn btn-primary btn-copy" data-clipboard-target="#{{current_mg}}-example-num-{{forloop.index}}"><i class="fas fa-copy"></i></button>
+                  </div>
+              </div>
+              <div class="modal-footer">
+                  <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+              </div>
+              </div>
+          </div>
+      </div>
+  </td>
+</tr>
+<tr>
+  <td class="property-column">@type</td>
+  <td>Text</td>
+  <td class="description-column">Schema.org/Bioschemas class for the resource declared using JSON-LD syntax. For other serialisations please use the appropriate mechanism.<br/>While it is permissible to provide multiple types, it is preferred to use a single type.</td>
+  <td>MANY</td>
+  <td class="control-vocabulary-column">Schema.org, Bioschemas</td>
+  <td class="example-column">
+      <!-- Example modal starts here -->
+      <div class="example-button">
+          <span class="tooltiptext">View <strong>&#8810@type&#8811</strong> example</span>
+          <button type="button" class="btn btn-bioschema" data-toggle="modal" data-target="#myModalid"><i class="fas fa-file-code"></i></button>
+      </div>
+      <!-- Modal -->
+      <div id="myModalid" class="modal fade" role="dialog">
+          <div class="modal-dialog modal-large">
+
+              <!-- Modal content-->
+              <div class="modal-content">
+              <div class="modal-header">
+                  <span class="modal-title">Property <strong>&#8810@type&#8811</strong> example</span>
+                  <button type="button" class="close" data-dismiss="modal">&times;</button>
+              </div>
+              <div class="modal-body">
+                  <div id="{{current_mg}}-example-num-{{forloop.index}}" class="example-code">
+                  {% highlight javascript %}
+                  {
+                    "@type": "{{page.parent_type}}"
+                  }{% endhighlight %}
+                  <button type="button" class="btn btn-primary btn-copy" data-clipboard-target="#{{current_mg}}-example-num-{{forloop.index}}"><i class="fas fa-copy"></i></button>
+                  </div>
+              </div>
+              <div class="modal-footer">
+                  <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+              </div>
+              </div>
+          </div>
+      </div>
+  </td>
+</tr>
+<tr>
+  <td class="property-column">@id</td>
+  <td>IRI</td>
+  <td class="description-column">Used to distinguish the resource being described in JSON-LD. For other serialisations use the appropriate approach.</td>
+  <td>ONE</td>
+  <td class="control-vocabulary-column"></td>
+  <td class="example-column">
+      <!-- Example modal starts here -->
+      <div class="example-button">
+          <span class="tooltiptext">View <strong>&#8810@id&#8811</strong> example</span>
+          <button type="button" class="btn btn-bioschema" data-toggle="modal" data-target="#myModalType"><i class="fas fa-file-code"></i></button>
+      </div>
+      <!-- Modal -->
+      <div id="myModalType" class="modal fade" role="dialog">
+          <div class="modal-dialog modal-large">
+
+              <!-- Modal content-->
+              <div class="modal-content">
+              <div class="modal-header">
+                  <span class="modal-title">Property <strong>&#8810@id&#8811</strong> example</span>
+                  <button type="button" class="close" data-dismiss="modal">&times;</button>
+              </div>
+              <div class="modal-body">
+                  <div id="{{current_mg}}-example-num-{{forloop.index}}" class="example-code">
+                  {% highlight javascript %}
+                  {
+                    "@id": "http://example.com/entity/A12345"
+                  }{% endhighlight %}
+                  <button type="button" class="btn btn-primary btn-copy" data-clipboard-target="#{{current_mg}}-example-num-{{forloop.index}}"><i class="fas fa-copy"></i></button>
+                  </div>
+              </div>
+              <div class="modal-footer">
+                  <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+              </div>
+              </div>
+          </div>
+      </div>
+  </td>
+</tr>
+<tr>
+  <td class="property-column">dct:conformsTo</td>
+  <td>IRI</td>
+  <td class="description-column">Used to state the Bioschemas profile that the markup relates to. The versioned URL of the profile must be used.<br/>Note that we use a CURIE in the table here but the full URL for Dublin Core terms must be used in the markup (http://purl.org/dc/terms/conformsTo), see example.</td>
+  <td>ONE</td>
+  <td class="control-vocabulary-column">Bioschemas profile versioned URL</td>
+  <td class="example-column">
+      <!-- Example modal starts here -->
+      <div class="example-button">
+          <span class="tooltiptext">View <strong>&#8810dct:conformsTo&#8811</strong> example</span>
+          <button type="button" class="btn btn-bioschema" data-toggle="modal" data-target="#myModalconformsTo"><i class="fas fa-file-code"></i></button>
+      </div>
+      <!-- Modal -->
+      <div id="myModalconformsTo" class="modal fade" role="dialog">
+          <div class="modal-dialog modal-large">
+
+              <!-- Modal content-->
+              <div class="modal-content">
+              <div class="modal-header">
+                  <span class="modal-title">Property <strong>&#8810dct:conformsTo&#8811</strong> example</span>
+                  <button type="button" class="close" data-dismiss="modal">&times;</button>
+              </div>
+              <div class="modal-body">
+                  <div id="{{current_mg}}-example-num-{{forloop.index}}" class="example-code">
+                  {% highlight javascript %}
+                  {
+                    "http://purl.org/dc/terms/conformsTo": {
+                      "@id": "https://bioschemas.org{{page.url}}",
+                      "@type": "CreativeWork"
+                    }
+                  }{% endhighlight %}
+                  <button type="button" class="btn btn-primary btn-copy" data-clipboard-target="#{{current_mg}}-example-num-{{forloop.index}}"><i class="fas fa-copy"></i></button>
+                  </div>
+              </div>
+              <div class="modal-footer">
+                  <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+              </div>
+              </div>
+          </div>
+      </div>
+  </td>
+</tr>

--- a/pages/_posts/2021-10-13-Standard-Properties.md
+++ b/pages/_posts/2021-10-13-Standard-Properties.md
@@ -7,7 +7,7 @@ tags:
 ---
 A standard set of properties have been added to all Bioschemas [profiles](/profiles/). These properties allow consumers of markup to more easily understand the markup, and to validate it against the relevant profile. Essentially the properties form a boilerplate for any markup, see following code snippet for an example protein taken from [DisProt](https://disprot.org/).
 
-```JSON
+```json
 {
   "@context": "https://schema.org/",
   "@type": "Protein",

--- a/pages/_posts/2021-10-13-Standard-Properties.md
+++ b/pages/_posts/2021-10-13-Standard-Properties.md
@@ -1,0 +1,23 @@
+---
+layout: post
+title: "Standard Properties"
+tags:
+- Community
+- Profile
+---
+A standard set of properties have been added to all Bioschemas [profiles](/profiles/). These properties allow consumers of markup to more easily understand the markup, and to validate it against the relevant profile. Essentially the properties form a boilerplate for any markup, see following code snippet for an example protein taken from [DisProt](https://disprot.org/).
+
+```JSON
+{
+  "@context": "https://schema.org/",
+  "@type": "Protein",
+  "@id": "https://disprot.org/DP00003",
+  "http://purl.org/dc/terms/conformsTo": {
+    "@id": "https://bioschemas.org/profiles/Protein/0.11-RELEASE",
+    "@type": "CreativeWork"
+  },
+  ...
+}
+```
+
+Note that while the properties are stated in the JSON-LD form, there are equivalents for RDFa.

--- a/pages/_tutorials/howto/howto_create_new_profile.md
+++ b/pages/_tutorials/howto/howto_create_new_profile.md
@@ -35,11 +35,11 @@ bioschemas:
     name: "Kenneth McLeod"
     "@id": https://bioschemas.org/people/KennethMcLeod
     url: https://bioschemas.org/people/KennethMcLeod
-  dateModified: 2021-07-22
+  dateModified: 2021-10-13
   description: "In this how-to, we will guide you through the necessary steps to create a new Bioschemas profile."
   keywords: "schema.org, markup, structured data, bioschemas profile"
   license: CC-BY 4.0
-  version: 1.0
+  version: 1.1
 ---
 
 ## 1. Before you start
@@ -52,8 +52,8 @@ The development steps for a profile are:
 1. Identify the base Schema.org type for the profile, or develop a new Bioschemas type;  
 *__TODO:__ Add link to tutorial for creating a new type*
 
-2. For each property defined for the type
-
+2. For each property defined for the type  
+   _Note that the properties `@id`, `@type`, `@context`, and `dct:conformsTo` are automatically added as minimal properties to all profiles._
     1. Decide its cardinality recommendation (minimal, recommended, or optional) based on the defined use cases, with a goal of having no more than 6 minimal properties;
 
     2. Identify, where appropriate, controlled vocabulary terms from existing domain vocabularies to use as values for the property;
@@ -125,12 +125,12 @@ Examples should be stored in a subfolder indicating which version of the profile
 
 ### 4.2. Profile Properties
 
-The second task is to populate the profile with the properties from your chosen Schema.org or Bioschemas type. These should be included in the `Schema.org mapping` tab. This tab includes the following fields which are split into a `schema.org` section and a `bioschemas` section.
+The second task is to populate the profile with the properties from your chosen Schema.org or Bioschemas type. These should be included in the `Schema.org mapping` tab. This tab includes the following fields which are split into a `schema.org` section and a `bioschemas` section. There is no need to include the automatically added minimal properties to the GSheet.
 
-#### 4.2.1. schema.org Columns
-These columns are copy-pasted from a schema.org type definition page, or filled with types of external ontologies.
-- __Property:__ Name of the property from the selected schema.org type or external ontology type, i.e., SIO:is transcribe into. When an external ontology is used the __Type__ you must select "external" from the dropdown on the __Type__ column.
-- __Expected Type:__ Expected type for the property. This could be a schema.org property, a bioschemas property or an external ontology one, e.g., URL, BioChemEntity, Thing. These values can be separated by " or " or ",".
+#### 4.2.1. Schema.org Columns
+These columns are copy-pasted from a Schema.org type definition page, or filled with types of external ontologies.
+- __Property:__ Name of the property from the selected Schema.org type or external ontology type, e.g., `SIO:is transcribe into`. When an external ontology is used the __Type__ you must select "external" from the dropdown on the __Type__ column.
+- __Expected Type:__ Expected type for the property. This could be a Schema.org property, a bioschemas property or an external ontology one, e.g., URL, BioChemEntity, Thing. These values can be separated by " or " or ",".
 - __Description:__ Description of the property. This field accepts __Markdown__ formatting.
 - __Type:__ Type for the property, possible types are: _schema.org, pending, external or bioschemas_. Leaving this field blank has the same effect as selecting schema.org. For _external_ and _bioschemas_ type please fill the _Type URL_ column.
 - __Type URL:__ URL for the property type; it should be filled when using _bioschemas_ or _external_ as type in order to link the property on the website.
@@ -142,7 +142,7 @@ Note that all the expected types need to appear on a separate line within their 
 {% include image.html file="tutorials/howto/images_create_new_profile/propertiesInitial.png" alt="MedicalCondition properties after they have been pasted into the Schema.org tab" %}
 
 
-#### 4.2.2. bioschemas Columns
+#### 4.2.2. Bioschemas Columns
 These columns control which of the properties in the GSheet will appear in the Bioschemas profile.
 - __BSC Description:__ Additional text describing the usage of the property within a Bioschemas context. This field accepts __Markdown__ formatting.
 - __Marginality:__ Specifies the marginality level for the property with the options of `Minimum`, `Recommended`, or `Optional`. If left blank, then the property will not appear in the profile.

--- a/pages/_tutorials/howto/howto_new_profile_version.md
+++ b/pages/_tutorials/howto/howto_new_profile_version.md
@@ -135,7 +135,7 @@ You are now ready to publish the new draft version on the Bioschemas website.
 
 * If you have not done so yet, clone the [Bioschemas website repository](https://github.com/BioSchemas/bioschemas.github.io) so you have a local copy
 * Open your local copy in your preferred editor
-* Go to `_profiles/<your profile>`, in this case `_profiles/ScholarlyArticle`
+* Go to `pages/_profiles/<your profile>`, in this case `pages/_profiles/ScholarlyArticle`
 * Create a copy of the latest profile, in our case it is 0.2-DRAFT-2020_12_03.html
 * Rename the copy so it reflects the new draft version, in our case it would be 0.3-DRAFT.html (having the dates as part of the draft name is no longer needed/desired)
 
@@ -174,7 +174,7 @@ Now you are ready to update the part corresponding to the spreadsheet, go to the
   # DO NOT MANUALLY EDIT THE CONTENT
 ```
 
-* Keep the two first lines only, i.e., remove from the line ```spec_info``` all the way to a line with three dashes ```---```, which is right before the line ```<!DOCTYPE HTML>```
+* Keep the two first lines only, i.e., remove from the line ```spec_info``` all the way to a line with three dashes ```---```, which is at the end of the file
 * Add all the lines coming from the YAML file that you got from GO Web
 * Save the file!
 
@@ -207,10 +207,13 @@ Regardless whether it was a minor or major change, it is always a good idea to h
 * Create a new folder corresponding to your new draft, 0.3-DRAFT in this case
 * Add there the new examples in JSON-LD format using the extension file ```json```
 * If the examples for the previous version are fully compatible with the new version, it is ok if you add a note pointing to the previous examples rather than adding new ones
-* On the examples, always remember to add the ```dct:conformsTo``` property so it points to your profile version, for example
-
+* On the examples, always remember to add the ```dct:conformsTo``` property so it points to your profile version, for example  
+_Note that you should use the full IRI for the DCTerms property_
 ```json
-"http://purl.org/dc/terms/conformsTo": "https://bioschemas.org/profiles/ScholarlyArticle/0.3-DRAFT",
+"http://purl.org/dc/terms/conformsTo": {
+  "@id": "https://bioschemas.org/profiles/ScholarlyArticle/0.3-DRAFT",
+  "@type": "CreativeWork"
+}
 ```
 
 ## 7. Create a Pull Request

--- a/pages/_tutorials/howto/howto_new_profile_version.md
+++ b/pages/_tutorials/howto/howto_new_profile_version.md
@@ -29,11 +29,15 @@ bioschemas:
     name: "Alban Gaignard"
     "@id": https://bioschemas.org/people/AlbanGaignard
     url: https://bioschemas.org/people/AlbanGaignard   
-  dateModified: 2021-07-22
+  - "@type": Person
+    name: "Alasdair Gray"
+    "@id": https://bioschemas.org/people/AlasdairGray
+    url: https://bioschemas.org/people/AlasdairGray
+  dateModified: 2021-10-13
   description: "In this how-to, we will guide you through the necessary steps for you to update a profile, i.e.,create and publish a new draft profile, you need some knowledge on spreadsheets, GitHub, git and Jekyll."
   keywords: "schema.org, markup, structured data, bioschemas profile"
   license: CC-BY 4.0
-  version: 1.0
+  version: 1.1
 ---
 
 ## 1. Prepare your working environment
@@ -41,7 +45,7 @@ bioschemas:
 To update a profile you need access to a couple of Bioschemas resources, here we list them all together with the main role they play in the whole process. We will explain how to use them and what to do with them in later steps.
 
 * Bioschemas specifications [GDrive folder](https://drive.google.com/drive/folders/0B8yXU9SkT3ftaWJtTGYyTTJjck0): to create the spreadsheet corresponding to the new draft profile, you need editing rights
-  * Note 1: a specification in Bioschemas defines either a type (existing in schema.org or created by Bioschemas) or a profile (set of rules on how to use a type). A type specification corresponds to a set of relations, aka properties, between the described type and other types (for instance, the specification for the [type Protein](/types/Protein) includes a property ```associatedDisease``` describing how a relation between a protein and a disease). A profile specification selects the most useful properties for a given type and provides additional information on cardinality, marginality and controlled vocabularies (for instance, the specification for the [Protein profile](/profiles/Protein/) indicates that the property ```associatedDisease``` is recommended and has cardinality MANY)
+  * Note 1: a specification in Bioschemas defines either a type (existing in Schema.org or created by Bioschemas) or a profile (set of rules on how to use a type). A type specification corresponds to a set of relations, aka properties, between the described type and other types (for instance, the specification for the [type Protein](/types/Protein) includes a property ```associatedDisease``` describing how a relation between a protein and a disease). A profile specification selects the most useful properties for a given type and provides additional information on cardinality, marginality and controlled vocabularies (for instance, the specification for the [Protein profile](/profiles/Protein/) indicates that the property ```associatedDisease``` is recommended and has cardinality MANY)
   * Note 2: a GDrive, short for Google Drive, is a file storage and synchronization service developed by Google. Bioschemas uses a GDrive folder to host information related to, for instance, specifications
 * [GOWeb repository](https://github.com/BioSchemas/bioschemas-goweb): to move from the spreadsheet to the website
 * [Website repository](https://github.com/BioSchemas/bioschemas.github.io): to publish the new draft profile, you need editing rights
@@ -63,6 +67,8 @@ A new profile is commonly based on the previous one so the easiest way to start 
   * Note: a mapping file corresponds to a Google spreadsheet and it is the way that Bioschemas uses to do a crosswalk on a profile before adding it to the website. Bioschemas groups will work first on this crosswalk (mapping file, spreadsheet) and when it is ready to go (i.e., the involved people is happy with the content, it has been reviewed and approved), it can be published to the website
 * Rename the copy so it reflects the new draft version, in this case it would be ScholarlyArticle Mapping 0.3-DRAFT
 
+_Note that the properties `@id`, `@type`, `@context`, and `dct:conformsTo` are automatically added as minimal properties to all profiles and are not present in the GSheet._
+
 We will now discuss the different tabs in the spreadsheet and how they are used in updating a profile.
 
 ### 2.1. The Specification Info tab
@@ -76,8 +82,8 @@ In this tab, you need to update the "Description" column. In most cases the actu
     <ul>
       <li>Add examples</li>
       <li>Updates identifier property to MANY so multiple identifiers can be included</li>
-      <li>Uses name for the title (as per schema.org examples) and keeps headline (optional) for compatibility purposes</li>
-      <li>Update ranges as per latest version of schema.org</li>   
+      <li>Uses name for the title (as per Schema.org examples) and keeps headline (optional) for compatibility purposes</li>
+      <li>Update ranges as per latest version of Schema.org</li>   
     </ul>
 
 ```


### PR DESCRIPTION
This PR adds the following properties to the minimal properties for **all** profiles:
- `@context`: loads in the JSON-LD definition of the vocabulary; other serialisations would use full IRIs or mechanisms appropriate to the serialisation.
- `@type`: declares the resource identified in the markup to be of a specific type, e.g. Gene, MolecularEntity, or Protein; non-JSON-LD serialisations would need to use the appropriate mechanism for the serialisation
- `@id`: sets the identifier for the resource, avoiding the introduction of blank nodes in the markup; non-JSON-LD serialisations would use equivalent mechanism
- `dct:conformsTo`: states what profile version the markup complies with, useful for validation engines

This fixes issues:
- https://github.com/BioSchemas/specifications/issues/294
- https://github.com/BioSchemas/specifications/issues/297
- https://github.com/BioSchemas/specifications/issues/481