### PR TITLE
Fix link to markup generator http-only on the Software page

### DIFF
--- a/pages/_developer/software.html
+++ b/pages/_developer/software.html
@@ -39,7 +39,7 @@ bioschemas:
           "@type": Person
 
     - "@type": SoftwareApplication
-      "@id": https://www.macs.hw.ac.uk/SWeL/BioschemasGenerator/
+      "@id": http://www.macs.hw.ac.uk/SWeL/BioschemasGenerator/
       "http://purl.org/dc/terms/conformsTo": https://bioschemas.org/profiles/ComputationalTool/1.0-RELEASE
       description: | 
         This web application supports users in the creation of Bioschemas compliant markup required for inclusion on their web resource. Bioschemas provides profiles for Schema.org mark-up in order to structure and expose life-sciences metadata on the web. Each profile brings a list of allowed attributes with their constraints and properties. Some attributes are required, some are composite, some allow multiple values, some are under controlled vocabularies, and some can even be all of that.
@@ -47,7 +47,7 @@ bioschemas:
         The Bioschemas Generator is a web application that assists users in the creation of their metadata structure, through dynamically generated forms, allowing easier development of Bioschemas compliant markup for web resources.  
     
       name: "Bioschemas Generator"
-      url: https://www.macs.hw.ac.uk/SWeL/BioschemasGenerator/
+      url: http://www.macs.hw.ac.uk/SWeL/BioschemasGenerator/
       applicationCategory: generator
       applicationSubCategory: 
         - "@id": http://edamontology.org/topic_0089


### PR DESCRIPTION
The https version of the markup generator appears to work but it is broken (reported here: https://github.com/BioSchemas/BioschemasMarkupGenerator/issues/16). Use the http version for now.