### PR TITLE
feat: add Metabolic Atlas as a live deploy

### DIFF
--- a/_data/live_deployments.json
+++ b/_data/live_deployments.json
@@ -1728,6 +1728,26 @@
           "highlight": "Over 1,500 ontologies, controlled vocabularies, and resources including their preferred prefix, name, description, homepage, mappings to other registries, and more."
         }
       ]
+    },
+    {
+      "name": "Metabolic Atlas",
+      "description": "A web platform integrating open-source genome scale metabolic models (GEMs) for easy browsing and analysis. ",
+      "url": "https://metabolicatlas.org",
+      "nodes": ["SE"],
+      "profiles": [
+        {
+          "profileName": "MolecularEntity",
+          "conformsTo": "0.5-RELEASE",
+          "exampleURL": "https://metabolicatlas.org/explore/Human-GEM/gem-browser/metabolite/MAM00217c",
+          "highlight": "Over 3'000 metabolites."
+        },
+        {
+          "profileName": "Gene",
+          "conformsTo": "1.0-RELEASE",
+          "exampleURL": "https://metabolicatlas.org/explore/Human-GEM/gem-browser/gene/ENSG00000078237",
+          "highlight": "Over 15'000 genes from multiple organisms."
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
In this PR the aim is to add Metabolic Atlas a live deploy of 2 Bioschemas profiles.