### PR TITLE
Dataset 1.0 supersedes Dataset 0.5-DRAFT

### DIFF
--- a/_data/profile_versions.yaml
+++ b/_data/profile_versions.yaml
@@ -57,7 +57,7 @@ DataRecord:
 
 Dataset:
     name: "Dataset"
-    latest_publication: "0.5-DRAFT"
+    latest_publication: 
     latest_release: "1.0-RELEASE"
     status: "active"
 


### PR DESCRIPTION
Dataset 0.5-DRAFT still appears in the draft profile list even though it was superseded by Dataset 1.0-RELEASE.

This PR corrects the profile data so that only the Dataset 1.0-RELEASE is shown.