### PR TITLE
Hide Page/SMV/BMUSE buttons if missing or invalid exampleURL

### DIFF
--- a/_includes/live-deploy-site-info.html
+++ b/_includes/live-deploy-site-info.html
@@ -57,17 +57,17 @@
                     <small class="text-muted me-2">{{profile.highlight}}</small>
                     {%- endif %}
                 </div>
-                {%- if profile.exampleURL != nil %}
+                {%- if profile.exampleURL != nil and profile.exampleURL != "http://" %}
                 <div class="ps-1">
                     <a href="{{profile.exampleURL}}" data-bs-toggle="tooltip" data-bs-placement="top" title="{{page.exampleHoverText}}" class="btn btn-sm btn-primary" target="_blank">Page</a>
                 </div>
                 {%- endif %}
-                {%- if profile.exampleURL != nil %}
+                {%- if profile.exampleURL != nil and profile.exampleURL != "http://" %}
                 <div class="ps-1">
                     <a href="https://validator.schema.org/#url={{profile.exampleURL}}" data-bs-toggle="tooltip" data-bs-placement="top" title="{{page.schemaHoverText}}" class="btn btn-sm btn-primary" target="_blank">SMV</a>
                 </div>
                 {%- endif %}
-                {%- if profile.exampleURL != nil %}
+                {%- if profile.exampleURL != nil and profile.exampleURL != "http://" %}
                 <div class="ps-1">
                     <a href="https://swel.macs.hw.ac.uk/scraper/getRDF?url={{profile.exampleURL}}&output=jsonld" data-bs-toggle="tooltip" data-bs-placement="top" title="{{page.bmuseHoverText}}" class="btn btn-sm btn-primary" target="_blank">BMUSE</a>
                 </div>

--- a/pages/_developer/liveDeploys.html
+++ b/pages/_developer/liveDeploys.html
@@ -94,17 +94,17 @@ bmuseHoverText: "Retrieve using Bioschemas Scraping service"
                                 <small class="text-muted me-2">{{live.highlight}}</small>
                                 {%- endif %}
                             </div>
-                            {%- if live.exampleURL != nil %}
+                            {%- if live.exampleURL != nil and live.exampleURL != "http://" %}
                             <div class="ps-1">
                                 <a href="{{live.exampleURL}}" data-bs-toggle="tooltip" data-bs-placement="top" title="{{page.exampleHoverText}}" class="btn btn-sm btn-primary" target="_blank">Page</a>
                             </div>
                             {%- endif %}
-                            {%- if live.exampleURL != nil %}
+                            {%- if live.exampleURL != nil and live.exampleURL != "http://" %}
                             <div class="ps-1">
                                 <a href="https://validator.schema.org/#url={{live.exampleURL}}" data-bs-toggle="tooltip" data-bs-placement="top" title="{{page.schemaHoverText}}" class="btn btn-sm btn-primary" target="_blank">SMV</a>
                             </div>
                             {%- endif %}
-                            {%- if live.exampleURL != nil %}
+                            {%- if live.exampleURL != nil and live.exampleURL != "http://" %}
                             <div class="ps-1">
                                 <a href="https://swel.macs.hw.ac.uk/scraper/getRDF?url={{live.exampleURL}}&output=jsonld" data-bs-toggle="tooltip" data-bs-placement="top" title="{{page.bmuseHoverText}}" class="btn btn-sm btn-primary" target="_blank">BMUSE</a>
                             </div>
@@ -236,17 +236,17 @@ bmuseHoverText: "Retrieve using Bioschemas Scraping service"
                                                 <small class="text-muted me-2">{{profile.highlight}}</small>
                                                 {%- endif %}
                                             </div>
-                                            {%- if profile.exampleURL != nil %}
+                                            {%- if profile.exampleURL != nil and profile.exampleURL != "http://" %}
                                             <div class="ps-1">
                                                 <a href="{{profile.exampleURL}}" data-bs-toggle="tooltip" data-bs-placement="top" title="{{page.exampleHoverText}}" class="btn btn-sm btn-primary" target="_blank">Page</a>
                                             </div>
                                             {%- endif %}
-                                            {%- if profile.exampleURL != nil %}
+                                            {%- if profile.exampleURL != nil and profile.exampleURL != "http://" %}
                                             <div class="ps-1">
                                                 <a href="https://validator.schema.org/#url={{profile.exampleURL}}" data-bs-toggle="tooltip" data-bs-placement="top" title="{{page.schemaHoverText}}" class="btn btn-sm btn-primary" target="_blank">SMV</a>
                                             </div>
                                             {%- endif %}
-                                            {%- if profile.exampleURL != nil %}
+                                            {%- if profile.exampleURL != nil and profile.exampleURL != "http://" %}
                                             <div class="ps-1">
                                                 <a href="https://swel.macs.hw.ac.uk/scraper/getRDF?url={{profile.exampleURL}}&output=jsonld" data-bs-toggle="tooltip" data-bs-placement="top" title="{{page.bmuseHoverText}}" class="btn btn-sm btn-primary" target="_blank">BMUSE</a>
                                             </div>


### PR DESCRIPTION
`live_deployments.json` lists resources with profiles with missing or invalid (`"exampleURL": "http://"`) `exampleURL` property. This fix will skip the rendering of Page, SMV and BMUSE buttons under Live Deploys page.

This will however leave wrong `exampleURL`s under Live Deploys/By Profile (e.g. under MolecularEntity profile). But this is tricky to fix and will require a new issue.