### PR TITLE
Update script and files to include associatedDisease equivalence

### DIFF
--- a/notebooks/BioschemasTypes.ipynb
+++ b/notebooks/BioschemasTypes.ipynb
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "90246e73-5b99-42b6-9c54-28a2fc147ea0",
    "metadata": {},
    "outputs": [],
@@ -220,7 +220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 2,
    "id": "8f5d0652-2029-4cfd-b9cc-9faa9964214f",
    "metadata": {},
    "outputs": [],
@@ -229,7 +229,7 @@
     "\n",
     "    #Classes and properties already aincluded in schema.org\n",
     "    types_in_schema = [\"BioChemEntity\", \"ChemicalSubstance\", \"Gene\", \"MolecularEntity\", \"Protein\", \"Taxon\"]\n",
-    "    properties_in_schema = [\"bioChemInteraction\", \"bioChemSimilarity\", \"biologicalRole\", \"hasBioChemEntityPart\", \"hasMolecularFunction\", \"hasRepresentation\", \"isEncodedByBioChemEntity\", \"isInvolvedInBiologicalProcess\", \"isLocatedInSubcellularLocation\", \"isPartOfBioChemEntity\", \"taxonomicRange\", \"alternativeOf\", \"encodesBioChemEntity\", \"expressedIn\", \"hasBioPolymerSequence\", \"chemicalComposition\", \"chemicalRole\", \"potentialUse\", \"chemicalRole\", \"inChi\", \"inChiKey\", \"iupacName\", \"molecularFormula\", \"molecularWeight\", \"monoisotopicMolecularWeight\", \"smiles\", \"childTaxon\", \"parentTaxon\", \"taxonRank\"]\n",
+    "    properties_in_schema = [\"associatedDisease\", \"bioChemInteraction\", \"bioChemSimilarity\", \"biologicalRole\", \"hasBioChemEntityPart\", \"hasMolecularFunction\", \"hasRepresentation\", \"isEncodedByBioChemEntity\", \"isInvolvedInBiologicalProcess\", \"isLocatedInSubcellularLocation\", \"isPartOfBioChemEntity\", \"taxonomicRange\", \"alternativeOf\", \"encodesBioChemEntity\", \"expressedIn\", \"hasBioPolymerSequence\", \"chemicalComposition\", \"chemicalRole\", \"potentialUse\", \"chemicalRole\", \"inChi\", \"inChiKey\", \"iupacName\", \"molecularFormula\", \"molecularWeight\", \"monoisotopicMolecularWeight\", \"smiles\", \"childTaxon\", \"parentTaxon\", \"taxonRank\"]\n",
     "    eq_schema = URIRef(\"https://schema.org/\")\n",
     "    \n",
     "    #iterates over all classes in the bioschemas namespace\n",
@@ -265,7 +265,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 3,
    "id": "c47ba42a-79a9-416c-bd63-32d72df73210",
    "metadata": {},
    "outputs": [],
@@ -298,7 +298,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 4,
    "id": "7515e020-7489-4238-b879-156fe1d61003",
    "metadata": {},
    "outputs": [],

