### PR TITLE
Dde tutorial typo

### DIFF
--- a/pages/_tutorials/dde/index.md
+++ b/pages/_tutorials/dde/index.md
@@ -4,9 +4,9 @@ title: Data Discovery Engine
 ---
 
 # Data Discovery Engine
-The [Data Discovery Engine (DDE)](https://discovery.biothings.io/) provides guidance for researchers on how to make their data discoverable and reusable, and bring the practical benefits of data sharing to researcher’s own research projects, as well as the research community as a whole. It was developed and is maintained by Dr. Chunlei Wu’s lab at the Scripps Research Institute and is supported by funding from the National Center for Data to Health (CD2H). The Data Discovery Engine has user-friendly tools which help with the extension and reusability of schemas. A general overview of the DDE Schema Playground can be found at: [https://discovery.biothings.io/faq/dde#what-is-schema-playground]
+The [Data Discovery Engine (DDE)](https://discovery.biothings.io/) provides guidance for researchers on how to make their data discoverable and reusable, and bring the practical benefits of data sharing to researcher’s own research projects, as well as the research community as a whole. It was developed and is maintained by Dr. Chunlei Wu’s lab at the Scripps Research Institute and is supported by funding from the National Center for Data to Health (CD2H). The Data Discovery Engine has user-friendly tools which help with the extension and reusability of schemas. A general overview of the DDE Schema Playground can be found at: (https://discovery.biothings.io/faq/dde#what-is-schema-playground)
 
- - Note, a GitHub account is required to unlock most of the functionality of the DDE. You can sign up for GitHub for free at [https://github.com]
+ - Note, a GitHub account is required to unlock most of the functionality of the DDE. You can sign up for GitHub for free at (https://github.com)
 
 ### How Bioschemas Specifications are stored in the DDE Schema Registry
 Only the most recent drafts and releases of specifications should be saved to the registry. The DDE does not currently distinguish between profiles and types and instead treats all specifications as classes. The term **class** in the DDE is equivalent to the term **specification** in Bioschemas; hence, different kinds of specifications are saved to different namespaces in the DDE registry. These namespaces include:

--- a/pages/_tutorials/dde/index.md
+++ b/pages/_tutorials/dde/index.md
@@ -4,9 +4,9 @@ title: Data Discovery Engine
 ---
 
 # Data Discovery Engine
-The [Data Discovery Engine (DDE)](https://discovery.biothings.io/) provides guidance for researchers on how to make their data discoverable and reusable, and bring the practical benefits of data sharing to researcher’s own research projects, as well as the research community as a whole. It was developed and is maintained by Dr. Chunlei Wu’s lab at the Scripps Research Institute and is supported by funding from the National Center for Data to Health (CD2H). The Data Discovery Engine has user-friendly tools which help with the extension and reusability of schemas. A general overview of the DDE Schema Playground can be found at: https://discovery.biothings.io/faq/dde#what-is-schema-playground
+The [Data Discovery Engine (DDE)](https://discovery.biothings.io/) provides guidance for researchers on how to make their data discoverable and reusable, and bring the practical benefits of data sharing to researcher’s own research projects, as well as the research community as a whole. It was developed and is maintained by Dr. Chunlei Wu’s lab at the Scripps Research Institute and is supported by funding from the National Center for Data to Health (CD2H). The Data Discovery Engine has user-friendly tools which help with the extension and reusability of schemas. A general overview of the DDE Schema Playground can be found at: [https://discovery.biothings.io/faq/dde#what-is-schema-playground]
 
- - Note, a GitHub account is required to unlock most of the functionality of the DDE. You can sign up for GitHub for free at https://github.com
+ - Note, a GitHub account is required to unlock most of the functionality of the DDE. You can sign up for GitHub for free at [https://github.com]
 
 ### How Bioschemas Specifications are stored in the DDE Schema Registry
 Only the most recent drafts and releases of specifications should be saved to the registry. The DDE does not currently distinguish between profiles and types and instead treats all specifications as classes. The term **class** in the DDE is equivalent to the term **specification** in Bioschemas; hence, different kinds of specifications are saved to different namespaces in the DDE registry. These namespaces include:

--- a/pages/_tutorials/dde/index.md
+++ b/pages/_tutorials/dde/index.md
@@ -4,9 +4,9 @@ title: Data Discovery Engine
 ---
 
 # Data Discovery Engine
-The [Data Discovery Engine (DDE)](https://discovery.biothings.io/) provides guidance for researchers on how to make their data discoverable and reusable, and bring the practical benefits of data sharing to researcher’s own research projects, as well as the research community as a whole. It was developed and is maintained by Dr. Chunlei Wu’s lab at the Scripps Research Institute and is supported by funding from the National Center for Data to Health (CD2H). The Data Discovery Engine has user-friendly tools which help with the extension and reusability of schemas. A general overview of the DDE Schema Playground can be found at: (https://discovery.biothings.io/faq/dde#what-is-schema-playground)
+The [Data Discovery Engine (DDE)](https://discovery.biothings.io/) provides guidance for researchers on how to make their data discoverable and reusable, and bring the practical benefits of data sharing to researcher’s own research projects, as well as the research community as a whole. It was developed and is maintained by Dr. Chunlei Wu’s lab at the Scripps Research Institute and is supported by funding from the National Center for Data to Health (CD2H). The Data Discovery Engine has user-friendly tools which help with the extension and reusability of schemas. A general overview of the DDE Schema Playground can be found at: <https://discovery.biothings.io/faq/dde#what-is-schema-playground>
 
- - Note, a GitHub account is required to unlock most of the functionality of the DDE. You can sign up for GitHub for free at (https://github.com)
+ - Note, a GitHub account is required to unlock most of the functionality of the DDE. You can sign up for GitHub for free at <https://github.com>
 
 ### How Bioschemas Specifications are stored in the DDE Schema Registry
 Only the most recent drafts and releases of specifications should be saved to the registry. The DDE does not currently distinguish between profiles and types and instead treats all specifications as classes. The term **class** in the DDE is equivalent to the term **specification** in Bioschemas; hence, different kinds of specifications are saved to different namespaces in the DDE registry. These namespaces include:

--- a/pages/_tutorials/dde/review_a_specification_pull_request.md
+++ b/pages/_tutorials/dde/review_a_specification_pull_request.md
@@ -89,8 +89,8 @@ A community member has created or updated a Bioschemas specification JSON-LD fil
 
 
 ### Links and Further Reading
-* Documentation on the automated JSON-LD-to-webpage conversion: [https://hackmd.io/zGOAxx-BRfi4rDiaW9Rk4Q?both] 
-* Documentation on the automated DDE-updates: [https://github.com/bioschemas/bioschemas-dde]
-* About JSON-LD: [https://json-ld.org/]
-* About JSON-schema: [https://json-schema.org/]
-* The FAQ for the Data Discovery Engine (DDE): [https://discovery.biothings.io/faq/dde] 
+* Documentation on the automated JSON-LD-to-webpage conversion: <https://hackmd.io/zGOAxx-BRfi4rDiaW9Rk4Q?both>
+* Documentation on the automated DDE-updates: <https://github.com/bioschemas/bioschemas-dde>
+* About JSON-LD: <https://json-ld.org/>
+* About JSON-schema: <https://json-schema.org/>
+* The FAQ for the Data Discovery Engine (DDE): <https://discovery.biothings.io/faq/dde>

--- a/pages/_tutorials/dde/review_a_specification_pull_request.md
+++ b/pages/_tutorials/dde/review_a_specification_pull_request.md
@@ -89,8 +89,8 @@ A community member has created or updated a Bioschemas specification JSON-LD fil
 
 
 ### Links and Further Reading
-* Documentation on the automated JSON-LD-to-webpage conversion: https://hackmd.io/zGOAxx-BRfi4rDiaW9Rk4Q?both
-* Documentation on the automated DDE-updates: https://github.com/bioschemas/bioschemas-dde
-* About JSON-LD: https://json-ld.org/
-* About JSON-schema: https://json-schema.org/
-* The FAQ for the Data Discovery Engine (DDE): https://discovery.biothings.io/faq/dde 
+* Documentation on the automated JSON-LD-to-webpage conversion: [https://hackmd.io/zGOAxx-BRfi4rDiaW9Rk4Q?both] 
+* Documentation on the automated DDE-updates: [https://github.com/bioschemas/bioschemas-dde]
+* About JSON-LD: [https://json-ld.org/]
+* About JSON-schema: [https://json-schema.org/]
+* The FAQ for the Data Discovery Engine (DDE): [https://discovery.biothings.io/faq/dde] 

--- a/pages/_tutorials/dde/update_profile.md
+++ b/pages/_tutorials/dde/update_profile.md
@@ -133,7 +133,7 @@ You have come to a community consensus on changes needed to a profile that alrea
 ### Step 3 - Save your JSON-LD to the Bioschemas Specification Repository and create a pull request
 * Go to the [Bioschemas Specification repository](https://github.com/BioSchemas/specifications) 
 * Create a [new branch](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/viewing-branches-in-your-repository) or [fork the repository](https://docs.github.com/en/get-started/quickstart/fork-a-repo)
-* In your branch or fork, and find your specification
+* In your branch or fork, go and find your specification
 * Add your JSON-LD to the `jsonld` directory for your specification
 * Create a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) for your fork or branch
   * Include any issues you encountered from your test that you were unable to address


### PR DESCRIPTION
Fix typo (page update_profile) and make links with no text clickable (pages review_a_specification_pull_request and index)