### PR TITLE
fixed error in example for alternateName: wrong quotation mark

### DIFF
--- a/pages/_profiles/Dataset/1.0-RELEASE.html
+++ b/pages/_profiles/Dataset/1.0-RELEASE.html
@@ -49,7 +49,7 @@ mapping:
      "alternateName": "MetaboLights dataset",
       "alternateName": "Automated Label-free Quantification of Metabolites from Liquid Chromatography",
       "alternateName": "Mass Spectrometry Data (Plasma) Automated Label-free Quantification of Metabolites from Liquid Chromatography",
-      "alternateName": “Mass Spectrometry Data (Plasma)"
+      "alternateName": "Mass Spectrometry Data (Plasma)"
     }
 - property: citation
   expected_types:


### PR DESCRIPTION
I noticed that the example for alternateName contains a wrong quotation mark, causing issues with the syntax parser: 
![quotation mark error in alternateName example](https://github.com/BioSchemas/bioschemas.github.io/assets/7805030/ddcbb9a8-bfdc-4d8f-90b2-6b2a8bb0f8b8)

I hope this can be fixed like this, and does not require a new release, as this is an error in the example and not in the specification itself.
