### PR TITLE
Add GTN to live deployment list of TrainingMaterial 1.0

### DIFF
--- a/_data/live_deployments.json
+++ b/_data/live_deployments.json
@@ -109,6 +109,19 @@
       ]
     },
     {
+      "name": "Galaxy Training Network",
+      "url": "https://training.galaxyproject.org/",
+      "sitemap": "https://training.galaxyproject.org/sitemap.xml",
+      "nodes": ["DE", "NL", "FR", "GR", "EE"],
+      "profiles": [
+        {
+          "profileName": "TrainingMaterial",
+          "conformsTo": "1.0-RELEASE",
+          "exampleURL": "https://training.galaxyproject.org/training-material/topics/introduction/tutorials/galaxy-intro-101-everyone/tutorial.html"
+        }
+      ]
+    },
+    {
       "name": "EGA",
       "keywords": ["CDR", "DDR"],
       "url": "https://ega-archive.org/",


### PR DESCRIPTION
I see no examples of `nodes` being a list, but it's plural? So it must accept a list, right? Otherwise I can reduce this to just one node but that'd be too bad since it's a great example of cross node collaboration