### PR TITLE
Update Training.md

### DIFF
--- a/_includes/profile-start.html
+++ b/_includes/profile-start.html
@@ -127,7 +127,7 @@
       <div id="leadTable">
          {% for g in group %}
          {% for leader in g.lead %}
-         {% assign lead-id = "/people/" | append: leader %}
+         {% assign lead-id = "/people/" | append: leader.person %}
          {% assign author = site.people | where:"id", lead-id | first %}
          {% if author.homepage or author.github_username or author.orcid %}
          <p><a href="{{ author.url | relative_url }}">{{ author.first-name }} {{ author.last-name }}</a></p>

--- a/_includes/type-start.html
+++ b/_includes/type-start.html
@@ -109,7 +109,7 @@
     <div id="leadTable">
       {% for g in group %}
       {% for leader in g.lead %}
-      {% assign lead-id = "/people/" | append: leader %}
+      {% assign lead-id = "/people/" | append: leader.person %}
       {% assign author = site.people | where:"id", lead-id | first %}
       {% if author.homepage or author.github_username or author.orcid %}
       <p><a href="{{ author.url | relative_url }}">{{ author.first-name }} {{ author.last-name }}</a></p>

--- a/_layouts/group-details.html
+++ b/_layouts/group-details.html
@@ -95,20 +95,15 @@ layout: default
 <h5>Group Leaders</h5>
 <div id="leadTable">
    <ul>
-   {% if page.lead %}
    {% for leader in page.lead %}
-   {% assign lead-id = "/people/" | append: leader %}
-   {% assign author = site.people | where:"id", lead-id | first %}
-      <li><a href="{{ author.url | relative_url }}">{{ author.first-name }} {{ author.last-name }}</a></li>
-   {% endfor %}
-   {% else %}
-   {% for leader in page.current-leads %}
    {% assign lead-id = "/people/" | append: leader.person %}
    {% assign author = site.people | where:"id", lead-id | first %}
-      <li><a href="{{ author.url | relative_url }}">{{ author.first-name }} {{ author.last-name }}</a><br/>
-      (since {{leader.start-date | date_to_long_string}})</li>
+      <li><a href="{{ author.url | relative_url }}">{{ author.first-name }} {{ author.last-name }}</a>
+      {% if leader.start-date %}
+         <br/>(since {{leader.start-date | date_to_long_string}})
+      {% endif %}
+      </li>
    {% endfor %}
-   {% endif %}
    </ul>
 </div>
 <br />

--- a/pages/_groups/Beacons.md
+++ b/pages/_groups/Beacons.md
@@ -6,7 +6,9 @@ collection: groups
 active: true
 type: generic
 description: Specification for Beacon Type
-lead: [SerenaScollen, AudaldLloret]
+lead: 
+- person: SerenaScollen
+- person: AudaldLloret
 email: enquiries@bioschemas.org
 issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Beacon
 folder: https://drive.google.com/drive/folders/0BwpCuN9mloG8WTl6X3hkeFIwems

--- a/pages/_groups/Biodiversity.md
+++ b/pages/_groups/Biodiversity.md
@@ -6,7 +6,9 @@ collection: groups
 active: true
 type: biological
 description: Specification for biodiversity-related profiles and/or types
-lead: [FranckMichel, LeylaGarcia]
+lead: 
+- person: FranckMichel
+- person: LeylaGarcia
 email: enquiries@bioschemas.org
 issues: https://github.com/Bioschemas/specifications/labels/type%3A%20Taxon
 folder: https://drive.google.com/drive/folders/1Fp2AKbb07So7rVvUhnQIjpl8HLPSwpbP

--- a/pages/_groups/BiologicalEntities.md
+++ b/pages/_groups/BiologicalEntities.md
@@ -6,7 +6,10 @@ collection: groups
 active: true
 type: generic
 description: Specification for biological entities
-lead: [CarlosHorro, LeylaGarcia, PhilippeRocca-Serra]
+lead: 
+- person: CarlosHorro
+- person: LeylaGarcia
+- person: PhilippeRocca-Serra
 email: enquiries@bioschemas.org
 issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20biochementity
 folder: https://drive.google.com/open?id=0B0fE3oOZIq44MUxtQWlYYmdvWnc

--- a/pages/_groups/Chemicals.md
+++ b/pages/_groups/Chemicals.md
@@ -6,7 +6,10 @@ collection: groups
 active: true
 type: biological
 description: Specification for protein type