--- a/pages/_types/bioschemas_types.jsonld
+++ b/pages/_types/bioschemas_types.jsonld
@@ -33,6 +33,252 @@
   },
   "@graph": [
     {
+      "@id": "bioschemas:bioChemInteraction",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/bioChemInteraction"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/bioChemInteraction"
+        },
+        {
+          "@id": "schema:bioChemInteraction"
+        }
+      ],
+      "rdfs:comment": "A BioChemEntity that is know to interact with this item.",
+      "rdfs:label": "bioChemInteraction",
+      "schema:domainIncludes": {
+        "@id": "bioschemas:BioChemEntity"
+      },
+      "schema:rangeIncludes": {
+        "@id": "bioschemas:BioChemEntity"
+      }
+    },
+    {
+      "@id": "bioschemas:childTaxon",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/childTaxon"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/childTaxon"
+        },
+        {
+          "@id": "schema:childTaxon"
+        }
+      ],
+      "rdfs:comment": "Closest child taxa of the taxon in question.\nInverse property: parentTaxon Direct, most proximate lower-rank child taxa",
+      "rdfs:label": "childTaxon",
+      "schema:domainIncludes": {
+        "@id": "bioschemas:Taxon"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Taxon"
+        },
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:URL"
+        }
+      ]
+    },
+    {
+      "@id": "bioschemas:samplingAge",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/samplingAge"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/samplingAge"
+        }
+      ],
+      "rdfs:comment": "The age of the object when the Sample was created. ",
+      "rdfs:label": "samplingAge",
+      "schema:domainIncludes": {
+        "@id": "bioschemas:BioSample"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:Integer"
+      }
+    },
+    {
+      "@id": "bioschemas:hasStatus",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/hasStatus"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/hasStatus"
+        }
+      ],
+      "rdfs:comment": "Schema:  One of pseudogene, dead, killed, live, predicted, suppressed.",
+      "rdfs:label": "hasStatus",
+      "schema:domainIncludes": {
+        "@id": "bioschemas:Gene"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:Text"
+      }
+    },
+    {
+      "@id": "bioschemas:ChemicalSubstance",
+      "@type": "rdfs:Class",
+      "owl:equivalentClass": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/ChemicalSubstance"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/ChemicalSubstance"
+        },
+        {
+          "@id": "schema:ChemicalSubstance"
+        }
+      ],
+      "rdfs:comment": "A chemical substance is 'a portion of matter of constant composition, composed of molecular entities of the same type or of different types' (source: ChEBI:59999). Version: 0.3-RELEASE-2019_09_02. This version is was released as a pending class as of schema.org version 13",
+      "rdfs:label": "ChemicalSubstance",
+      "rdfs:subClassOf": {
+        "@id": "schema:BioChemEntity"
+      },
+      "schema:schemaVersion": [
+        "https://github.com/BioSchemas/specifications/tree/master/ChemicalSubstance/jsonld/type/ChemicalSubstance_v0.3-RELEASE-2019_09_02.json",
+        "https://bioschemas.org/types/ChemicalSubstance/0.3-RELEASE-2019_09_02"
+      ]
+    },
+    {
+      "@id": "bioschemas:additionalProperty",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/additionalProperty"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/additionalProperty"
+        }
+      ],
+      "rdfs:comment": "A property-value pair representing an additional characteristics of the entitity, e.g. a product feature or another characteristic for which there is no matching property in schema.org. Note: Publishers should be aware that applications designed to use specific schema.org properties (e.g. http://schema.org/width, http://schema.org/color, http://schema.org/gtin13, ...) will typically expect such data to be provided using those properties, rather than using the generic property/value mechanism.",
+      "rdfs:label": "additionalProperty",
+      "schema:domainIncludes": {
+        "@id": "bioschemas:BioSample"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:PropertyValue"
+      },
+      "schema:sameAs": {
+        "@id": "schema:additionalProperty"
+      }
+    },
+    {
+      "@id": "bioschemas:monoisotopicMolecularWeight",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/monoisotopicMolecularWeight"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/monoisotopicMolecularWeight"
+        },
+        {
+          "@id": "schema:monoisotopicMolecularWeight"
+        }
+      ],
+      "rdfs:comment": "The monoisotopic mass is the sum of the masses of the atoms in a molecule using the unbound, ground-state, rest mass of the principal (most abundant) isotope for each element instead of the isotopic average mass. Please include the units the form '<Number> <unit>', for example '770.230488 g/mol' or as '<QuantitativeValue>.",
+      "rdfs:label": "monoisotopicMolecularWeight",
+      "schema:domainIncludes": {
+        "@id": "bioschemas:MolecularEntity"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:QuantitativeValue"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "bioschemas:parentTaxon",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/parentTaxon"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/parentTaxon"
+        },
+        {
+          "@id": "schema:parentTaxon"
+        }
+      ],
+      "rdfs:comment": "Closest parent taxon of the taxon in question.\nInverse property: childTaxon Direct, most proximate higher-rank parent taxon",
+      "rdfs:label": "parentTaxon",
+      "schema:domainIncludes": {
+        "@id": "bioschemas:Taxon"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Taxon"
+        },
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:URL"
+        }
+      ]
+    },
+    {
+      "@id": "bioschemas:collector",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/collector"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/collector"
+        }
+      ],
+      "rdfs:comment": "The Person or Organization who collected the Sample. ",
+      "rdfs:label": "collector",
+      "schema:domainIncludes": {
+        "@id": "bioschemas:BioSample"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Organization"
+        },
+        {
+          "@id": "schema:Person"
+        }
+      ]
+    },
+    {
+      "@id": "bioschemas:ComputationalWorkflow",
+      "@type": "rdfs:Class",
+      "owl:equivalentClass": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/ComputationalWorkflow"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/ComputationalWorkflow"
+        }
+      ],
+      "rdfs:comment": "A computational workflow consists of an orchestrated and repeatable pattern of activity enabled by the systematic organization of resources into processes that transform materials, provide services, or process information (source Wikipedia.org). It is executed by a computational process and is thus distinct from laboratory or business workflows. version 1.0-RELEASE",
+      "rdfs:label": "ComputationalWorkflow",
+      "rdfs:subClassOf": {
+        "@id": "schema:SoftwareSourceCode"
+      },
+      "schema:schemaVersion": [
+        "https://bioschemas.org/types/ComputationalWorkflow/1.0-RELEASE",
+        "https://github.com/BioSchemas/specifications/blob/master/ComputationalWorkflow/jsonld/type/ComputationalWorkflow_v1.0-RELEASE.json"
+      ]
+    },
+    {
       "@id": "bioschemas:MolecularEntity",
       "@type": "rdfs:Class",
       "owl:equivalentClass": [
@@ -55,6 +301,187 @@
         "https://bioschemas.org/types/MolecularEntity/0.3-RELEASE-2019_09_02",
         "https://github.com/BioSchemas/specifications/tree/master/MolecularEntity/jsonld/type/MolecularEntity_v0.3-RELEASE-2019_09_02.json"
       ]
+    },
+    {
+      "@id": "bioschemas:TaxonName",
+      "@type": "rdfs:Class",
+      "owl:equivalentClass": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/TaxonName"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/TaxonName"
+        }
+      ],
+      "rdfs:comment": "A name of a biological taxon, may it be valid (zoology) / accepted (botany) or not. Version: 1.0-RELEASE",
+      "rdfs:label": "TaxonName",
+      "rdfs:subClassOf": {
+        "@id": "schema:CreativeWork"
+      },
+      "schema:schemaVersion": [
+        "https://github.com/BioSchemas/specifications/blob/master/TaxonName/jsonld/type/TaxonName_v1.0-RELEASE.json",
+        "https://bioschemas.org/types/TaxonName/1.0-RELEASE"
+      ]
+    },
+    {
+      "@id": "bioschemas:gender",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/gender"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/gender"
+        }
+      ],
+      "rdfs:comment": "Gender of the person. While http://schema.org/Male and http://schema.org/Female may be used, text strings are also acceptable for people who do not identify as a binary gender",
+      "rdfs:label": "gender",
+      "schema:domainIncludes": {
+        "@id": "bioschemas:BioSample"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:GenderType"
+        }
+      ],
+      "schema:sameAs": {
+        "@id": "schema:gender"
+      }
+    },
+    {
+      "@id": "bioschemas:associatedDisease",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/associatedDisease"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/associatedDisease"
+        },
+        {
+          "@id": "schema:associatedDisease"
+        }
+      ],
+      "rdfs:comment": "Disease associated to this BioChemEntity. Such a disease can be a MedicalCondition or a URL. If you want to add an evidence supporting the association, please use PropertyValue.",
+      "rdfs:label": "associatedDisease",
+      "schema:domainIncludes": {
+        "@id": "bioschemas:BioChemEntity"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:MedicalCondition"
+        },
+        {
+          "@id": "schema:URL"
+        },
+        {
+          "@id": "schema:PropertyValue"
+        }
+      ]
+    },
+    {
+      "@id": "bioschemas:inChI",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/inChI"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/inChI"
+        }
+      ],
+      "rdfs:comment": "Non-proprietary identifier for molecular entity that can be used in printed and electronic data sources thus enabling easier linking of diverse data compilations.",
+      "rdfs:label": "inChI",
+      "schema:domainIncludes": {
+        "@id": "bioschemas:MolecularEntity"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:Text"
+      }
+    },
+    {
+      "@id": "bioschemas:molecularWeight",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/molecularWeight"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/molecularWeight"
+        },
+        {
+          "@id": "schema:molecularWeight"
+        }
+      ],
+      "rdfs:comment": "This is the molecular weight of the entity being described, not of the parent. Units should be included in the form '<Number> <unit>', for example '12 amu' or as '<QuantitativeValue>.",
+      "rdfs:label": "molecularWeight",
+      "schema:domainIncludes": {
+        "@id": "bioschemas:MolecularEntity"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:QuantitativeValue"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "bioschemas:custodian",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/custodian"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/custodian"
+        }
+      ],
+      "rdfs:comment": "The Person or Organization who is responsible for the Sample.",
+      "rdfs:label": "custodian",
+      "schema:domainIncludes": {
+        "@id": "bioschemas:BioSample"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Organization"
+        },
+        {
+          "@id": "schema:Person"
+        }
+      ]
+    },
+    {
+      "@id": "bioschemas:potentialUse",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/potentialUse"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/potentialUse"
+        },
+        {
+          "@id": "schema:potentialUse"
+        }
+      ],
+      "rdfs:comment": "Intended use of the BioChemEntity by humans. ",
+      "rdfs:label": "potentialUse",
+      "schema:domainIncludes": [
+        {
+          "@id": "bioschemas:ChemicalSubstance"
+        },
+        {
+          "@id": "bioschemas:MolecularEntity"
+        }
+      ],
+      "schema:rangeIncludes": {
+        "@id": "schema:DefinedTerm"
+      }
     },
     {
       "@id": "bioschemas:molecularFormula",
@@ -80,28 +507,27 @@
       }
     },
     {
-      "@id": "bioschemas:Protein",
-      "@type": "rdfs:Class",
-      "owl:equivalentClass": [
+      "@id": "bioschemas:chemicalComposition",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
         {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/Protein"
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/chemicalComposition"
         },
         {
-          "@id": "https://w3id.org/bioschemas/terms/Protein"
+          "@id": "https://w3id.org/bioschemas/terms/chemicalComposition"
         },
         {
-          "@id": "schema:Protein"
+          "@id": "schema:chemicalComposition"
         }
       ],
-      "rdfs:comment": "Protein is here used in its widest possible definition, as classes of amino acid based molecules. Amyloid-beta Protein in human (UniProt P05067), eukaryota (e.g. an OrthoDB group) or even a single molecule that one can point to are all of type schema:Protein. A protein can thus be a subclass of another protein, e.g. schema:Protein as a UniProt record can have multiple isoforms inside it which would also be schema:Protein. They can be imagined, synthetic, hypothetical or naturally occurring. This version has been added to schema.org as a pending type.",
-      "rdfs:label": "Protein",
-      "rdfs:subClassOf": {
-        "@id": "schema:BioChemEntity"
+      "rdfs:comment": "The chemical composition describes the identity and relative ratio of the chemical elements that make up the substance. For substances this often cannot be accurately determined, an approximation is acceptable.",
+      "rdfs:label": "chemicalComposition",
+      "schema:domainIncludes": {
+        "@id": "bioschemas:ChemicalSubstance"
       },
-      "schema:schemaVersion": [
-        "https://bioschemas.org/types/Protein/0.3-RELEASE-2019_09_02",
-        "https://github.com/BioSchemas/specifications/tree/master/Protein/jsonld/type/Protein_v0.3-RELEASE-2019_09_02.json"
-      ]
+      "schema:rangeIncludes": {
+        "@id": "schema:Text"
+      }
     },
     {
       "@id": "bioschemas:expressedIn",
@@ -138,116 +564,21 @@
       ]
     },
     {
-      "@id": "bioschemas:scientificName",
+      "@id": "bioschemas:isInvolvedInBiologicalProcess",
       "@type": "rdf:Property",
       "owl:equivalentProperty": [
         {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/scientificName"
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/isInvolvedInBiologicalProcess"
         },
         {
-          "@id": "https://w3id.org/bioschemas/terms/scientificName"
+          "@id": "https://w3id.org/bioschemas/terms/isInvolvedInBiologicalProcess"
+        },
+        {
+          "@id": "schema:isInvolvedInBiologicalProcess"
         }
       ],
-      "rdfs:comment": "A TaxonName representing the currently valid (zoological) or accepted (botanical) name for that taxon.",
-      "rdfs:label": "scientificName",
-      "schema:domainIncludes": {
-        "@id": "bioschemas:Taxon"
-      },
-      "schema:rangeIncludes": [
-        {
-          "@id": "bioschemas:TaxonName"
-        },
-        {
-          "@id": "schema:Text"
-        },
-        {
-          "@id": "schema:URL"
-        }
-      ]
-    },
-    {
-      "@id": "bioschemas:additionalProperty",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/additionalProperty"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/additionalProperty"
-        }
-      ],
-      "rdfs:comment": "A property-value pair representing an additional characteristics of the entitity, e.g. a product feature or another characteristic for which there is no matching property in schema.org. Note: Publishers should be aware that applications designed to use specific schema.org properties (e.g. http://schema.org/width, http://schema.org/color, http://schema.org/gtin13, ...) will typically expect such data to be provided using those properties, rather than using the generic property/value mechanism.",
-      "rdfs:label": "additionalProperty",
-      "schema:domainIncludes": {
-        "@id": "bioschemas:BioSample"
-      },
-      "schema:rangeIncludes": {
-        "@id": "schema:PropertyValue"
-      },
-      "schema:sameAs": {
-        "@id": "schema:additionalProperty"
-      }
-    },
-    {
-      "@id": "bioschemas:ComputationalWorkflow",
-      "@type": "rdfs:Class",
-      "owl:equivalentClass": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/ComputationalWorkflow"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/ComputationalWorkflow"
-        }
-      ],
-      "rdfs:comment": "A computational workflow consists of an orchestrated and repeatable pattern of activity enabled by the systematic organization of resources into processes that transform materials, provide services, or process information (source Wikipedia.org). It is executed by a computational process and is thus distinct from laboratory or business workflows. version 1.0-RELEASE",
-      "rdfs:label": "ComputationalWorkflow",
-      "rdfs:subClassOf": {
-        "@id": "schema:SoftwareSourceCode"
-      },
-      "schema:schemaVersion": [
-        "https://bioschemas.org/types/ComputationalWorkflow/1.0-RELEASE",
-        "https://github.com/BioSchemas/specifications/blob/master/ComputationalWorkflow/jsonld/type/ComputationalWorkflow_v1.0-RELEASE.json"
-      ]
-    },
-    {
-      "@id": "bioschemas:funding",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/funding"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/funding"
-        }
-      ],
-      "rdfs:comment": "The funding for the workflow",
-      "rdfs:label": "funding",
-      "schema:domainIncludes": {
-        "@id": "bioschemas:ComputationalWorkflow"
-      },
-      "schema:rangeIncludes": {
-        "@id": "schema:Grant"
-      },
-      "schema:sameAs": {
-        "@id": "schema:funding"
-      }
-    },
-    {
-      "@id": "bioschemas:taxonomicRange",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/taxonomicRange"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/taxonomicRange"
-        },
-        {
-          "@id": "schema:taxonomicRange"
-        }
-      ],
-      "rdfs:comment": "The taxonomic grouping of the organism that expresses, encodes, or in someway related to the BioChemEntity.",
-      "rdfs:label": "taxonomicRange",
+      "rdfs:comment": "Biological process this BioChemEntity is involved in; please use PropertyValue if you want to include any evidence.",
+      "rdfs:label": "isInvolvedInBiologicalProcess",
       "schema:domainIncludes": {
         "@id": "bioschemas:BioChemEntity"
       },
