### PR TITLE
Double H1 titles

### DIFF
--- a/pages/_tutorials/dde/new_profile.md
+++ b/pages/_tutorials/dde/new_profile.md
@@ -44,7 +44,6 @@ bioschemas:
   version: 0.2
 
 ---
-# Create a Profile
 
 You have come to a community consensus on changes needed to a profile that already exists. Congratulations! Now you have to update the new profile version on the Bioschemas website. Note, if you are comfortable with JSON schema and JSON-LD, you are welcome to copy, paste, and edit the JSON-LD files in the Bioschemas Specifications repository
 

--- a/pages/_tutorials/dde/new_type.md
+++ b/pages/_tutorials/dde/new_type.md
@@ -44,7 +44,6 @@ bioschemas:
   version: 0.2
 
 ---
-# Create a new Type on the Bioschemas site
 
 You have come to a community consensus on creating a new type. Congratulations! Now you have to add the new type on the Bioschemas website.
  Note, if you are comfortable with JSON schema and JSON-LD, you are welcome to copy, paste, and edit the JSON-LD files in the Bioschemas Specifications repository

--- a/pages/_tutorials/dde/review_a_specification_pull_request.md
+++ b/pages/_tutorials/dde/review_a_specification_pull_request.md
@@ -46,7 +46,7 @@ bioschemas:
   version: 0.2
 
 ---
-# Review a pull request for a Bioschemas Specification JSON-LD file
+
 A community member has created or updated a Bioschemas specification JSON-LD file and created a pull request. Here’s how to help review and merge it, so that the website and the DDE will be updated. 
 
 ### Step 1 ensure you have access to the appropriate channels and repositories

--- a/pages/_tutorials/dde/update_profile.md
+++ b/pages/_tutorials/dde/update_profile.md
@@ -44,7 +44,6 @@ bioschemas:
   version: 0.2
 
 ---
-# Update a Profile
 
 You have come to a community consensus on changes needed to a profile that already exists. Congratulations! Now you have to update the new profile version on the Bioschemas website. Note, if you are comfortable with JSON schema and JSON-LD, you are welcome to copy, paste, and edit the JSON-LD files in the Bioschemas Specifications repository
 

--- a/pages/_tutorials/dde/update_type.md
+++ b/pages/_tutorials/dde/update_type.md
@@ -44,7 +44,6 @@ bioschemas:
   version: 0.2
 
 ---
-# Update an existing Type on the Bioschemas site
 
 You have come to a community consensus on updating an existing Bioschemas type. Congratulations! Now you have to update the type on the Bioschemas website.
  Note, if you are comfortable with JSON schema and JSON-LD, you are welcome to copy, paste, and edit the JSON-LD files in the Bioschemas Specifications repository


### PR DESCRIPTION
It is recommended to only have one top level title, and since the title in the metadata of the md file is by default the H1 title, I would take away the one in the content.