-lead: [EgonWillighagen, RicardoArcila, DavidMendez]
+lead: 
+- person: EgonWillighagen
+- person: RicardoArcila
+- person: DavidMendez
 email: enquiries@bioschemas.org
 issues: https://github.com/Bioschemas/specifications/labels/type%3A%20Chemistry
 folder: https://drive.google.com/drive/folders/0B7J0zlrcfEkGNnk3MXhyb01mTEk

--- a/pages/_groups/Community.md
+++ b/pages/_groups/Community.md
@@ -6,7 +6,9 @@ collection: groups
 active: true
 type: other
 description: 'The objective of this workstream is to support this project and the involvement of the Bioschemas community.'
-lead: [CaroleGoble, AlasdairGray]
+lead: 
+- person: CaroleGoble
+- person: AlasdairGray
 email: enquiries@bioschemas.org
 issues: https://github.com/Bioschemas/bioschemas/labels/topic%3A%20community
 folder: https://drive.google.com/drive/u/1/folders/0Bw_p-HKWUjHoRWgxWHcwVHNQUGM

--- a/pages/_groups/DNA.md
+++ b/pages/_groups/DNA.md
@@ -7,7 +7,9 @@ collection: groups
 active: true
 type: biological
 description: Specification for DNA Type
-lead: [JamesAlastairMcLaughlin, ChristianAtallah]
+lead: 
+- person: JamesAlastairMcLaughlin
+- person: ChristianAtallah
 email: enquiries@bioschemas.org
 issues: https://github.com/Bioschemas/specifications/labels/type%3A%20DNA
 folder: https://drive.google.com/drive/folders/1Ar4E1UivzIfCxi8MB_FzYSkEO_EUbe8e

--- a/pages/_groups/DataRepositories.md
+++ b/pages/_groups/DataRepositories.md
@@ -6,7 +6,8 @@ collection: groups
 active: true
 type: generic
 description: Specification for data catalog profile
-lead: [HenningHermjakob]
+lead: 
+- person: HenningHermjakob
 email: enquiries@bioschemas.org
 issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20DataCatalog
 folder: https://drive.google.com/open?id=0Bw_p-HKWUjHoNDJNUWltYVBkV1k

--- a/pages/_groups/Datasets.md
+++ b/pages/_groups/Datasets.md
@@ -6,7 +6,8 @@ collection: groups
 active: true
 type: generic
 description: Specification for Dataset
-lead: [SusannaSansone]
+lead: 
+- person: SusannaSansone
 email: enquiries@bioschemas.org
 issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Dataset
 folder: https://drive.google.com/open?id=0B2tKthYRS0f5aEhkU1Q4aEE5TEU

--- a/pages/_groups/Diseases.md
+++ b/pages/_groups/Diseases.md
@@ -6,7 +6,9 @@ collection: groups
 active: true
 type: biological
 description: Specifications relating to diseases
-lead: [MarcHanauer, MarcoRoos]
+lead: 
+- person: MarcHanauer
+- person: MarcoRoos
 email: enquiries@bioschemas.org
 issues: https://github.com/Bioschemas/specifications/labels/type%3A%20Disease
 folder: https://drive.google.com/drive/folders/1NklfXu2wDW36t_2ylL26tFV94_pn9Hp_

--- a/pages/_groups/Events.md
+++ b/pages/_groups/Events.md
@@ -6,7 +6,8 @@ collection: groups
 active: false
 type: generic
 description: Specification for events
-lead: [MartinCook]
+lead: 
+- person: MartinCook
 email: enquiries@bioschemas.org
 issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20event
 folder: https://drive.google.com/drive/u/1/folders/0B6crv12s8piRODVQX2U2NHlkdXM

--- a/pages/_groups/Genes.md
+++ b/pages/_groups/Genes.md
@@ -6,7 +6,9 @@ collection: groups
 active: true
 type: generic
 description: Specification for Beacon Type
-lead: [LeylaGarcia, DeniseCarvalho-Silva]
+lead: 
+- person: LeylaGarcia
+- person: DeniseCarvalho-Silva
 email: enquiries@bioschemas.org
 issues: https://github.com/Bioschemas/specifications/labels/type%3A%20Gene
 folder: https://drive.google.com/open?id=10Qf59xiMItW4c48jYh3S1LEd8cCFv0sW

--- a/pages/_groups/LabProtocols.md
+++ b/pages/_groups/LabProtocols.md
@@ -6,7 +6,9 @@ collection: groups
 active: true
 type: generic
 description: Specification for biological laboratory protocol Type