@@ -260,9 +591,6 @@
         },
         {
           "@id": "schema:URL"
-        },
-        {
-          "@id": "bioschemas:Taxon"
         }
       ]
     },
@@ -290,262 +618,27 @@
       }
     },
     {
-      "@id": "bioschemas:iupacName",
+      "@id": "bioschemas:isEncodedByBioChemEntity",
       "@type": "rdf:Property",
       "owl:equivalentProperty": [
         {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/iupacName"
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/isEncodedByBioChemEntity"
         },
         {
-          "@id": "https://w3id.org/bioschemas/terms/iupacName"
+          "@id": "https://w3id.org/bioschemas/terms/isEncodedByBioChemEntity"
         },
         {
-          "@id": "schema:iupacName"
+          "@id": "schema:isEncodedByBioChemEntity"
         }
       ],
-      "rdfs:comment": "Systematic method of naming chemical compounds as recommended by the International Union of Pure and Applied Chemistry (IUPAC).",
-      "rdfs:label": "iupacName",
+      "rdfs:comment": "Another BioChemEntity encoding this one. Inverse property: encodesBioChemEntity.",
+      "rdfs:label": "isEncodedByBioChemEntity",
       "schema:domainIncludes": {
-        "@id": "bioschemas:MolecularEntity"
+        "@id": "bioschemas:BioChemEntity"
       },
       "schema:rangeIncludes": {
-        "@id": "schema:Text"
+        "@id": "bioschemas:Gene"
       }
-    },
-    {
-      "@id": "bioschemas:parentTaxon",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/parentTaxon"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/parentTaxon"
-        },
-        {
-          "@id": "schema:parentTaxon"
-        }
-      ],
-      "rdfs:comment": "Closest parent taxon of the taxon in question.\nInverse property: childTaxon Direct, most proximate higher-rank parent taxon",
-      "rdfs:label": "parentTaxon",
-      "schema:domainIncludes": {
-        "@id": "bioschemas:Taxon"
-      },
-      "schema:rangeIncludes": [
-        {
-          "@id": "schema:Taxon"
-        },
-        {
-          "@id": "schema:Text"
-        },
-        {
-          "@id": "schema:URL"
-        }
-      ]
-    },
-    {
-      "@id": "bioschemas:inChIKey",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/inChIKey"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/inChIKey"
-        }
-      ],
-      "rdfs:comment": "InChIKey is a hashed version of the full InChI (using the SHA-256 algorithm).",
-      "rdfs:label": "inChIKey",
-      "schema:domainIncludes": {
-        "@id": "bioschemas:MolecularEntity"
-      },
-      "schema:rangeIncludes": {
-        "@id": "schema:Text"
-      }
-    },
-    {
-      "@id": "bioschemas:taxonRank",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/taxonRank"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/taxonRank"
-        },
-        {
-          "@id": "schema:taxonRank"
-        }
-      ],
-      "rdfs:comment": "The taxonomic rank of this taxon given preferably as a URI from a controlled vocabulary (e.g. the ranks from TDWG TaxonRank ontology or equivalent Wikidata URIs) ",
-      "rdfs:label": "taxonRank",
-      "schema:domainIncludes": [
-        {
-          "@id": "bioschemas:Taxon"
-        },
-        {
-          "@id": "bioschemas:TaxonName"
-        }
-      ],
-      "schema:rangeIncludes": [
-        {
-          "@id": "schema:PropertyValue"
-        },
-        {
-          "@id": "schema:Text"
-        },
-        {
-          "@id": "schema:URL"
-        }
-      ]
-    },
-    {
-      "@id": "bioschemas:Taxon",
-      "@type": "rdfs:Class",
-      "owl:equivalentClass": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/Taxon"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/Taxon"
-        },
-        {
-          "@id": "schema:Taxon"
-        }
-      ],
-      "rdfs:comment": "A set of organisms asserted to represent a natural cohesive biological unit. Version: 1.0-RELEASE",
-      "rdfs:label": "Taxon",
-      "rdfs:subClassOf": {
-        "@id": "schema:Thing"
-      },
-      "schema:schemaVersion": [
-        "https://github.com/BioSchemas/specifications/blob/master/Taxon/jsonld/type/Taxon_v1.0-RELEASE.json",
-        "https://bioschemas.org/types/Taxon/1.0-RELEASE"
-      ]
-    },
-    {
-      "@id": "bioschemas:alternateScientificName",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/alternateScientificName"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/alternateScientificName"
-        }
-      ],
-      "rdfs:comment": "A TaxonName representing a scientific name, with authorship and date information if known, of a synonym of the currently valid (zoological) or accepted (botanical) name.",
-      "rdfs:label": "alternateScientificName",
-      "schema:domainIncludes": {
-        "@id": "bioschemas:Taxon"
-      },
-      "schema:rangeIncludes": [
-        {
-          "@id": "bioschemas:TaxonName"
-        },
-        {
-          "@id": "schema:Text"
-        },
-        {
-          "@id": "schema:URL"
-        }
-      ]
-    },
-    {
-      "@id": "bioschemas:locationCreated",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/locationCreated"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/locationCreated"
-        }
-      ],
-      "rdfs:comment": "The location where the CreativeWork was created, which may not be the same as the location depicted in the CreativeWork. ",
-      "rdfs:label": "locationCreated",
-      "schema:domainIncludes": {
-        "@id": "bioschemas:BioSample"
-      },
-      "schema:rangeIncludes": {
-        "@id": "schema:Place"
-      },
-      "schema:sameAs": {
-        "@id": "schema:locationCreated"
-      }
-    },
-    {
-      "@id": "bioschemas:samplingAge",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/samplingAge"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/samplingAge"
-        }
-      ],
-      "rdfs:comment": "The age of the object when the Sample was created. ",
-      "rdfs:label": "samplingAge",
-      "schema:domainIncludes": {
-        "@id": "bioschemas:BioSample"
-      },
-      "schema:rangeIncludes": {
-        "@id": "schema:Integer"
-      }
-    },
-    {
-      "@id": "bioschemas:defaultValue",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/defaultValue"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/defaultValue"
-        }
-      ],
-      "rdfs:comment": "The default value for the FormalParameter. This is commonly only used for Inputs.",
-      "rdfs:label": "defaultValue",
-      "schema:domainIncludes": {
-        "@id": "bioschemas:FormalParameter"
-      },
-      "schema:rangeIncludes": [
-        {
-          "@id": "schema:Text"
-        },
-        {
-          "@id": "schema:Thing"
-        }
-      ]
-    },
-    {
-      "@id": "bioschemas:monoisotopicMolecularWeight",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/monoisotopicMolecularWeight"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/monoisotopicMolecularWeight"
-        },
-        {
-          "@id": "schema:monoisotopicMolecularWeight"
-        }
-      ],
-      "rdfs:comment": "The monoisotopic mass is the sum of the masses of the atoms in a molecule using the unbound, ground-state, rest mass of the principal (most abundant) isotope for each element instead of the isotopic average mass. Please include the units the form '<Number> <unit>', for example '770.230488 g/mol' or as '<QuantitativeValue>.",
-      "rdfs:label": "monoisotopicMolecularWeight",
-      "schema:domainIncludes": {
-        "@id": "bioschemas:MolecularEntity"
-      },
-      "schema:rangeIncludes": [
-        {
-          "@id": "schema:QuantitativeValue"
-        },
-        {
-          "@id": "schema:Text"
-        }
-      ]
     },
     {
       "@id": "bioschemas:dateCreated",
@@ -596,27 +689,401 @@
       ]
     },
     {
-      "@id": "bioschemas:biologicalRole",
+      "@id": "bioschemas:isPartOfBioChemEntity",
       "@type": "rdf:Property",
       "owl:equivalentProperty": [
         {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/biologicalRole"
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/isPartOfBioChemEntity"
         },
         {
-          "@id": "https://w3id.org/bioschemas/terms/biologicalRole"
+          "@id": "https://w3id.org/bioschemas/terms/isPartOfBioChemEntity"
         },
         {
-          "@id": "schema:biologicalRole"
+          "@id": "schema:isPartOfBioChemEntity"
         }
       ],
-      "rdfs:comment": "A role played by the molecular entity within a biological context.",
-      "rdfs:label": "biologicalRole",
+      "rdfs:comment": "Indicates a BioChemEntity that is (in some sense) a part of this BioChemEntity. Inverse property: hasBioChemEntityPart",
+      "rdfs:label": "isPartOfBioChemEntity",
       "schema:domainIncludes": {
         "@id": "bioschemas:BioChemEntity"
       },
       "schema:rangeIncludes": {
-        "@id": "schema:DefinedTerm"
+        "@id": "bioschemas:BioChemEntity"
       }
+    },
+    {
+      "@id": "bioschemas:isLocatedInSubcellularLocation",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/isLocatedInSubcellularLocation"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/isLocatedInSubcellularLocation"
+        },
+        {
+          "@id": "schema:isLocatedInSubcellularLocation"
+        }
+      ],
+      "rdfs:comment": "Subcellular location where this BioChemEntity is located; please use PropertyValue if you want to include any evidence.",
+      "rdfs:label": "isLocatedInSubcellularLocation",
+      "schema:domainIncludes": {
+        "@id": "bioschemas:BioChemEntity"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:DefinedTerm"
+        },
+        {
+          "@id": "schema:PropertyValue"
+        },
+        {
+          "@id": "schema:URL"
+        }
+      ]
+    },
+    {
+      "@id": "bioschemas:hasBioPolymerSequence",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/hasBioPolymerSequence"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/hasBioPolymerSequence"
+        },
+        {
+          "@id": "schema:hasBioPolymerSequence"
+        }
+      ],
+      "rdfs:comment": "A symbolic representation of a BioChemEnity. For example, a nucleotide sequence of a Gene or an amino acid sequence of a Protein.",
+      "rdfs:label": "hasBioPolymerSequence",
+      "schema:domainIncludes": [
+        {
+          "@id": "bioschemas:Gene"
+        },
+        {
+          "@id": "bioschemas:Protein"
+        }
+      ],
+      "schema:rangeIncludes": {
+        "@id": "schema:Text"
+      }
+    },
+    {
+      "@id": "bioschemas:hasMolecularFunction",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/hasMolecularFunction"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/hasMolecularFunction"
+        },
+        {
+          "@id": "schema:hasMolecularFunction"
+        }
+      ],
+      "rdfs:comment": "Molecular function performed by this BioChemEntity; please use PropertyValue if you want to include any evidence.",
+      "rdfs:label": "hasMolecularFunction",
+      "schema:domainIncludes": {
+        "@id": "bioschemas:BioChemEntity"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:DefinedTerm"
+        },
+        {
+          "@id": "schema:PropertyValue"
+        },
+        {
+          "@id": "schema:URL"
+        }
+      ]
+    },
+    {
+      "@id": "bioschemas:taxonomicRange",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/taxonomicRange"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/taxonomicRange"
+        },
+        {
+          "@id": "schema:taxonomicRange"
+        }
+      ],
+      "rdfs:comment": "The taxonomic grouping of the organism that expresses, encodes, or in someway related to the BioChemEntity.",
+      "rdfs:label": "taxonomicRange",
+      "schema:domainIncludes": {
+        "@id": "bioschemas:BioChemEntity"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:DefinedTerm"
+        },
+        {
+          "@id": "schema:PropertyValue"
+        },
+        {
+          "@id": "schema:URL"
+        },
+        {
+          "@id": "bioschemas:Taxon"
+        }
+      ]
+    },
+    {
+      "@id": "bioschemas:hasBioChemEntityPart",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/hasBioChemEntityPart"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/hasBioChemEntityPart"
+        },
+        {
+          "@id": "schema:hasBioChemEntityPart"
+        }
+      ],
+      "rdfs:comment": "Indicates a BioChemEntity that (in some sense) has this BioChemEntity as a part. Inverse property: isPartOfBioChemEntity",
+      "rdfs:label": "hasBioChemEntityPart",
+      "schema:domainIncludes": {
+        "@id": "bioschemas:BioChemEntity"
+      },
+      "schema:rangeIncludes": {
+        "@id": "bioschemas:BioChemEntity"
+      }
+    },
+    {
+      "@id": "bioschemas:scientificName",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/scientificName"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/scientificName"
+        }
+      ],
+      "rdfs:comment": "A TaxonName representing the currently valid (zoological) or accepted (botanical) name for that taxon.",
+      "rdfs:label": "scientificName",
+      "schema:domainIncludes": {
+        "@id": "bioschemas:Taxon"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "bioschemas:TaxonName"
+        },
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:URL"
+        }
+      ]
+    },
+    {
+      "@id": "bioschemas:alternativeOf",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/alternativeOf"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/alternativeOf"
+        },
+        {
+          "@id": "schema:alternativeOf"
+        }
+      ],
+      "rdfs:comment": "Another gene which is a variation of this one.",
+      "rdfs:label": "alternativeOf",
+      "schema:domainIncludes": {
+        "@id": "bioschemas:Gene"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:Gene"
+      }
+    },
+    {
+      "@id": "bioschemas:taxonRank",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/taxonRank"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/taxonRank"
+        },
+        {
+          "@id": "schema:taxonRank"
+        }
+      ],
+      "rdfs:comment": "The taxonomic rank of this taxon given preferably as a URI from a controlled vocabulary (e.g. the ranks from TDWG TaxonRank ontology or equivalent Wikidata URIs) ",
+      "rdfs:label": "taxonRank",
+      "schema:domainIncludes": [
+        {
+          "@id": "bioschemas:Taxon"
+        },
+        {
+          "@id": "bioschemas:TaxonName"
+        }
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:PropertyValue"
+        },
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:URL"
+        }
+      ]
+    },
+    {
+      "@id": "bioschemas:encodingFormat",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/encodingFormat"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/encodingFormat"
+        }
+      ],
+      "rdfs:comment": "URLs to accepted formats.  It is strongly recommented that this be specified. If it is not specified, then nothing should be assumed about the encoding formats of the FormalParameter. Recommended ontology: http://edamontology.org/format_1915",
+      "rdfs:label": "encodingFormat",
+      "schema:domainIncludes": {
+        "@id": "bioschemas:FormalParameter"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:URL"
+        }
+      ]
+    },
+    {
+      "@id": "bioschemas:valueRequired",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/valueRequired"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/valueRequired"
+        }
+      ],
+      "rdfs:comment": "If the FormalParameter must be specified. This is commonly only used for Inputs",
+      "rdfs:label": "valueRequired",
+      "schema:domainIncludes": {
+        "@id": "bioschemas:FormalParameter"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:Boolean"
+      }
+    },
+    {
+      "@id": "bioschemas:locationCreated",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/locationCreated"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/locationCreated"
+        }
+      ],
+      "rdfs:comment": "The location where the CreativeWork was created, which may not be the same as the location depicted in the CreativeWork. ",
+      "rdfs:label": "locationCreated",
+      "schema:domainIncludes": {
+        "@id": "bioschemas:BioSample"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:Place"
+      },
+      "schema:sameAs": {
+        "@id": "schema:locationCreated"
+      }
+    },
+    {
+      "@id": "bioschemas:bioChemSimilarity",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/bioChemSimilarity"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/bioChemSimilarity"
+        },
+        {
+          "@id": "schema:bioChemSimilarity"
+        }
+      ],
+      "rdfs:comment": "A similar molecular entity, e.g., obtained by fingerprint similarity algorithm.",
+      "rdfs:label": "bioChemSimilarity",
+      "schema:domainIncludes": {
+        "@id": "bioschemas:BioChemEntity"
+      },
+      "schema:rangeIncludes": {
+        "@id": "bioschemas:BioChemEntity"
+      }
+    },
+    {
+      "@id": "bioschemas:FormalParameter",
+      "@type": "rdfs:Class",
+      "owl:equivalentClass": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/FormalParameter"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/FormalParameter"
+        }
+      ],
+      "rdfs:comment": "A FormalParameter is an identified variable used to stand for the actual value(s) that are consumed/produced by a set of steps. Version: 1.0-RELEASE (09 March 2021) ",
+      "rdfs:label": "FormalParameter",
+      "rdfs:subClassOf": {
+        "@id": "schema:Intangible"
+      },
+      "schema:schemaVersion": [
+        "https://bioschemas.org/types/FormalParameter/1.0-RELEASE",
+        "https://github.com/BioSchemas/specifications/blob/master/FormalParameter/jsonld/type/FormalParameter_v1.0-RELEASE.json"
+      ]
+    },
+    {
+      "@id": "bioschemas:alternateScientificName",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/alternateScientificName"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/alternateScientificName"
+        }
+      ],
+      "rdfs:comment": "A TaxonName representing a scientific name, with authorship and date information if known, of a synonym of the currently valid (zoological) or accepted (botanical) name.",
+      "rdfs:label": "alternateScientificName",
+      "schema:domainIncludes": {
+        "@id": "bioschemas:Taxon"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "bioschemas:TaxonName"
+        },
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:URL"
+        }
+      ]
     },
     {
       "@id": "dct:conformsTo",
@@ -668,249 +1135,70 @@
       ]
     },
     {
-      "@id": "bioschemas:TaxonName",
-      "@type": "rdfs:Class",
-      "owl:equivalentClass": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/TaxonName"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/TaxonName"
-        }
-      ],
-      "rdfs:comment": "A name of a biological taxon, may it be valid (zoology) / accepted (botany) or not. Version: 1.0-RELEASE",
-      "rdfs:label": "TaxonName",
-      "rdfs:subClassOf": {
-        "@id": "schema:CreativeWork"
-      },
-      "schema:schemaVersion": [
-        "https://github.com/BioSchemas/specifications/blob/master/TaxonName/jsonld/type/TaxonName_v1.0-RELEASE.json",
-        "https://bioschemas.org/types/TaxonName/1.0-RELEASE"
-      ]
-    },
-    {
-      "@id": "bioschemas:custodian",
+      "@id": "bioschemas:encodesBioChemEntity",
       "@type": "rdf:Property",
       "owl:equivalentProperty": [
         {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/custodian"
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/encodesBioChemEntity"
         },
         {
-          "@id": "https://w3id.org/bioschemas/terms/custodian"
+          "@id": "https://w3id.org/bioschemas/terms/encodesBioChemEntity"
+        },
+        {
+          "@id": "schema:encodesBioChemEntity"
         }
       ],
-      "rdfs:comment": "The Person or Organization who is responsible for the Sample.",
-      "rdfs:label": "custodian",
+      "rdfs:comment": "Another BioChemEntity encoded by this one. Inverse property: isEncodedByBioChemEntity.",
+      "rdfs:label": "encodesBioChemEntity",
+      "schema:domainIncludes": {
+        "@id": "bioschemas:Gene"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:BioChemEntity"
+      }
+    },
+    {
+      "@id": "bioschemas:isControl",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/isControl"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/isControl"
+        }
+      ],
+      "rdfs:comment": "Indicates whether the sample is being used as a normal control, may be in combination with another sample.",
+      "rdfs:label": "isControl",
       "schema:domainIncludes": {
         "@id": "bioschemas:BioSample"
       },
