### PR TITLE
Fix minor typo in howto_add_markup.md

### DIFF
--- a/pages/_tutorials/howto/howto_add_markup.md
+++ b/pages/_tutorials/howto/howto_add_markup.md
@@ -119,7 +119,7 @@ If you choose to have multiple ```<script type="application/ld+json">``` element
 
 {% include image.html file="/tutorials/images/brca_gene_summary.png" caption="Figure 1: BRCA2 gene summary" alt="BRCA2 gene summary" %}
 
-This summary corresponds to a two-colum ```<div>``` used to show the name, CCDS, UniProtKB and so on. In Figure 2, we show the respective HTML code where the two-column ```<div>``` is highlighted in blue and the row corresponding to the Ensembl version has been expanded. Below this ```<div>``` appears the JSON-LD with the corresponding markup.
+This summary corresponds to a two-column ```<div>``` used to show the name, CCDS, UniProtKB and so on. In Figure 2, we show the respective HTML code where the two-column ```<div>``` is highlighted in blue and the row corresponding to the Ensembl version has been expanded. Below this ```<div>``` appears the JSON-LD with the corresponding markup.
 
 {% include image.html file="/tutorials/images/brca_gene_html.png" caption="Figure 2: Code corresponding to the BRCA2 gene summary" alt="Code corresponding to the BRCA2 gene summary" %}
 


### PR DESCRIPTION
Added missing letter `n` in `column` (section 3.4).