-lead: [OlgaXimenaGiraldo, AlexanderGarcia]
+lead: 
+- person: OlgaXimenaGiraldo
+- person: AlexanderGarcia
 email: enquiries@bioschemas.org
 issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20LabProtocol
 folder: https://drive.google.com/drive/folders/0B0fE3oOZIq44TzFwejFEbE9WdXM

--- a/pages/_groups/Organizations.md
+++ b/pages/_groups/Organizations.md
@@ -6,7 +6,9 @@ collection: groups
 active: false
 type: generic
 description: Specification for organization
-lead: [RafaelJimenez, RichardHolland]
+lead: 
+- person: RafaelJimenez
+- person: RichardHolland
 email: enquiries@bioschemas.org
 issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20organization
 folder: https://drive.google.com/drive/u/1/folders/0B1TdgUL4-iBaOXVaZ0szWlRQc2M

--- a/pages/_groups/People.md
+++ b/pages/_groups/People.md
@@ -6,7 +6,8 @@ collection: groups
 active: false
 type: generic
 description: Specification for describing people
-lead: [NiallBeard]
+lead: 
+- person: NiallBeard
 email: enquiries@bioschemas.org
 issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20person
 folder: https://drive.google.com/drive/u/1/folders/0B6crv12s8piRd1hFM2JUeS1wSEk

--- a/pages/_groups/Phenotypes.md
+++ b/pages/_groups/Phenotypes.md
@@ -6,7 +6,8 @@ collection: groups
 active: true
 type: biological
 description: Specification for phenotype profile
-lead: [FedericoLopezGomez]
+lead: 
+- person: FedericoLopezGomez
 email: enquiries@bioschemas.org
 issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Phenotype
 folder: https://drive.google.com/open?id=1zznGVUcp4yTSzyMoIA7BF9k-nieOSHbL

--- a/pages/_groups/Proteins.md
+++ b/pages/_groups/Proteins.md
@@ -6,7 +6,9 @@ collection: groups
 active: true
 type: biological
 description: Specification for protein type
-lead: [MariaMartin, LeylaGarcia]
+lead: 
+- person: MariaMartin
+- person: LeylaGarcia
 email: enquiries@bioschemas.org
 issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20protein
 folder: https://drive.google.com/drive/folders/0B0fE3oOZIq44eFktTmhFQlhLeDA

--- a/pages/_groups/Publications.md
+++ b/pages/_groups/Publications.md
@@ -6,7 +6,9 @@ collection: groups
 active: true
 type: generic
 description: Specifications for scholarly publication related profiles
-lead: [AlexanderGarcia, LeylaGarcia]
+lead: 
+- person: AlexanderGarcia
+- person: LeylaGarcia
 email: enquiries@bioschemas.org
 issues:
   - https://github.com/BioSchemas/specifications/labels/group%3A%20Scholarly%20Publication

--- a/pages/_groups/Samples.md
+++ b/pages/_groups/Samples.md
@@ -6,7 +6,10 @@ collection: groups
 active: true
 type: biological
 description: Specification for sample profile
-lead: [HelenParkinson, TonyBurdett, MelanieCourtot]
+lead: 
+- person: HelenParkinson
+- person: TonyBurdett
+- person: MelanieCourtot
 email: enquiries@bioschemas.org
 issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20Sample
 folder: https://drive.google.com/drive/folders/0Bw_p-HKWUjHoaWhkTnBka2FWRE0

--- a/pages/_groups/Standards.md
+++ b/pages/_groups/Standards.md
@@ -6,7 +6,8 @@ collection: groups
 active: false
 type: generic
 description: Specification for standards
-lead: [PeterMcQuilton]
+lead: 
+- person: PeterMcQuilton
 email: enquiries@bioschemas.org
 issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20standard
 folder: https://drive.google.com/drive/u/1/folders/0Bw_p-HKWUjHoaDRIWlVwUXNJcHM

--- a/pages/_groups/Studies.md
+++ b/pages/_groups/Studies.md
@@ -6,7 +6,8 @@ collection: groups
 active: true
 type: generic
 description: Developing a profile and type to capture studies and their associated projects
-lead: [To be determined]
+lead: 
+- person: To be determined
 email: enquiries@bioschemas.org    
 issues: https://github.com/Bioschemas/specifications/labels/type%3A%20Study
 folder: https://drive.google.com/drive/folders/1ml4elMOIlLUOie4i8gnXmP5eNn-8D2QD

