### PR TITLE
Add example deployments of TrainingMaterial

### DIFF
--- a/_data/live_deployments.json
+++ b/_data/live_deployments.json
@@ -1512,7 +1512,7 @@
         	"profileName": "TrainingMaterial",
         	"conformsTo": "0.9-DRAFT-2020_12_08",
         	"exampleURL": "https://enanomapper.github.io/tutorials/BrowseOntology/Tutorial%20browsing%20eNM%20ontology.html"
-      	},
+      	}
     	]
     },
     {

--- a/_data/live_deployments.json
+++ b/_data/live_deployments.json
@@ -1043,6 +1043,11 @@
           "profileName": "Dataset",
           "conformsTo": "0.4-DRAFT",
           "exampleURL": "https://nanocommons.github.io/datasets/"
+        },
+        {
+          "profileName": "TrainingMaterial",
+          "conformsTo": "0.9-DRAFT",
+          "exampleURL": "https://nanocommons.github.io/tutorials/enteringData"
         }
       ]
     },

--- a/_data/live_deployments.json
+++ b/_data/live_deployments.json
@@ -1500,6 +1500,34 @@
           "highlight": "Bioschemas annotation of 26 protein structures. For these 0.6 million docking results are found in the database"
         }
       ]
+    },
+    {
+      "name": "Browsing the eNanoMapper ontology with BioPortal, AberOWL and Protégé",
+      "description": "Lesson on browsing the eNanoMapper ontology with BioPortal, AberOWL and Protégé",
+      "url": "https://enanomapper.github.io/tutorials/",
+      "nodes": "NL",
+      "sitemap": "https://enanomapper.github.io/tutorials/sitemap.xml",
+      "profiles":[
+      	{
+        	"profileName": "TrainingMaterial",
+        	"conformsTo": "0.9-DRAFT-2020_12_08",
+        	"exampleURL": "https://enanomapper.github.io/tutorials/BrowseOntology/Tutorial%20browsing%20eNM%20ontology.html"
+      	},
+    	]
+    },
+    {
+      "name": "Biomedical semantics, information retrieval and knowledge discovery",
+      "description": "Lecture on biomedical semantics, information retrieval and knowledge discovery",
+      "url": "https://zbmed-semtec.github.io/BioMedSem-IR-KD",
+      "sitemap": "https://zbmed-semtec.github.io/BioMedSem-IR-KD/sitemap",
+      "profiles":[
+        {
+          "profileName": "TrainingMaterial",
+          "conformsTo": "0.9-DRAFT-2020_12_08",
+          "exampleURL": "https://zbmed-semtec.github.io/BioMedSem-IR-KD/docs/Lesson1.html",
+          "highlight": "12"
+        }
+      ]
     }
   ]
 }

--- a/pages/_news/2022-03-22-TrainingMaterials-Deployments.md
+++ b/pages/_news/2022-03-22-TrainingMaterials-Deployments.md
@@ -1,0 +1,9 @@
+---
+layout: post
+title: "Two Deployments of the TrainingMaterial Profile"
+tags:
+- Deployment
+- TrainingMaterial
+---
+
+The [Training Working Group](/groups/Training) are finalising the [TrainingMaterial Profile](/profiles/TrainingMaterial) and now have two deployments of the profile. The first is for a lecture series on [Biomedical semantics, information retrieval and knowledge discovery](https://zbmed-semtec.github.io/BioMedSem-IR-KD/). The second is for a [collection of tutorials on eNanoMapper](https://enanomapper.github.io/tutorials/).

--- a/pages/_news/2022-03-22-TrainingMaterials-Deployments.md
+++ b/pages/_news/2022-03-22-TrainingMaterials-Deployments.md
@@ -1,9 +1,9 @@
 ---
 layout: post
-title: "Two Deployments of the TrainingMaterial Profile"
+title: "Three Deployments of the TrainingMaterial Profile"
 tags:
 - Deployment
 - TrainingMaterial
 ---
 
-The [Training Working Group](/groups/Training) are finalising the [TrainingMaterial Profile](/profiles/TrainingMaterial) and now have two deployments of the profile. The first is for a lecture series on [Biomedical semantics, information retrieval and knowledge discovery](https://zbmed-semtec.github.io/BioMedSem-IR-KD/). The second is for a [collection of tutorials on eNanoMapper](https://enanomapper.github.io/tutorials/).
+The [Training Working Group](/groups/Training) are finalising the [TrainingMaterial Profile](/profiles/TrainingMaterial) and have added three live deployments of the profile. The first is for a lecture series on [Biomedical semantics, information retrieval and knowledge discovery](https://zbmed-semtec.github.io/BioMedSem-IR-KD/). The second is for a [collection of tutorials on eNanoMapper](https://enanomapper.github.io/tutorials/). The third is for the training materials associated with a workshop on [NanoSafety and the Semantic Web](https://nanocommons.github.io/workshops/2021-12-08/).


### PR DESCRIPTION
Add details of two known deployments of the TrainingMaterial profile together with a small news item about them.