### PR TITLE
Fix contrast issues of property/type status

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Since the website uses [GitHub pages](https://pages.github.com/) for its deploym
 
 It is possible to preview the website locally to preview changes. You need a Ruby installation in order to do so. Ruby version 2.7.* works out of the box well with Jekyll, more recent versions will need `bundle add webrick` to make it work. If you already have the correct Ruby installed on your machine, then the following files will allow you to get started by installing the relevant dependencies:
 
-- Install Jekyll and Dependencies: ```gem install jekyll bundler ``` and ```gem install jekyll-sitemap jekyll-sitemap jekyll-gist jekyll-redirect-from```
+- Install Jekyll and Dependencies: ```gem install jekyll bundler ``` and ```gem install jekyll-sitemap jekyll-sitemap jekyll-gist jekyll-redirect-from jekyll-relative-links```
 - Clone the repository: ```git clone https://github.com/Bioschemas/bioschemas.github.io.git```
 - Run the website: ```jekyll serve```
 

--- a/_includes/spec-table-key.html
+++ b/_includes/spec-table-key.html
@@ -6,6 +6,3 @@
   <li><em style="color: #0000CC;"><strong>Blue</strong></em> properties/types exist in the pending area of Schema.org</li>
   <li><em style="color: #454547;"><strong>Black</strong></em> properties/types are reused from external vocabularies/ontologies</li>
 </ul>
-{% if page.spec_type == 'Profile' %}
-<p>CD = Cardinality</p>
-{% endif %}

--- a/_includes/specification-table.html
+++ b/_includes/specification-table.html
@@ -64,13 +64,17 @@
         {%- for prop in props_list %}
         <tr>
             {%- if prop.type == "bioschemas" %}
-            <td class="property-column"><a href="{{prop.type_url }}" target="_blank" class="bioschema">{{prop.property}}</a></td>
+            <td class="property-column"><a href="{{prop.type_url }}" target="_blank" class="bioschema">{{prop.property}}</a>
+            <br><abbr class="status" title="Properties/types are proposed by Bioschemas, or proposed changes by Bioschemas to Schema.org">Bioschemas</abbr></td>
             {%- elsif prop.type == "schemas.org" or prop.type == "" %}
-            <td class="property-column"><a href="http://schema.org/{{prop.property}}" target="_blank" class="schemaorg">{{prop.property}}</a></td>
+            <td class="property-column"><a href="http://schema.org/{{prop.property}}" target="_blank" class="schemaorg">{{prop.property}}</a>
+            <br><abbr class="status" title="Properties/types exist in the core of Schema.org">Schema.org</abbr></td>
             {%- elsif prop.type == "pending" %}
-            <td class="property-column"><a href="http://schema.org/{{prop.property}}" target="_blank" class="pending">{{prop.property}}</a></td>
+            <td class="property-column"><a href="http://schema.org/{{prop.property}}" target="_blank" class="pending">{{prop.property}}</a>
+            <br><abbr class="status" title="Properties/types exist in the pending area of Schema.org">Pending</abbr></td>
             {%- else %}
-            <td class="property-column"><a href="{{prop.type_url}}" target="_blank" class="external">{{prop.property}}</a></td>
+            <td class="property-column"><a href="{{prop.type_url}}" target="_blank" class="external">{{prop.property}}</a>
+            <br><abbr class="status" title="Properties/types are reused from external vocabularies/ontologies">External</abbr></td>
             {%- endif %}
             <td>
                 {%- for temp_exp_type in prop.expected_types %}

--- a/_includes/specification-table.html
+++ b/_includes/specification-table.html
@@ -42,7 +42,7 @@
             <th>Property</th>
             <th>Expected Type</th>
             <th>Description</th>
-            <th>CD</th>
+            <th><abbr title="Cardinality">CD</abbr></th>
             <th class="control-vocabulary-column">Controlled Vocabulary</th>
             <th class="example-column">Example</th>
         </tr>

--- a/assets/css/_spec-tables.scss
+++ b/assets/css/_spec-tables.scss
@@ -49,6 +49,11 @@
     .property-column {
         background: $gray-200;
         font-weight: bold;
+        
+        .status {
+            font-style: italic;
+            font-weight: normal;
+        }
     }
     .expected-type-column {
         min-width: 15em;

--- a/pages/_profiles/Organization/0.1-DRAFT-2018_03_13.html
+++ b/pages/_profiles/Organization/0.1-DRAFT-2018_03_13.html
@@ -41,7 +41,7 @@ spec_info:
          <th>Property</th>
          <th>Expected Type</th>
          <th>Description</th>
-         <th>CD</th>
+         <th><abbr title="Cardinality">CD</abbr></th>
          <th>Controlled Vocabulary</th>
       </tr>
    </thead>

--- a/pages/_profiles/Organization/0.2-DRAFT-2019_07_17.html
+++ b/pages/_profiles/Organization/0.2-DRAFT-2019_07_17.html
@@ -394,7 +394,7 @@ mapping:
          <th>Property</th>
          <th>Expected Type</th>
          <th>Description</th>
-         <th>CD</th>
+         <th><abbr title="Cardinality">CD</abbr></th>
          <th>Controlled Vocabulary</th>
       </tr>
    </thead>

--- a/pages/_profiles/Person/0.1-DRAFT-2018_03_14.html
+++ b/pages/_profiles/Person/0.1-DRAFT-2018_03_14.html
@@ -40,7 +40,7 @@ spec_info:
          <th>Property</th>
          <th>Expected Type</th>
          <th>Description</th>
-         <th>CD</th>
+         <th><abbr title="Cardinality">CD</abbr></th>
          <th>Controlled Vocabulary</th>
       </tr>
    </thead>

--- a/pages/_profiles/Sample/0.1-DRAFT-2018_02_25.html
+++ b/pages/_profiles/Sample/0.1-DRAFT-2018_02_25.html
@@ -144,7 +144,7 @@ mapping:
          <th>Property</th>
          <th>Expected Type</th>
          <th>Description</th>
-         <th>CD</th>
+         <th><abbr title="Cardinality">CD</abbr></th>
          <th>Controlled Vocabulary</th>
       </tr>
    </thead>
@@ -242,7 +242,7 @@ mapping:
          <th>Property</th>
          <th>Expected Type</th>
          <th>Description</th>
-         <th>CD</th>
+         <th><abbr title="Cardinality">CD</abbr></th>
          <th>Controlled Vocabulary</th>
       </tr>
    </thead>

--- a/pages/_profiles/Sample/0.2-DRAFT-2018_11_09.html
+++ b/pages/_profiles/Sample/0.2-DRAFT-2018_11_09.html
@@ -148,7 +148,7 @@ mapping:
          <th>Property</th>
          <th>Expected Type</th>
          <th>Description</th>
-         <th>CD</th>
+         <th><abbr title="Cardinality">CD</abbr></th>
          <th>Controlled Vocabulary</th>
       </tr>
    </thead>
@@ -246,7 +246,7 @@ mapping:
          <th>Property</th>
          <th>Expected Type</th>
          <th>Description</th>
-         <th>CD</th>
+         <th><abbr title="Cardinality">CD</abbr></th>
          <th>Controlled Vocabulary</th>
       </tr>
    </thead>

--- a/pages/_profiles/Sample/0.2-DRAFT-2018_11_10.html
+++ b/pages/_profiles/Sample/0.2-DRAFT-2018_11_10.html
@@ -152,7 +152,7 @@ mapping:
          <th>Property</th>
          <th>Expected Type</th>
          <th>Description</th>
-         <th>CD</th>
+         <th><abbr title="Cardinality">CD</abbr></th>
          <th>Controlled Vocabulary</th>
       </tr>
    </thead>
@@ -250,7 +250,7 @@ mapping:
          <th>Property</th>
          <th>Expected Type</th>
          <th>Description</th>
-         <th>CD</th>
+         <th><abbr title="Cardinality">CD</abbr></th>
          <th>Controlled Vocabulary</th>
       </tr>
    </thead>

--- a/pages/_profiles/Sample/0.2-RELEASE-2018_11_10.html
+++ b/pages/_profiles/Sample/0.2-RELEASE-2018_11_10.html
@@ -163,7 +163,7 @@ mapping:
          <th>Property</th>
          <th>Expected Type</th>
          <th>Description</th>
-         <th>CD</th>
+         <th><abbr title="Cardinality">CD</abbr></th>
          <th>Controlled Vocabulary</th>
       </tr>
    </thead>
@@ -261,7 +261,7 @@ mapping:
          <th>Property</th>
          <th>Expected Type</th>
          <th>Description</th>
-         <th>CD</th>
+         <th><abbr title="Cardinality">CD</abbr></th>
          <th>Controlled Vocabulary</th>
       </tr>
    </thead>

--- a/pages/_profiles/Tool/0.3-DRAFT-2018_11_21.html
+++ b/pages/_profiles/Tool/0.3-DRAFT-2018_11_21.html
@@ -687,7 +687,7 @@ mapping:
                     <th>Property</th>
                     <th>Expected Type</th>
                     <th>Description</th>
-                    <th>CD</th>
+                    <th><abbr title="Cardinality">CD</abbr></th>
                     <th class="control-vocabulary-column">Controlled Vocabulary</th>
                     <th class="example-column">Example</th>
                   </tr>
@@ -1096,7 +1096,7 @@ mapping:
                                         <th>Property</th>
                                         <th>Expected Type</th>
                                         <th>Description</th>
-                                        <th>CD</th>
+                                        <th><abbr title="Cardinality">CD</abbr></th>
                                         <th class="control-vocabulary-column">Controlled Vocabulary</th>
                                         <th class="example-column">Example</th>
                                       </tr>

--- a/pages/_profiles/Tool/0.3-DRAFT-2019_07_18.html
+++ b/pages/_profiles/Tool/0.3-DRAFT-2019_07_18.html
@@ -688,7 +688,7 @@ mapping:
                     <th>Property</th>
                     <th>Expected Type</th>
                     <th>Description</th>
-                    <th>CD</th>
+                    <th><abbr title="Cardinality">CD</abbr></th>
                     <th class="control-vocabulary-column">Controlled Vocabulary</th>
                     <th class="example-column">Example</th>
                   </tr>
@@ -1097,7 +1097,7 @@ mapping:
                                         <th>Property</th>
                                         <th>Expected Type</th>
                                         <th>Description</th>
-                                        <th>CD</th>
+                                        <th><abbr title="Cardinality">CD</abbr></th>
                                         <th class="control-vocabulary-column">Controlled Vocabulary</th>
                                         <th class="example-column">Example</th>
                                       </tr>


### PR DESCRIPTION
I'm working on updating my schemas and I am really struggling to see red from black, given the colours. Additionally if y'all care about WCAG this is a failure of [SC 1.4.1](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html), as only colour is used to convey this category information. Another method (icon, text, text decoration) needs to be used in addition to colour to pass SC1.4.1

Thus a PR to address this.

- [x] Replaced CD explanation with a proper HTML [abbr](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr) element explaining the `CD` abbreviation.
- [X] Fixes contrast issue by including a text representation of the status (again with abbr) below each property key.

![example showing new abbreviation below each property name](https://github.com/BioSchemas/bioschemas.github.io/assets/458683/addbe017-7d62-44b4-a57d-dca20c110cc2)
