### PR TITLE
Update Publications page with new presentations

### DIFF
--- a/_data/presentations.csv
+++ b/_data/presentations.csv
@@ -1,0 +1,8 @@
+﻿Title,Presenter,Slides,EventBSLink,EventURL,EventName,EventDate
+Bioschemas: Improving the Findability of Life Sciences Resources using Schema.org,AlasdairGray,https://docs.google.com/presentation/d/1iUTg0ioFqVGxhAk04ZI-nbeZe7k7TtbvlAGn73cSvgs/edit?usp=sharing,2021-11_RDA18,,,
+Global Bioschemas: Community Update,AlasdairGray,https://docs.google.com/presentation/d/1UOOBLHaZ0oVlja-PXI68YE80M1cbOoqYLv49FkqlpFw/edit#slide=id.p1,2021-11_ELIXIR-DataInterOp,,,
+Bioschemas for the IDP Community,AlasdairGray,https://docs.google.com/presentation/d/13_Ngz1jbnIrYTSW2ZLvoh_eDljPXHDJCLMhoODqbtPo/edit#slide=id.p1,2022-01_IDP-Interop,,,
+(Bio)schemas – Making (not only life science) data resources more interoperable and discoverable on the Web,AlasdairGray,https://docs.google.com/presentation/d/1TqvYpZVBvq_nhUkfzrzar6n87lDkryS-KYBf5bBH7bI/edit#slide=id.p1,2022-04_NFDI-InfraTalk,,,
+Contributing to EOSC Research Graphs: the role of FAIRsharing and Bioschemas,SusannaSansone,https://docs.google.com/presentation/d/1lwm-452v-pyfd7egfmh4APbX3CHXe9xu/edit#slide=id.g12f39d505fa_0_535,2022-06_ELIXIRAllHands2022,,,
+(Bio)schemas: Making data resources more Interoperable and Discoverable on the Web,AlasdairGray,https://docs.google.com/presentation/d/1MDWzlx4Mm1dpHOVnRlZcQqAIQuaOrvOfRVSLvArQBug/edit#slide=id.p1,2022-09_Ont4Chem,,,
+Bioschemas: Marking up biodiversity websites to improve data discovery and web-scale integration,FranckMichel,https://docs.google.com/presentation/d/15HB6ldOSN5C_H10w9chwWyPt_CNh8AlM/edit#slide=id.p1,,,"NFDI4Biodiversity All Hands Conference, Workshop on Data Standards & Common Language",12-14 October 2022

--- a/_includes/presentations.html
+++ b/_includes/presentations.html
@@ -1,0 +1,25 @@
+{% assign presentations = site.data.presentations %}
+{% for presentation in site.data.presentations reversed %}
+    <li>
+    {% if presentation.EventBSLink %}
+        {% assign event-id = "/meetings/" | append: {{presentation.EventBSLink}} %}
+        {% assign event = site.meetings | where:"id", event-id | first %}
+        <a href="{{event-id}}">{{event.name}}</a>, {{event.dates}}
+    {% else %}
+        {% if presentation.EventURL %}
+            <a href="{{presentation.EventURL}}">{{presentation.EventName}}</a>
+        {% else %}
+            {{presentation.EventName}}, {{presentation.EventDate}}
+        {% endif %}
+    {% endif %}
+    <ul><li>
+        {% assign author-id = "/people/" | append: presentation.Presenter %}
+        {% assign author = site.people | where:"id", author-id | first %}
+        <a href="{{author-id}}">{{author.first-name}} {{author.last-name}}</a>. 
+        {{presentation.first[1]}}
+        (<a href="{{presentation.Slides}}">Slides</a>)
+    </li></ul>
+</li>
+{% endfor %}
+
+{{presentation.first | remove_first: "Title"}} 

--- a/pages/_about/publications.html
+++ b/pages/_about/publications.html
@@ -10,11 +10,7 @@ layout: default
     <div id="pub_list">
       <p>A list of publications and talks in which Bioschemas was presented:</p>
       <ol>
-        <li><a href="/meetings/2021-11_RDA18">BoF: Metadata for Data Indexing and Data Discovery in Materials Science and Engineering</a>, 18th RDA Plenary Meeting, 9 November 2021
-          <ul>
-            <li>Alasdair Gray. Bioschemas: Improving the Findability of Life Sciences Resources using Schema.org (<a href="https://docs.google.com/presentation/d/1iUTg0ioFqVGxhAk04ZI-nbeZe7k7TtbvlAGn73cSvgs/edit?usp=sharing">Slides</a>)</li>
-          </ul>
-        </li>
+        {% include presentations.html %}
         <li>TDWG Webinar (<a href="/meetings/2021-03_BiodiversityMarkupathon/">Details</a>)
           <ul>
             <li>Franck Michel. Bioschemas: marking up biodiversity websites to improve data discovery and web-scale integration (<a href="https://docs.google.com/presentation/d/1YDI8cxAoHsF3kbHFPerUyoJi8lwWF1fU/">Slides</a>, <a href="https://www.youtube.com/watch?v=ueg5Fi6kgGA">Video</a>)</li>

--- a/pages/_meetings/2021-11_RDA18.md
+++ b/pages/_meetings/2021-11_RDA18.md
@@ -1,6 +1,6 @@
 ---
 layout: meeting
-name: Metadata for Data Indexing and Data Discovery in Materials Science and Engineering
+name: Metadata for Data Indexing and Data Discovery in Materials Science and Engineering, 18th RDA Plenary Meeting
 title: Metadata for Data Indexing and Data Discovery in Materials Science and Engineering
 dates: 9 November 2021
 start_date: 2021-11-09

--- a/pages/_meetings/2022-09_Ont4Chem.md
+++ b/pages/_meetings/2022-09_Ont4Chem.md
@@ -1,6 +1,6 @@
 ---
 layout: meeting
-name: 'Ontologies for Chemistry, '
+name: 'Ontologies for Chemistry, NFDI4Chem Workshop'
 title: 'Ont4Cehm'
 dates: 7-8 September 2022
 start_date: 2022-09-07


### PR DESCRIPTION
The publications page was missing several of our recent presentations. This has added several of them.

the PR also changes the mechanism by which publications are added. They are now added by putting them in a csv file. Hopefully this is more straightforward.