### PR TITLE
Remove Galaxy Hub from LiveDeploys

### DIFF
--- a/_data/live_deployments.json
+++ b/_data/live_deployments.json
@@ -433,17 +433,6 @@
       ]
     },
     {
-      "name": "Galaxy Project",
-      "url": "https://galaxyproject.org/",
-      "profiles": [
-        {
-          "profileName": "Event",
-          "conformsTo": "0.1",
-          "exampleURL": "https://galaxyproject.org/events/"
-        }
-      ]
-    },
-    {
       "name": "OmicsDI",
       "keywords": ["RIR"],
       "url": "https://www.omicsdi.org/",


### PR DESCRIPTION
Hi, the Galaxy/Events pages lost their Bioschemas markup. This regression is tracked in https://github.com/galaxyproject/galaxy-hub/issues/2177 with no timeline for a fix. Let's leave this PR open for a while, and hope we can cancel it when fixed by the Galaxy team. 
Yours, Steffen