--- a/pages/_groups/Technical.md
+++ b/pages/_groups/Technical.md
@@ -7,7 +7,8 @@ collection: groups
 active: true
 type: generic
 description:
-lead: [JustinClark-Casey]
+lead: 
+- person: JustinClark-Casey
 email: enquiries@bioschemas.org
 issues: https://github.com/Bioschemas/bioschemas/labels/SupportSoftware
 

--- a/pages/_groups/Tools.md
+++ b/pages/_groups/Tools.md
@@ -6,7 +6,10 @@ collection: groups
 active: false
 type: generic
 description: Specification for tools
-lead: [RicardoArcila, JustinClark-Casey, LeylaGarcia]
+lead: 
+- person: RicardoArcila
+- person: JustinClark-Casey
+- person: LeylaGarcia
 email: enquiries@bioschemas.org
 issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20tool
 folder: https://drive.google.com/open?id=0BzDhyOWTnRNTYkdQNHppUjZ3U2M

--- a/pages/_groups/Training.md
+++ b/pages/_groups/Training.md
@@ -6,7 +6,7 @@ collection: groups
 active: true
 type: generic
 description: Specification for describing training resources such as materials and courses.
-current-leads:
+lead:
 - person: PatriciaPalagi
   start-date: 2020-11-02
 - person: MichelleBrazas
@@ -20,7 +20,6 @@ former-leads:
 - person: GabriellaRustici
   start-date: 2018-09-25
   end-date: 2020-10-01
-lead: [PatriciaPalagi, MichelleBrazas, LeylaGarcia]
 email: enquiries@bioschemas.org
 issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20training%20material
 folder: https://drive.google.com/drive/u/1/folders/0B6crv12s8piRT0w5VXRUc09VTFU

--- a/pages/_groups/Training.md
+++ b/pages/_groups/Training.md
@@ -40,8 +40,6 @@ specifications:
 
 
 members:
-    - MichelleBrazas
-    - PatriciaPalagi
     - CeliaVanGelder
     - SonikaTyagi
     - TerriAtwood   
@@ -58,7 +56,6 @@ members:
     - AnnMeyer
     - PaulaMartinez     
     - SarahMorgan    
-    - LeylaGarcia
     - VictoriaDominguezDelAngel
     - ChrisChild
 

--- a/pages/_groups/Training.md
+++ b/pages/_groups/Training.md
@@ -11,6 +11,8 @@ current-leads:
   start-date: 2020-11-02
 - person: MichelleBrazas
   start-date: 2020-11-02
+- person: LeylaGarcia
+  start-date: 2022-08-09  
 former-leads:
 - person: NiallBeard
   start-date: 2018-09-25
@@ -18,6 +20,7 @@ former-leads:
 - person: GabriellaRustici
   start-date: 2018-09-25
   end-date: 2020-10-01
+lead: [PatriciaPalagi, MichelleBrazas, LeylaGarcia]
 email: enquiries@bioschemas.org
 issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20training%20material
 folder: https://drive.google.com/drive/u/1/folders/0B6crv12s8piRT0w5VXRUc09VTFU

--- a/pages/_groups/Validation.md
+++ b/pages/_groups/Validation.md
@@ -6,7 +6,8 @@ collection: groups
 active: true
 type: other
 description: Tools for validating markup against a specification
-lead: [AlasdairGray]
+lead: 
+- person: AlasdairGray
 email: enquiries@bioschemas.org
 
 # Progress status

--- a/pages/_groups/Workflow.md
+++ b/pages/_groups/Workflow.md
@@ -6,7 +6,10 @@ collection: groups
 active: true
 type: generic
 description: Description for Workflow related data, pattern of activities and so on.
-lead: [AlanWilliams, StuartOwen, BertDroesbeke]
+lead: 
+- person: AlanWilliams
+- person: StuartOwen
+- person: BertDroesbeke
 email: enquiries@bioschemas.org
 issues: https://github.com/Bioschemas/bioschemas/labels/type%3A%20ComputationalWorkflow
 folder: https://drive.google.com/open?id=10QSvgnEGFXTeOT8qz4-4xwZgLT5GJrqG


### PR DESCRIPTION
* Adds a new group lead to the Training group (as agreed with the other two leads)
* Uses YAML property ```lead``` in addition to ```current-leads``` as a temporary solution for leads to be listed in the group profile pages (a more permanent solution would be desirable, see https://github.com/BioSchemas/specifications/issues/586)