-      "schema:rangeIncludes": [
-        {
-          "@id": "schema:Organization"
-        },
-        {
-          "@id": "schema:Person"
-        }
-      ]
-    },
-    {
-      "@id": "bioschemas:BioSample",
-      "@type": "rdfs:Class",
-      "owl:equivalentClass": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/BioSample"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/BioSample"
-        }
-      ],
-      "rdfs:comment": "A biological material entity that is representative of a whole.\nComments: Typically samples are intended to be representative of the whole or aspects thereof. Examples of samples include biomedical samples (blood, urine) and plant specimens held at herbaria. Version 0.1-RELEASE. Note, the parent class for this schema has been updated to a pending class in schema.org.",
-      "rdfs:label": "BioSample",
-      "rdfs:subClassOf": {
-        "@id": "schema:BioChemEntity"
-      },
-      "schema:schemaVersion": [
-        "https://github.com/BioSchemas/specifications/tree/master/BioSample/jsonld/type/BioSample_v0.1-RELEASE.json",
-        "https://bioschemas.org/types/BioSample/0.1-RELEASE"
-      ]
-    },
-    {
-      "@id": "bioschemas:isInvolvedInBiologicalProcess",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/isInvolvedInBiologicalProcess"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/isInvolvedInBiologicalProcess"
-        },
-        {
-          "@id": "schema:isInvolvedInBiologicalProcess"
-        }
-      ],
-      "rdfs:comment": "Biological process this BioChemEntity is involved in; please use PropertyValue if you want to include any evidence.",
-      "rdfs:label": "isInvolvedInBiologicalProcess",
-      "schema:domainIncludes": {
-        "@id": "bioschemas:BioChemEntity"
-      },
-      "schema:rangeIncludes": [
-        {
-          "@id": "schema:DefinedTerm"
-        },
-        {
-          "@id": "schema:PropertyValue"
-        },
-        {
-          "@id": "schema:URL"
-        }
-      ]
-    },
-    {
-      "@id": "bioschemas:Gene",
-      "@type": "rdfs:Class",
-      "owl:equivalentClass": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/Gene"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/Gene"
-        },
-        {
-          "@id": "schema:Gene"
-        }
-      ],
-      "rdfs:comment": "A discrete unit of inheritance which affects one or more biological traits (Source: https://en.wikipedia.org/wiki/Gene). Examples include FOXP2 (Forkhead box protein P2), SCARNA21 (small Cajal body-specific RNA 21), A- (agouti genotype). Note, this version of the type has been added as a pending class in schema.org.",
-      "rdfs:label": "Gene",
-      "rdfs:subClassOf": {
-        "@id": "schema:BioChemEntity"
-      },
-      "schema:schemaVersion": [
-        "https://bioschemas.org/types/Gene/0.3-RELEASE-2019_09_02",
-        "https://github.com/BioSchemas/specifications/tree/master/Gene/jsonld/type/Gene_v0.3-RELEASE-2019_09_02.json"
-      ]
-    },
-    {
-      "@id": "bioschemas:hasBioChemEntityPart",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/hasBioChemEntityPart"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/hasBioChemEntityPart"
-        },
-        {
-          "@id": "schema:hasBioChemEntityPart"
-        }
-      ],
-      "rdfs:comment": "Indicates a BioChemEntity that (in some sense) has this BioChemEntity as a part. Inverse property: isPartOfBioChemEntity",
-      "rdfs:label": "hasBioChemEntityPart",
-      "schema:domainIncludes": {
-        "@id": "bioschemas:BioChemEntity"
-      },
       "schema:rangeIncludes": {
-        "@id": "bioschemas:BioChemEntity"
+        "@id": "schema:Boolean"
       }
     },
     {
-      "@id": "bioschemas:potentialUse",
+      "@id": "bioschemas:defaultValue",
       "@type": "rdf:Property",
       "owl:equivalentProperty": [
         {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/potentialUse"
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/defaultValue"
         },
         {
-          "@id": "https://w3id.org/bioschemas/terms/potentialUse"
-        },
-        {
-          "@id": "schema:potentialUse"
+          "@id": "https://w3id.org/bioschemas/terms/defaultValue"
         }
       ],
-      "rdfs:comment": "Intended use of the BioChemEntity by humans. ",
-      "rdfs:label": "potentialUse",
-      "schema:domainIncludes": [
-        {
-          "@id": "bioschemas:ChemicalSubstance"
-        },
-        {
-          "@id": "bioschemas:MolecularEntity"
-        }
-      ],
-      "schema:rangeIncludes": {
-        "@id": "schema:DefinedTerm"
-      }
-    },
-    {
-      "@id": "bioschemas:output",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/output"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/output"
-        }
-      ],
-      "rdfs:comment": "An output produced by the workflow",
-      "rdfs:label": "output",
+      "rdfs:comment": "The default value for the FormalParameter. This is commonly only used for Inputs.",
+      "rdfs:label": "defaultValue",
       "schema:domainIncludes": {
-        "@id": "bioschemas:ComputationalWorkflow"
-      },
-      "schema:rangeIncludes": {
         "@id": "bioschemas:FormalParameter"
-      }
-    },
-    {
-      "@id": "bioschemas:isEncodedByBioChemEntity",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/isEncodedByBioChemEntity"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/isEncodedByBioChemEntity"
-        },
-        {
-          "@id": "schema:isEncodedByBioChemEntity"
-        }
-      ],
-      "rdfs:comment": "Another BioChemEntity encoding this one. Inverse property: encodesBioChemEntity.",
-      "rdfs:label": "isEncodedByBioChemEntity",
-      "schema:domainIncludes": {
-        "@id": "bioschemas:BioChemEntity"
-      },
-      "schema:rangeIncludes": {
-        "@id": "bioschemas:Gene"
-      }
-    },
-    {
-      "@id": "bioschemas:hasMolecularFunction",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/hasMolecularFunction"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/hasMolecularFunction"
-        },
-        {
-          "@id": "schema:hasMolecularFunction"
-        }
-      ],
-      "rdfs:comment": "Molecular function performed by this BioChemEntity; please use PropertyValue if you want to include any evidence.",
-      "rdfs:label": "hasMolecularFunction",
-      "schema:domainIncludes": {
-        "@id": "bioschemas:BioChemEntity"
       },
       "schema:rangeIncludes": [
         {
-          "@id": "schema:DefinedTerm"
+          "@id": "schema:Text"
         },
         {
-          "@id": "schema:PropertyValue"
-        },
-        {
-          "@id": "schema:URL"
+          "@id": "schema:Thing"
         }
       ]
     },
