### PR TITLE
Add redirection from terms (Bioschemas ns) to types

### DIFF
--- a/pages/_types/drafts/index.html
+++ b/pages/_types/drafts/index.html
@@ -1,0 +1,5 @@
+---
+redirect_to: /types#nav-draft
+redirect_from:
+- "/devTypes/"
+---

--- a/pages/_types/index.html
+++ b/pages/_types/index.html
@@ -4,6 +4,7 @@ title: Bioschemas Types
 redirect_from:
 - "/devTypes/"
 - "/types/drafts/"
+- "/terms/"
 signposting:
 - rel: "cite-as"
   link: "Gray, A.J.G, Goble, C.A. and Jimenez, R., 2017. Bioschemas: From Potato Salad to Protein Annotation. In International Semantic Web Conference (Posters, Demos & Industry Tracks)."

--- a/pages/_types/index.html
+++ b/pages/_types/index.html
@@ -2,8 +2,6 @@
 layout: default
 title: Bioschemas Types
 redirect_from:
-- "/devTypes/"
-- "/types/drafts/"
 - "/terms/"
 signposting:
 - rel: "cite-as"


### PR DESCRIPTION
We need https://bioschemas.org/terms/ (Bioschemas canonical namespace) to resolve to https://bioschemas.org/types, where we include links and signposting to the JSON-LD and TTL files.