@@ -943,6 +1231,30 @@
       }
     },
     {
+      "@id": "bioschemas:Taxon",
+      "@type": "rdfs:Class",
+      "owl:equivalentClass": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/Taxon"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/Taxon"
+        },
+        {
+          "@id": "schema:Taxon"
+        }
+      ],
+      "rdfs:comment": "A set of organisms asserted to represent a natural cohesive biological unit. Version: 1.0-RELEASE",
+      "rdfs:label": "Taxon",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      },
+      "schema:schemaVersion": [
+        "https://github.com/BioSchemas/specifications/blob/master/Taxon/jsonld/type/Taxon_v1.0-RELEASE.json",
+        "https://bioschemas.org/types/Taxon/1.0-RELEASE"
+      ]
+    },
+    {
       "@id": "bioschemas:BioChemEntity",
       "@type": "rdfs:Class",
       "owl:equivalentClass": [
@@ -967,382 +1279,25 @@
       ]
     },
     {
-      "@id": "bioschemas:chemicalComposition",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/chemicalComposition"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/chemicalComposition"
-        },
-        {
-          "@id": "schema:chemicalComposition"
-        }
-      ],
-      "rdfs:comment": "The chemical composition describes the identity and relative ratio of the chemical elements that make up the substance. For substances this often cannot be accurately determined, an approximation is acceptable.",
-      "rdfs:label": "chemicalComposition",
-      "schema:domainIncludes": {
-        "@id": "bioschemas:ChemicalSubstance"
-      },
-      "schema:rangeIncludes": {
-        "@id": "schema:Text"
-      }
-    },
-    {
-      "@id": "bioschemas:collector",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/collector"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/collector"
-        }
-      ],
-      "rdfs:comment": "The Person or Organization who collected the Sample. ",
-      "rdfs:label": "collector",
-      "schema:domainIncludes": {
-        "@id": "bioschemas:BioSample"
-      },
-      "schema:rangeIncludes": [
-        {
-          "@id": "schema:Organization"
-        },
-        {
-          "@id": "schema:Person"
-        }
-      ]
-    },
-    {
-      "@id": "bioschemas:isPartOfBioChemEntity",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/isPartOfBioChemEntity"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/isPartOfBioChemEntity"
-        },
-        {
-          "@id": "schema:isPartOfBioChemEntity"
-        }
-      ],
-      "rdfs:comment": "Indicates a BioChemEntity that is (in some sense) a part of this BioChemEntity. Inverse property: hasBioChemEntityPart",
-      "rdfs:label": "isPartOfBioChemEntity",
-      "schema:domainIncludes": {
-        "@id": "bioschemas:BioChemEntity"
-      },
-      "schema:rangeIncludes": {
-        "@id": "bioschemas:BioChemEntity"
-      }
-    },
-    {
-      "@id": "bioschemas:itemLocation",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/itemLocation"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/itemLocation"
-        }
-      ],
-      "rdfs:comment": "Current location of the item. ",
-      "rdfs:label": "itemLocation",
-      "schema:domainIncludes": {
-        "@id": "bioschemas:BioSample"
-      },
-      "schema:rangeIncludes": [
-        {
-          "@id": "schema:Place"
-        },
-        {
-          "@id": "schema:PostalAddress"
-        },
-        {
-          "@id": "schema:Text"
-        }
-      ]
-    },
-    {
-      "@id": "bioschemas:alternativeOf",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/alternativeOf"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/alternativeOf"
-        },
-        {
-          "@id": "schema:alternativeOf"
-        }
-      ],
-      "rdfs:comment": "Another gene which is a variation of this one.",
-      "rdfs:label": "alternativeOf",
-      "schema:domainIncludes": {
-        "@id": "bioschemas:Gene"
-      },
-      "schema:rangeIncludes": {
-        "@id": "schema:Gene"
-      }
-    },
-    {
-      "@id": "bioschemas:gender",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/gender"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/gender"
-        }
-      ],
-      "rdfs:comment": "Gender of the person. While http://schema.org/Male and http://schema.org/Female may be used, text strings are also acceptable for people who do not identify as a binary gender",
-      "rdfs:label": "gender",
-      "schema:domainIncludes": {
-        "@id": "bioschemas:BioSample"
-      },
-      "schema:rangeIncludes": [
-        {
-          "@id": "schema:Text"
-        },
-        {
-          "@id": "schema:GenderType"
-        }
-      ],
-      "schema:sameAs": {
-        "@id": "schema:gender"
-      }
-    },
-    {
-      "@id": "bioschemas:encodesBioChemEntity",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/encodesBioChemEntity"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/encodesBioChemEntity"
-        },
-        {
-          "@id": "schema:encodesBioChemEntity"
-        }
-      ],
-      "rdfs:comment": "Another BioChemEntity encoded by this one. Inverse property: isEncodedByBioChemEntity.",
-      "rdfs:label": "encodesBioChemEntity",
-      "schema:domainIncludes": {
-        "@id": "bioschemas:Gene"
-      },
-      "schema:rangeIncludes": {
-        "@id": "schema:BioChemEntity"
-      }
-    },
-    {
-      "@id": "bioschemas:encodingFormat",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/encodingFormat"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/encodingFormat"
-        }
-      ],
-      "rdfs:comment": "URLs to accepted formats.  It is strongly recommented that this be specified. If it is not specified, then nothing should be assumed about the encoding formats of the FormalParameter. Recommended ontology: http://edamontology.org/format_1915",
-      "rdfs:label": "encodingFormat",
-      "schema:domainIncludes": {
-        "@id": "bioschemas:FormalParameter"
-      },
-      "schema:rangeIncludes": [
-        {
-          "@id": "schema:Text"
-        },
-        {
-          "@id": "schema:URL"
-        }
-      ]
-    },
-    {
-      "@id": "bioschemas:input",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/input"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/input"
-        }
-      ],
-      "rdfs:comment": "An input required to use the computational workflow (eg. Excel spreadsheet, BAM file)",
-      "rdfs:label": "input",
-      "schema:domainIncludes": {
-        "@id": "bioschemas:ComputationalWorkflow"
-      },
-      "schema:rangeIncludes": {
-        "@id": "bioschemas:FormalParameter"
-      }
-    },
-    {
-      "@id": "bioschemas:associatedDisease",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/associatedDisease"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/associatedDisease"
-        }
-      ],
-      "rdfs:comment": "Disease associated to this BioChemEntity. Such a disease can be a MedicalCondition or a URL. If you want to add an evidence supporting the association, please use PropertyValue.",
-      "rdfs:label": "associatedDisease",
-      "schema:domainIncludes": {
-        "@id": "bioschemas:BioChemEntity"
-      },
-      "schema:rangeIncludes": [
-        {
-          "@id": "schema:MedicalCondition"
-        },
-        {
-          "@id": "schema:URL"
-        },
-        {
-          "@id": "schema:PropertyValue"
-        }
-      ]
-    },
-    {
-      "@id": "bioschemas:FormalParameter",
+      "@id": "bioschemas:BioSample",
       "@type": "rdfs:Class",
       "owl:equivalentClass": [
         {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/FormalParameter"
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/BioSample"
         },
         {
-          "@id": "https://w3id.org/bioschemas/terms/FormalParameter"
+          "@id": "https://w3id.org/bioschemas/terms/BioSample"
         }
       ],
-      "rdfs:comment": "A FormalParameter is an identified variable used to stand for the actual value(s) that are consumed/produced by a set of steps. Version: 1.0-RELEASE (09 March 2021) ",
-      "rdfs:label": "FormalParameter",
+      "rdfs:comment": "A biological material entity that is representative of a whole.\nComments: Typically samples are intended to be representative of the whole or aspects thereof. Examples of samples include biomedical samples (blood, urine) and plant specimens held at herbaria. Version 0.1-RELEASE. Note, the parent class for this schema has been updated to a pending class in schema.org.",
+      "rdfs:label": "BioSample",
       "rdfs:subClassOf": {
-        "@id": "schema:Intangible"
+        "@id": "schema:BioChemEntity"
       },
       "schema:schemaVersion": [
-        "https://bioschemas.org/types/FormalParameter/1.0-RELEASE",
-        "https://github.com/BioSchemas/specifications/blob/master/FormalParameter/jsonld/type/FormalParameter_v1.0-RELEASE.json"
+        "https://github.com/BioSchemas/specifications/tree/master/BioSample/jsonld/type/BioSample_v0.1-RELEASE.json",
+        "https://bioschemas.org/types/BioSample/0.1-RELEASE"
       ]
-    },
-    {
-      "@id": "bioschemas:isControl",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/isControl"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/isControl"
-        }
-      ],
-      "rdfs:comment": "Indicates whether the sample is being used as a normal control, may be in combination with another sample.",
-      "rdfs:label": "isControl",
-      "schema:domainIncludes": {
-        "@id": "bioschemas:BioSample"
-      },
-      "schema:rangeIncludes": {
-        "@id": "schema:Boolean"
-      }
-    },
-    {
-      "@id": "bioschemas:bioChemInteraction",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/bioChemInteraction"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/bioChemInteraction"
-        },
-        {
-          "@id": "schema:bioChemInteraction"
-        }
-      ],
-      "rdfs:comment": "A BioChemEntity that is know to interact with this item.",
-      "rdfs:label": "bioChemInteraction",
-      "schema:domainIncludes": {
-        "@id": "bioschemas:BioChemEntity"
-      },
-      "schema:rangeIncludes": {
-        "@id": "bioschemas:BioChemEntity"
-      }
-    },
-    {
-      "@id": "bioschemas:valueRequired",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/valueRequired"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/valueRequired"
-        }
-      ],
-      "rdfs:comment": "If the FormalParameter must be specified. This is commonly only used for Inputs",
-      "rdfs:label": "valueRequired",
-      "schema:domainIncludes": {
-        "@id": "bioschemas:FormalParameter"
-      },
-      "schema:rangeIncludes": {
-        "@id": "schema:Boolean"
-      }
-    },
-    {
-      "@id": "bioschemas:molecularWeight",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/molecularWeight"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/molecularWeight"
-        },
-        {
-          "@id": "schema:molecularWeight"
-        }
-      ],
-      "rdfs:comment": "This is the molecular weight of the entity being described, not of the parent. Units should be included in the form '<Number> <unit>', for example '12 amu' or as '<QuantitativeValue>.",
-      "rdfs:label": "molecularWeight",
-      "schema:domainIncludes": {
-        "@id": "bioschemas:MolecularEntity"
-      },
-      "schema:rangeIncludes": [
-        {
-          "@id": "schema:QuantitativeValue"
-        },
-        {
-          "@id": "schema:Text"
-        }
-      ]
-    },
-    {
-      "@id": "bioschemas:hasStatus",
-      "@type": "rdf:Property",
-      "owl:equivalentProperty": [
-        {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/hasStatus"
-        },
-        {
-          "@id": "https://w3id.org/bioschemas/terms/hasStatus"
-        }
-      ],
-      "rdfs:comment": "Schema:  One of pseudogene, dead, killed, live, predicted, suppressed.",
-      "rdfs:label": "hasStatus",
-      "schema:domainIncludes": {
-        "@id": "bioschemas:Gene"
-      },
-      "schema:rangeIncludes": {
-        "@id": "schema:Text"
-      }
     },
     {
       "@id": "bioschemas:chemicalRole",
@@ -1373,113 +1328,166 @@
       }
     },
     {
-      "@id": "bioschemas:bioChemSimilarity",
+      "@id": "bioschemas:funding",
       "@type": "rdf:Property",
       "owl:equivalentProperty": [
         {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/bioChemSimilarity"
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/funding"
         },
         {
-          "@id": "https://w3id.org/bioschemas/terms/bioChemSimilarity"
-        },
-        {
-          "@id": "schema:bioChemSimilarity"
+          "@id": "https://w3id.org/bioschemas/terms/funding"
         }
       ],
-      "rdfs:comment": "A similar molecular entity, e.g., obtained by fingerprint similarity algorithm.",
-      "rdfs:label": "bioChemSimilarity",
+      "rdfs:comment": "The funding for the workflow",
+      "rdfs:label": "funding",
       "schema:domainIncludes": {
-        "@id": "bioschemas:BioChemEntity"
+        "@id": "bioschemas:ComputationalWorkflow"
       },
       "schema:rangeIncludes": {
-        "@id": "bioschemas:BioChemEntity"
+        "@id": "schema:Grant"
+      },
+      "schema:sameAs": {
+        "@id": "schema:funding"
       }
     },
     {
-      "@id": "bioschemas:childTaxon",
+      "@id": "bioschemas:iupacName",
       "@type": "rdf:Property",
       "owl:equivalentProperty": [
         {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/childTaxon"
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/iupacName"
         },
         {
-          "@id": "https://w3id.org/bioschemas/terms/childTaxon"
+          "@id": "https://w3id.org/bioschemas/terms/iupacName"
         },
         {
-          "@id": "schema:childTaxon"
+          "@id": "schema:iupacName"
         }
       ],
-      "rdfs:comment": "Closest child taxa of the taxon in question.\nInverse property: parentTaxon Direct, most proximate lower-rank child taxa",
-      "rdfs:label": "childTaxon",
+      "rdfs:comment": "Systematic method of naming chemical compounds as recommended by the International Union of Pure and Applied Chemistry (IUPAC).",
+      "rdfs:label": "iupacName",
       "schema:domainIncludes": {
-        "@id": "bioschemas:Taxon"
+        "@id": "bioschemas:MolecularEntity"
       },
-      "schema:rangeIncludes": [
-        {
-          "@id": "schema:Taxon"
-        },
-        {
-          "@id": "schema:Text"
-        },
-        {
-          "@id": "schema:URL"
-        }
-      ]
+      "schema:rangeIncludes": {
+        "@id": "schema:Text"
+      }
     },
     {
-      "@id": "bioschemas:ChemicalSubstance",
+      "@id": "bioschemas:Gene",
       "@type": "rdfs:Class",
       "owl:equivalentClass": [
         {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/ChemicalSubstance"
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/Gene"
         },
         {
-          "@id": "https://w3id.org/bioschemas/terms/ChemicalSubstance"
+          "@id": "https://w3id.org/bioschemas/terms/Gene"
         },
         {
-          "@id": "schema:ChemicalSubstance"
+          "@id": "schema:Gene"
         }
       ],
-      "rdfs:comment": "A chemical substance is 'a portion of matter of constant composition, composed of molecular entities of the same type or of different types' (source: ChEBI:59999). Version: 0.3-RELEASE-2019_09_02. This version is was released as a pending class as of schema.org version 13",
-      "rdfs:label": "ChemicalSubstance",
+      "rdfs:comment": "A discrete unit of inheritance which affects one or more biological traits (Source: https://en.wikipedia.org/wiki/Gene). Examples include FOXP2 (Forkhead box protein P2), SCARNA21 (small Cajal body-specific RNA 21), A- (agouti genotype). Note, this version of the type has been added as a pending class in schema.org.",
+      "rdfs:label": "Gene",
       "rdfs:subClassOf": {
         "@id": "schema:BioChemEntity"
       },
       "schema:schemaVersion": [
-        "https://github.com/BioSchemas/specifications/tree/master/ChemicalSubstance/jsonld/type/ChemicalSubstance_v0.3-RELEASE-2019_09_02.json",
-        "https://bioschemas.org/types/ChemicalSubstance/0.3-RELEASE-2019_09_02"
+        "https://bioschemas.org/types/Gene/0.3-RELEASE-2019_09_02",
+        "https://github.com/BioSchemas/specifications/tree/master/Gene/jsonld/type/Gene_v0.3-RELEASE-2019_09_02.json"
       ]
     },
     {
-      "@id": "bioschemas:isLocatedInSubcellularLocation",
+      "@id": "bioschemas:Protein",
+      "@type": "rdfs:Class",
+      "owl:equivalentClass": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/Protein"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/Protein"
+        },
+        {
+          "@id": "schema:Protein"
+        }
+      ],
+      "rdfs:comment": "Protein is here used in its widest possible definition, as classes of amino acid based molecules. Amyloid-beta Protein in human (UniProt P05067), eukaryota (e.g. an OrthoDB group) or even a single molecule that one can point to are all of type schema:Protein. A protein can thus be a subclass of another protein, e.g. schema:Protein as a UniProt record can have multiple isoforms inside it which would also be schema:Protein. They can be imagined, synthetic, hypothetical or naturally occurring. This version has been added to schema.org as a pending type.",
+      "rdfs:label": "Protein",
+      "rdfs:subClassOf": {
+        "@id": "schema:BioChemEntity"
+      },
+      "schema:schemaVersion": [
+        "https://bioschemas.org/types/Protein/0.3-RELEASE-2019_09_02",
+        "https://github.com/BioSchemas/specifications/tree/master/Protein/jsonld/type/Protein_v0.3-RELEASE-2019_09_02.json"
+      ]
+    },
+    {
+      "@id": "bioschemas:itemLocation",
       "@type": "rdf:Property",
       "owl:equivalentProperty": [
         {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/isLocatedInSubcellularLocation"
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/itemLocation"
         },
         {
-          "@id": "https://w3id.org/bioschemas/terms/isLocatedInSubcellularLocation"
-        },
-        {
-          "@id": "schema:isLocatedInSubcellularLocation"
+          "@id": "https://w3id.org/bioschemas/terms/itemLocation"
         }
       ],
-      "rdfs:comment": "Subcellular location where this BioChemEntity is located; please use PropertyValue if you want to include any evidence.",
-      "rdfs:label": "isLocatedInSubcellularLocation",
+      "rdfs:comment": "Current location of the item. ",
+      "rdfs:label": "itemLocation",
       "schema:domainIncludes": {
-        "@id": "bioschemas:BioChemEntity"
+        "@id": "bioschemas:BioSample"
       },
       "schema:rangeIncludes": [
         {
-          "@id": "schema:DefinedTerm"
+          "@id": "schema:Place"
         },
         {
-          "@id": "schema:PropertyValue"
+          "@id": "schema:PostalAddress"
         },
         {
-          "@id": "schema:URL"
+          "@id": "schema:Text"
         }
       ]
+    },
+    {
+      "@id": "bioschemas:output",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/output"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/output"
+        }
+      ],
+      "rdfs:comment": "An output produced by the workflow",
+      "rdfs:label": "output",
+      "schema:domainIncludes": {
+        "@id": "bioschemas:ComputationalWorkflow"
+      },
+      "schema:rangeIncludes": {
+        "@id": "bioschemas:FormalParameter"
+      }
+    },
+    {
+      "@id": "bioschemas:input",
+      "@type": "rdf:Property",
+      "owl:equivalentProperty": [
+        {
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/input"
+        },
+        {
+          "@id": "https://w3id.org/bioschemas/terms/input"
+        }
+      ],
+      "rdfs:comment": "An input required to use the computational workflow (eg. Excel spreadsheet, BAM file)",
+      "rdfs:label": "input",
+      "schema:domainIncludes": {
+        "@id": "bioschemas:ComputationalWorkflow"
+      },
+      "schema:rangeIncludes": {
+        "@id": "bioschemas:FormalParameter"
+      }
     },
     {
       "@id": "bioschemas:hasRepresentation",
@@ -1505,46 +1513,41 @@
       }
     },
     {
-      "@id": "bioschemas:hasBioPolymerSequence",
+      "@id": "bioschemas:biologicalRole",
       "@type": "rdf:Property",
       "owl:equivalentProperty": [
         {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/hasBioPolymerSequence"
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/biologicalRole"
         },
         {
-          "@id": "https://w3id.org/bioschemas/terms/hasBioPolymerSequence"
+          "@id": "https://w3id.org/bioschemas/terms/biologicalRole"
         },
         {
-          "@id": "schema:hasBioPolymerSequence"
+          "@id": "schema:biologicalRole"
         }
       ],
-      "rdfs:comment": "A symbolic representation of a BioChemEnity. For example, a nucleotide sequence of a Gene or an amino acid sequence of a Protein.",
-      "rdfs:label": "hasBioPolymerSequence",
-      "schema:domainIncludes": [
-        {
-          "@id": "bioschemas:Gene"
-        },
-        {
-          "@id": "bioschemas:Protein"
-        }
-      ],
+      "rdfs:comment": "A role played by the molecular entity within a biological context.",
+      "rdfs:label": "biologicalRole",
+      "schema:domainIncludes": {
+        "@id": "bioschemas:BioChemEntity"
+      },
       "schema:rangeIncludes": {
-        "@id": "schema:Text"
+        "@id": "schema:DefinedTerm"
       }
     },
     {
-      "@id": "bioschemas:inChI",
+      "@id": "bioschemas:inChIKey",
       "@type": "rdf:Property",
       "owl:equivalentProperty": [
         {
-          "@id": "https://discovery.biothings.io/view/bioschemastypes/inChI"
+          "@id": "https://discovery.biothings.io/view/bioschemastypes/inChIKey"
         },
         {
-          "@id": "https://w3id.org/bioschemas/terms/inChI"
+          "@id": "https://w3id.org/bioschemas/terms/inChIKey"
         }
       ],
-      "rdfs:comment": "Non-proprietary identifier for molecular entity that can be used in printed and electronic data sources thus enabling easier linking of diverse data compilations.",
-      "rdfs:label": "inChI",
+      "rdfs:comment": "InChIKey is a hashed version of the full InChI (using the SHA-256 algorithm).",
+      "rdfs:label": "inChIKey",
       "schema:domainIncludes": {
         "@id": "bioschemas:MolecularEntity"
       },

--- a/pages/_types/bioschemas_types.ttl
+++ b/pages/_types/bioschemas_types.ttl
@@ -151,6 +151,7 @@ bioschemas:associatedDisease a rdf:Property ;
     rdfs:label "associatedDisease" ;
     rdfs:comment "Disease associated to this BioChemEntity. Such a disease can be a MedicalCondition or a URL. If you want to add an evidence supporting the association, please use PropertyValue." ;
     owl:equivalentProperty <https://discovery.biothings.io/view/bioschemastypes/associatedDisease>,
+        schema:associatedDisease,
         <https://w3id.org/bioschemas/terms/associatedDisease> ;
     schema:domainIncludes bioschemas:BioChemEntity ;
     schema:rangeIncludes schema:MedicalCondition,


### PR DESCRIPTION
The equivalence towards schema.org types and properties for Bioschemas types included in pending requires a list of the included terms. We were missing assosciatedDisease, now included.