### PR TITLE
T7a6 Breadcrumbs

### DIFF
--- a/_includes/breadcrumb.html
+++ b/_includes/breadcrumb.html
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="d-none">
+    <symbol id="house-door-fill" viewBox="0 0 16 16">
+        <path d="M6.5 14.5v-3.505c0-.245.25-.495.5-.495h2c.25 0 .5.25.5.5v3.5a.5.5 0 0 0 .5.5h4a.5.5 0 0 0 .5-.5v-7a.5.5 0 0 0-.146-.354L13 5.793V2.5a.5.5 0 0 0-.5-.5h-1a.5.5 0 0 0-.5.5v1.293L8.354 1.146a.5.5 0 0 0-.708 0l-6 6A.5.5 0 0 0 1.5 7.5v7a.5.5 0 0 0 .5.5h4a.5.5 0 0 0 .5-.5z"/>
+    </symbol>
+</svg>
+
+<div class="container my-1">
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb p-3 bg-body-tertiary bg-light shadow rounded-3">
+            <li class="breadcrumb-item">
+                <a class="link-body-emphasis fw-semibold text-decoration-none" href="/">
+                    <svg class="bi" width="16" height="16" aria-hidden="true"><use xlink:href="#house-door-fill"></use></svg>
+                    Home
+                </a>
+            </li>
+            {% if page.breadcrumb.title1 %}
+            <li class="breadcrumb-item">
+                {% if page.breadcrumb.link1 %}
+                <a class="link-body-emphasis fw-semibold text-decoration-none" href="{{ page.breadcrumb.link1 | relative_url  }}">{{ page.breadcrumb.title1 }}</a>
+                {% else %}
+                {{ page.breadcrumb.title1 }}
+                {% endif %}
+            </li>
+            {% endif %}
+            {% if page.breadcrumb.title2 %}
+            <li class="breadcrumb-item">
+                {% if page.breadcrumb.link2 %}
+                <a class="link-body-emphasis fw-semibold text-decoration-none" href="{{ page.breadcrumb.link2 | relative_url  }}">{{ page.breadcrumb.title2 }}</a>
+                {% else %}
+                {{ page.breadcrumb.title2 }}
+                {% endif %}
+            </li>
+            {% endif %}
+            {% if page.breadcrumb.title3 %}
+            <li class="breadcrumb-item">
+                {% if page.breadcrumb.link3 %}
+                <a class="link-body-emphasis fw-semibold text-decoration-none" href="{{ page.breadcrumb.link3 | relative_url  }}">{{ page.breadcrumb.title3 }}</a>
+                {% else %}
+                {{ page.breadcrumb.title3 }}
+                {% endif %}
+            </li>
+            {% endif %}
+            <li class="breadcrumb-item active" aria-current="page">
+                {% if page.title %}
+                {{ page.title }}
+                {% else %}
+                {{ site.title }}
+                {% endif %}
+            </li>
+        </ol>
+    </nav>
+</div>

--- a/_includes/breadcrumb.html
+++ b/_includes/breadcrumb.html
@@ -1,3 +1,30 @@
+{% assign breadcrumb_title1 = page.breadcrumb.title1 %}
+{% assign breadcrumb_link1 = page.breadcrumb.link1 %}
+{% assign breadcrumb_title2 = page.breadcrumb.title2 %}
+{% assign breadcrumb_link2 = page.breadcrumb.link2 %}
+{% assign breadcrumb_title3 = page.breadcrumb.title3 %}
+{% assign breadcrumb_link3 = page.breadcrumb.link3 %}
+{% comment %}If included from a layout page instead of a regular page{% endcomment %}
+{% if include.title1 %}
+{% capture breadcrumb_title1 %}{{ include.title1 }}{% endcapture %}
+{% endif %}
+{% if include.link1 %}
+{% capture breadcrumb_link1 %}{{ include.link1 }}{% endcapture %}
+{% endif %}
+{% if include.title2 %}
+{% capture breadcrumb_title2 %}{{ include.title2 }}{% endcapture %}
+{% endif %}
+{% if include.link2 %}
+{% capture breadcrumb_link2 %}{{ include.link2 }}{% endcapture %}
+{% endif %}
+{% if include.title3 %}
+{% capture breadcrumb_title3 %}{{ include.title3 }}{% endcapture %}
+{% endif %}
+{% if include.link3 %}
+{% capture breadcrumb_link3 %}{{ include.link3 }}{% endcapture %}
+{% endif %}
+
+
 <svg xmlns="http://www.w3.org/2000/svg" class="d-none">
     <symbol id="house-door-fill" viewBox="0 0 16 16">
         <path d="M6.5 14.5v-3.505c0-.245.25-.495.5-.495h2c.25 0 .5.25.5.5v3.5a.5.5 0 0 0 .5.5h4a.5.5 0 0 0 .5-.5v-7a.5.5 0 0 0-.146-.354L13 5.793V2.5a.5.5 0 0 0-.5-.5h-1a.5.5 0 0 0-.5.5v1.293L8.354 1.146a.5.5 0 0 0-.708 0l-6 6A.5.5 0 0 0 1.5 7.5v7a.5.5 0 0 0 .5.5h4a.5.5 0 0 0 .5-.5z"/>
@@ -13,30 +40,30 @@
                     Home
                 </a>
             </li>
-            {% if page.breadcrumb.title1 %}
+            {% if breadcrumb_title1 %}
             <li class="breadcrumb-item">
-                {% if page.breadcrumb.link1 %}
-                <a class="link-body-emphasis fw-semibold text-decoration-none" href="{{ page.breadcrumb.link1 | relative_url  }}">{{ page.breadcrumb.title1 }}</a>
+                {% if breadcrumb_link1 %}
+                <a class="link-body-emphasis fw-semibold text-decoration-none" href="{{ breadcrumb_link1 | relative_url  }}">{{ breadcrumb_title1 }}</a>
                 {% else %}
-                {{ page.breadcrumb.title1 }}
+                {{ breadcrumb_title1 }}
                 {% endif %}
             </li>
             {% endif %}
-            {% if page.breadcrumb.title2 %}
+            {% if breadcrumb_title2 %}
             <li class="breadcrumb-item">
-                {% if page.breadcrumb.link2 %}
-                <a class="link-body-emphasis fw-semibold text-decoration-none" href="{{ page.breadcrumb.link2 | relative_url  }}">{{ page.breadcrumb.title2 }}</a>
+                {% if breadcrumb_link2 %}
+                <a class="link-body-emphasis fw-semibold text-decoration-none" href="{{ breadcrumb_link2 | relative_url  }}">{{ breadcrumb_title2 }}</a>
                 {% else %}
-                {{ page.breadcrumb.title2 }}
+                {{ breadcrumb_title2 }}
                 {% endif %}
             </li>
             {% endif %}
-            {% if page.breadcrumb.title3 %}
+            {% if breadcrumb_title3 %}
             <li class="breadcrumb-item">
-                {% if page.breadcrumb.link3 %}
-                <a class="link-body-emphasis fw-semibold text-decoration-none" href="{{ page.breadcrumb.link3 | relative_url  }}">{{ page.breadcrumb.title3 }}</a>
+                {% if breadcrumb_link3 %}
+                <a class="link-body-emphasis fw-semibold text-decoration-none" href="{{ breadcrumb_link3 | relative_url  }}">{{ breadcrumb_title3 }}</a>
                 {% else %}
-                {{ page.breadcrumb.title3 }}
+                {{ breadcrumb_title3 }}
                 {% endif %}
             </li>
             {% endif %}

--- a/_includes/breadcrumb.html
+++ b/_includes/breadcrumb.html
@@ -8,7 +8,7 @@
     <nav aria-label="breadcrumb">
         <ol class="breadcrumb p-3 bg-body-tertiary bg-light shadow rounded-3">
             <li class="breadcrumb-item">
-                <a class="link-body-emphasis fw-semibold text-decoration-none" href="/">
+                <a class="link-body-emphasis fw-semibold text-decoration-none" href="{{ "/" | relative_url }}">
                     <svg class="bi" width="16" height="16" aria-hidden="true"><use xlink:href="#house-door-fill"></use></svg>
                     Home
                 </a>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -43,7 +43,7 @@
                   type in the DDE</a></li>
             <li><a class="dropdown-item" href="{{ '/tutorials/dde/update_type' | relative_url }}">Updating a
                     type in DDE</a></li>
-            <li><a class="dropdown-item" href="{{ '/tutorials/tutorials/dde/add_validation_rules' | relative_url }}">Using a validation editor</a></li> 
+            <li><a class="dropdown-item" href="{{ '/tutorials/dde/validation_editor' | relative_url }}">Using a validation editor</a></li>
             <li><a class="dropdown-item"
                 href="{{ '/tutorials/dde/review_a_specification_pull_request' | relative_url }}">Review a Specification
                 Pull request (PR)</a></li>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -23,7 +23,6 @@
                 Bioschemas, what and why?</a></li>
             <li><a class="dropdown-item" href="{{ '/tutorials/howto/howto_right_profile' | relative_url }}">Choosing a
                 profile</a></li>
-            <li><a class="dropdown-item" href="{{ '/tutorials/dde/howto_create_new_profile' | relative_url }}">Developing profiles from scratch</a></li>
             <li><a class="dropdown-item" href="{{ '/tutorials/howto/howto_add_markup' | relative_url }}">Adding
                 Bioschemas markup to pages</a></li>
             <li><a class="dropdown-item" href="{{ '/tutorials/howto/howto_add_github' | relative_url }}">Adding markup
@@ -35,24 +34,27 @@
             </li>
             <li><a class="dropdown-item" href="{{ '/tutorials/dde/' | relative_url }}">Profile and Type Development in DDE</a>
             </li>
-            <li><a class="dropdown-item" href="{{ '/tutorials/dde/new_profile' | relative_url }}">Creating a new
-              profile in the DDE</a></li>
-            <li><a class="dropdown-item" href="{{ '/tutorials/dde/update_profile' | relative_url }}">Updating a
+            <ul>
+              <li><a class="dropdown-item" href="{{ '/tutorials/dde/update_profile' | relative_url }}">Updating a
                 profile in DDE</a></li>
-            <li><a class="dropdown-item" href="{{ '/tutorials/dde/new_type' | relative_url }}">Creating a new
+              <li><a class="dropdown-item" href="{{ '/tutorials/dde/howto_create_new_profile' | relative_url }}">Developing profiles from scratch</a></li>
+              <li><a class="dropdown-item" href="{{ '/tutorials/dde/new_profile' | relative_url }}">Creating a new
+                profile in the DDE</a></li>
+              <li><a class="dropdown-item" href="{{ '/tutorials/dde/update_type' | relative_url }}">Updating a
+                type in DDE</a></li>
+              <li><a class="dropdown-item" href="{{ '/tutorials/dde/new_type' | relative_url }}">Creating a new
                   type in the DDE</a></li>
-            <li><a class="dropdown-item" href="{{ '/tutorials/dde/update_type' | relative_url }}">Updating a
-                    type in DDE</a></li>
-            <li><a class="dropdown-item" href="{{ '/tutorials/dde/validation_editor' | relative_url }}">Using a validation editor</a></li>
-            <li><a class="dropdown-item"
+              <li><a class="dropdown-item"
                 href="{{ '/tutorials/dde/review_a_specification_pull_request' | relative_url }}">Review a Specification
                 Pull request (PR)</a></li>
+              <li><a class="dropdown-item" href="{{ '/tutorials/dde/validation_editor' | relative_url }}">Using a validation editor</a></li>
+            </ul>
             <li>
               <hr class="dropdown-divider">
             </li>
             <li><a class="dropdown-item" href="{{ '/tutorials/community/' | relative_url }}">Community-based
                 tutorials</a></li>
-            <li><a class="dropdown-item" href="{{ '/tutorials/community/idp' | relative_url }}">Adding markup to IDP
+            <ul><li><a class="dropdown-item" href="{{ '/tutorials/community/idp' | relative_url }}">Adding markup to IDP
                 resources</a></li>
             <li><a class="dropdown-item" href="{{ '/tutorials/community/plant' | relative_url }}">Adding markup to Plant
                 resources</a></li>
@@ -60,7 +62,7 @@
                 Disease resources</a></li>
             <li><a class="dropdown-item" href="{{ '/tutorials/community/biodiversity' | relative_url }}">Adding markup
                 to Biodiversity-related resources</a></li>
-                <li><a class="dropdown-item" href="{{ '/tutorials/community/training' | relative_url }}">Adding markup to training resources</a></li>
+                <li><a class="dropdown-item" href="{{ '/tutorials/community/training' | relative_url }}">Adding markup to training resources</a></li></ul>
             </ul>
         </li>
         <li class="nav-item dropdown">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,6 +5,9 @@
   <body>
     {% include header.html %}
     {% include navbar.html %}
+    {% if page.breadcrumb.title1 %}
+    {% include breadcrumb.html %}
+    {% endif %}
     <div class="container min-vh-100">
       <main id="main" class="my-5">
         {{ content }}

--- a/_layouts/meeting.html
+++ b/_layouts/meeting.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 ---
+{% include breadcrumb.html title1="Community" link1="/community/" title2="Meetings" link2="/meetings/" %}
 <h1>{{ page.name }}</h1>
 {% if page.time %}
 <p><strong>Time:</strong> {{page.time}}</p>

--- a/_layouts/person-details.html
+++ b/_layouts/person-details.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 ---
-
+{% include breadcrumb.html title1="Community" link1="/community/" title2="People" link2="/people/" %}
 <h1>{{ page.first-name }} {{ page.last-name }}</h1>
 {% if page.affiliation %}
 <p>{{ page.affiliation }}</p>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 ---
+{% include breadcrumb.html title1="Community" link1="/community/" title2="News" link2="/news/" %}
 <div id="landing">
   <div class="row">
     <div class="col-md-8">

--- a/_layouts/profiles.html
+++ b/_layouts/profiles.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 ---
+{% include breadcrumb.html %}
 {% include profile-start.html %}
 {% include specification-table.html %}
 {{content}}

--- a/_layouts/profiles.html
+++ b/_layouts/profiles.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 ---
-{% include breadcrumb.html %}
+{% include breadcrumb.html title1="Specifications" title2="Profiles" link2="/profiles/" %}
 {% include profile-start.html %}
 {% include specification-table.html %}
 {{content}}

--- a/_layouts/use-case.html
+++ b/_layouts/use-case.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 ---
+{% include breadcrumb.html title1="Community" link1="/community/" title2="Use Cases" link2="/useCases/" %}
 <h1>Use Cases for {{page.name}}</h1>
 {% assign group = site.groups | where:"identifier", page.group %}
 {% for g in group %}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -218,3 +218,11 @@ table:not(.rouge-table):not(.table-borderless) {
     @extend .shadow;
     @extend .rounded;
 }
+
+
+/*******************************************************************************
+Breadcrumbs
+*******************************************************************************/
+.breadcrumb .breadcrumb-item {
+    line-height: 1; /* does this do anything? */
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -224,5 +224,6 @@ table:not(.rouge-table):not(.table-borderless) {
 Breadcrumbs
 *******************************************************************************/
 .breadcrumb .breadcrumb-item {
-    line-height: 1; /* does this do anything? */
+    line-height: 1;
+    margin: 0;
 }

--- a/pages/_about/funding.html
+++ b/pages/_about/funding.html
@@ -1,6 +1,8 @@
 ---
 layout: default
 title: Funding
+breadcrumb:
+  title1: About
 redirect_from:
   - /about/funders
 ---

--- a/pages/_about/logos.html
+++ b/pages/_about/logos.html
@@ -1,5 +1,7 @@
 ---
 layout: default
+breadcrumb:
+  title1: About
 ---
 <div itemscope itemtype="http://schema.org/Organization">
     <div id="logo-usage" class="container">        

--- a/pages/_about/privacy.html
+++ b/pages/_about/privacy.html
@@ -1,6 +1,8 @@
 ---
 layout: default
 title: Privacy
+breadcrumb:
+  title1: About
 ---
 <h1>Privacy Policy</h1>
 <p>Last updated: September 16, 2024</p>

--- a/pages/_about/publications.html
+++ b/pages/_about/publications.html
@@ -1,5 +1,7 @@
 ---
 layout: default
+breadcrumb:
+  title1: About
 ---
 <h1>How to cite Bioschemas</h1>
 

--- a/pages/_community/champions.html
+++ b/pages/_community/champions.html
@@ -1,6 +1,9 @@
 ---
 layout: default
 title: Champions
+breadcrumb:
+  link1: /community/
+  title1: Community
 ---
 
 <div itemscope itemtype="http://schema.org/Organization">

--- a/pages/_community/howtojoin.html
+++ b/pages/_community/howtojoin.html
@@ -1,6 +1,9 @@
 ---
 layout: default
 title: How To Join
+breadcrumb:
+  link1: /community/
+  title1: Community
 ---
 
 <div itemscope itemtype="http://schema.org/Organization">

--- a/pages/_community/index.html
+++ b/pages/_community/index.html
@@ -1,6 +1,9 @@
 ---
 layout: default
-title: Community
+title: Community Overview
+breadcrumb:
+  link1: /community/
+  title1: Community
 ---
 
 <div itemscope itemtype="http://schema.org/Organization">

--- a/pages/_community/related.md
+++ b/pages/_community/related.md
@@ -1,6 +1,9 @@
 ---
 layout: default
-title: Community
+title: Related communities
+breadcrumb:
+  link1: /community/
+  title1: Community
 ---
 # Related communities and activities
 

--- a/pages/_community/stories.md
+++ b/pages/_community/stories.md
@@ -1,6 +1,9 @@
 ---
 layout: default
 title: Bioschemas stories
+breadcrumb:
+  link1: /community/
+  title1: Community
 ---
 # Bioschemas user stories
 

--- a/pages/_developer/liveDeploys.html
+++ b/pages/_developer/liveDeploys.html
@@ -1,6 +1,8 @@
 ---
 layout: default
 title: Live Deploys
+breadcrumb:
+  title1: "Deploy & Develop"
 redirect_from:
   - "/liveDeploys/"
   - "/liveDeploys"

--- a/pages/_developer/software.html
+++ b/pages/_developer/software.html
@@ -6,6 +6,8 @@ redirect_from:
   - "/software"
 layout: default
 title: Software
+breadcrumb:
+  title1: "Deploy & Develop"
 description: |-
   This is a list of software that can help you generate, consume or otherwise work with [Bioschemas](/) markup.
   If you have such software and you'd like to list it here, please email us at [enquiries@bioschemas.org](mailto:enquiries@bioschemas.org).

--- a/pages/_groups/Beacons.md
+++ b/pages/_groups/Beacons.md
@@ -31,4 +31,10 @@ members:
   - AndraWaagmeester
   - MichaelBaudis
   - RafaelJimenez
+  
+breadcrumb:
+  link1: /community/
+  title1: Community
+  link2: /groups/
+  title2: Groups
 ---

--- a/pages/_groups/Biodiversity.md
+++ b/pages/_groups/Biodiversity.md
@@ -39,4 +39,10 @@ members:
     - RomanBaum
     - CarlBoettiger
     - MattYoder
+
+breadcrumb:
+  link1: /community/
+  title1: Community
+  link2: /groups/
+  title2: Groups
 ---

--- a/pages/_groups/BiologicalEntities.md
+++ b/pages/_groups/BiologicalEntities.md
@@ -42,4 +42,10 @@ members:
   - MichelDumontier
   - anyango
   - AlexanderGarcia
+
+breadcrumb:
+  link1: /community/
+  title1: Community
+  link2: /groups/
+  title2: Groups
 ---

--- a/pages/_groups/Chemicals.md
+++ b/pages/_groups/Chemicals.md
@@ -35,4 +35,10 @@ members:
   - AnnaGaulton
   - RicardoArcila
   - DavidMendez
+
+breadcrumb:
+  link1: /community/
+  title1: Community
+  link2: /groups/
+  title2: Groups
 ---

--- a/pages/_groups/Community.md
+++ b/pages/_groups/Community.md
@@ -47,4 +47,10 @@ members:
     - RobertoPreste
     - RafaelJimenez
     - PetrosPapadopoulos
+
+breadcrumb:
+  link1: /community/
+  title1: Community
+  link2: /groups/
+  title2: Groups
 ---

--- a/pages/_groups/DNA.md
+++ b/pages/_groups/DNA.md
@@ -33,4 +33,10 @@ types:
 members:
     - NathanDunn
     - AnilWipat
+
+breadcrumb:
+  link1: /community/
+  title1: Community
+  link2: /groups/
+  title2: Groups
 ---

--- a/pages/_groups/DataRepositories.md
+++ b/pages/_groups/DataRepositories.md
@@ -61,4 +61,10 @@ members:
   - MichaelCrusoe
   - DavidvanEnckevort
   - RafaelJimenez
+
+breadcrumb:
+  link1: /community/
+  title1: Community
+  link2: /groups/
+  title2: Groups
 ---

--- a/pages/_groups/Datasets.md
+++ b/pages/_groups/Datasets.md
@@ -65,4 +65,10 @@ members:
   - HaydeeArtaza
   - DavidvanEnckevort
   - SteffenNeumann
+
+breadcrumb:
+  link1: /community/
+  title1: Community
+  link2: /groups/
+  title2: Groups
 ---

--- a/pages/_groups/Diseases.md
+++ b/pages/_groups/Diseases.md
@@ -28,4 +28,10 @@ specifications:
 
 members:
 - RajaramKaliyaperumal
+
+breadcrumb:
+  link1: /community/
+  title1: Community
+  link2: /groups/
+  title2: Groups
 ---

--- a/pages/_groups/Events.md
+++ b/pages/_groups/Events.md
@@ -52,5 +52,11 @@ members:
     - DavidvanEnckevort
     - AndyJenkinson
     - RafaelJimenez
-    - VictoriaDominguezDelAngel   
+    - VictoriaDominguezDelAngel
+
+breadcrumb:
+  link1: /community/
+  title1: Community
+  link2: /groups/
+  title2: Groups
 ---

--- a/pages/_groups/Genes.md
+++ b/pages/_groups/Genes.md
@@ -38,4 +38,10 @@ members:
     - AndyJenkinson
     - RicardoArcila
     - ChunleiWu
+
+breadcrumb:
+  link1: /community/
+  title1: Community
+  link2: /groups/
+  title2: Groups
 ---

--- a/pages/_groups/LabProtocols.md
+++ b/pages/_groups/LabProtocols.md
@@ -68,4 +68,10 @@ former-members:
     - PetrHolub
     - DavidvanEnckevort
     - AlexanderGarcia
+
+breadcrumb:
+  link1: /community/
+  title1: Community
+  link2: /groups/
+  title2: Groups
 ---

--- a/pages/_groups/MachineLearning.md
+++ b/pages/_groups/MachineLearning.md
@@ -35,6 +35,11 @@ members:
 - DietrichRebholzSchuhmann
 - IvanMicetic
 
+breadcrumb:
+  link1: /community/
+  title1: Community
+  link2: /groups/
+  title2: Groups
 ---
 
 <h2>Further Details</h2>

--- a/pages/_groups/Organizations.md
+++ b/pages/_groups/Organizations.md
@@ -40,4 +40,10 @@ members:
     - MichaelCrusoe
     - AndyJenkinson
     - GabriellaRustici
+
+breadcrumb:
+  link1: /community/
+  title1: Community
+  link2: /groups/
+  title2: Groups
 ---

--- a/pages/_groups/People.md
+++ b/pages/_groups/People.md
@@ -42,4 +42,10 @@ members:
     - MichaelCrusoe
     - AndyJenkinson
     - RafaelJimenez
+
+breadcrumb:
+  link1: /community/
+  title1: Community
+  link2: /groups/
+  title2: Groups
 ---

--- a/pages/_groups/Phenotypes.md
+++ b/pages/_groups/Phenotypes.md
@@ -41,4 +41,10 @@ members:
     - PhilippeRocca-Serra
     - AndraWaagmeester
     - GiuliaBabbi
+
+breadcrumb:
+  link1: /community/
+  title1: Community
+  link2: /groups/
+  title2: Groups
 ---

--- a/pages/_groups/Proteins.md
+++ b/pages/_groups/Proteins.md
@@ -44,4 +44,10 @@ members:
     - VictoriaDominguezDelAngel
     - NathanDunn
     - JervenBolleman
+
+breadcrumb:
+  link1: /community/
+  title1: Community
+  link2: /groups/
+  title2: Groups
 ---

--- a/pages/_groups/Publications.md
+++ b/pages/_groups/Publications.md
@@ -32,6 +32,12 @@ specifications:
 members:
     - OlgaXimenaGiraldo
     - DietrichRebholzSchuhmann
+
+breadcrumb:
+  link1: /community/
+  title1: Community
+  link2: /groups/
+  title2: Groups
 ---
 
 <h2>Further Details</h2>

--- a/pages/_groups/Samples.md
+++ b/pages/_groups/Samples.md
@@ -66,4 +66,10 @@ Former members:
     - LucaCherubin
     - DavidvanEnckevort
     - RafaelJimenez
+
+breadcrumb:
+  link1: /community/
+  title1: Community
+  link2: /groups/
+  title2: Groups
 ---

--- a/pages/_groups/Standards.md
+++ b/pages/_groups/Standards.md
@@ -44,4 +44,10 @@ members:
     - NicolasLeNovère
     - MiloThurston
     - MichaelCrusoe
+
+breadcrumb:
+  link1: /community/
+  title1: Community
+  link2: /groups/
+  title2: Groups
 ---

--- a/pages/_groups/Studies.md
+++ b/pages/_groups/Studies.md
@@ -31,4 +31,10 @@ types:
 members: #List members
 - AhmedAli
 - PhilippeRocca-Serra
+
+breadcrumb:
+  link1: /community/
+  title1: Community
+  link2: /groups/
+  title2: Groups
 ---

--- a/pages/_groups/Technical.md
+++ b/pages/_groups/Technical.md
@@ -22,6 +22,12 @@ members:
     - KennethMcLeod
     - PetrosPapadopoulos
     - SaharFrikha
+
+breadcrumb:
+  link1: /community/
+  title1: Community
+  link2: /groups/
+  title2: Groups
 ---
 
 <div id="links">

--- a/pages/_groups/Tools.md
+++ b/pages/_groups/Tools.md
@@ -62,6 +62,12 @@ members:
     - MatusKalas
     - StianSoiland-Reyes
     - SaharFrikha
+
+breadcrumb:
+  link1: /community/
+  title1: Community
+  link2: /groups/
+  title2: Groups
 ---
 
 <h2>Further Details</h2>

--- a/pages/_groups/Training.md
+++ b/pages/_groups/Training.md
@@ -80,4 +80,10 @@ former-members:
     - MichaelCrusoe
     - RafaelJimenez
 
+breadcrumb:
+  link1: /community/
+  title1: Community
+  link2: /groups/
+  title2: Groups
+
 ---

--- a/pages/_groups/Validation.md
+++ b/pages/_groups/Validation.md
@@ -35,4 +35,10 @@ members:
     - MichaelCrusoe
     - RobertoPreste
     - AlbanGaignard
+
+breadcrumb:
+  link1: /community/
+  title1: Community
+  link2: /groups/
+  title2: Groups
 ---

--- a/pages/_groups/Workflow.md
+++ b/pages/_groups/Workflow.md
@@ -63,4 +63,10 @@ members:
 #    - longr
 #    - FrederikCoppens
 #    - PeterBlomberg
+
+breadcrumb:
+  link1: /community/
+  title1: Community
+  link2: /groups/
+  title2: Groups
 ---

--- a/pages/_groups/index.html
+++ b/pages/_groups/index.html
@@ -1,6 +1,9 @@
 ---
 layout: default
 title: Bioschemas Groups
+breadcrumb:
+  link1: /community/
+  title1: Community
 ---
 
 <h1>Bioschemas Groups 

--- a/pages/_meetings/index.html
+++ b/pages/_meetings/index.html
@@ -1,6 +1,9 @@
 ---
 layout: default
 title: Meetings
+breadcrumb:
+  link1: /community/
+  title1: Community
 ---
 
 <h1>Meetings</h1>

--- a/pages/_news/index.md
+++ b/pages/_news/index.md
@@ -1,6 +1,10 @@
 ---
 layout: default
 title: News
+
+breadcrumb:
+  link1: /community/
+  title1: Community
 ---
 # Bioschemas News
 {%- assign news = site.news | where: "layout", "post" | reverse %}

--- a/pages/_people/index.html
+++ b/pages/_people/index.html
@@ -1,8 +1,10 @@
 ---
 layout: default
 title: People
+breadcrumb:
+  link1: /community/
+  title1: Community
 ---
-
 <h1>People</h1>
 <div id="peopleTable">
 <ul>

--- a/pages/_profiles/index.html
+++ b/pages/_profiles/index.html
@@ -1,6 +1,8 @@
 ---
 layout: default
 title: Bioschemas Profiles
+breadcrumb:
+  title1: Specifications
 redirect_from:
  - "/devSpecs/"
  - "/specifications/drafts/"

--- a/pages/_properties/index.html
+++ b/pages/_properties/index.html
@@ -1,6 +1,8 @@
 ---
 layout: default
 title: Bioschemas Properties
+breadcrumb:
+  title1: Specifications
 # redirect_from:
 # - "/devTypes/"
 # - "/types/drafts/"

--- a/pages/_tutorials/community/biodiversity.md
+++ b/pages/_tutorials/community/biodiversity.md
@@ -3,6 +3,11 @@ title: How to markup biodiversity-related resources
 overviewTutorial:
   link: ./community/
   title: Return to community tutorials overview
+breadcrumb:
+  link1: /tutorials/
+  title1: Getting Started
+  link2: /tutorials/community/
+  title2: "Community-based"
 
 bioschemas:
   "@context": https://schema.org/

--- a/pages/_tutorials/community/idp.md
+++ b/pages/_tutorials/community/idp.md
@@ -3,6 +3,11 @@ title: How to add markup to IDP resources
 overviewTutorial:
   link: ./community/
   title: Return to community tutorials overview
+breadcrumb:
+  link1: /tutorials/
+  title1: Getting Started
+  link2: /tutorials/community/
+  title2: "Community-based"
 
 
 bioschemas:

--- a/pages/_tutorials/community/index.md
+++ b/pages/_tutorials/community/index.md
@@ -1,6 +1,10 @@
 ---
 layout: default
 title: Community-based Tutorials
+breadcrumb:
+  link1: /tutorials/
+  title1: Getting Started
+  title2: "Community-based"
 ---
 
 # Community-based tutorials

--- a/pages/_tutorials/community/plant.md
+++ b/pages/_tutorials/community/plant.md
@@ -3,6 +3,11 @@ title: How to add markup to plant resources
 overviewTutorial:
   link: ./community/
   title: Return to community tutorials overview
+breadcrumb:
+  link1: /tutorials/
+  title1: Getting Started
+  link2: /tutorials/community/
+  title2: "Community-based"
 
 bioschemas:
   "@context": https://schema.org/

--- a/pages/_tutorials/community/rd.md
+++ b/pages/_tutorials/community/rd.md
@@ -3,6 +3,11 @@ title: Marking up clinical entities in the Rare Diseases community
 overviewTutorial:
   link: ./community/
   title: Return to community tutorials overview
+breadcrumb:
+  link1: /tutorials/
+  title1: Getting Started
+  link2: /tutorials/community/
+  title2: "Community-based"
 
 bioschemas:
   "@context": https://schema.org/

--- a/pages/_tutorials/community/training.md
+++ b/pages/_tutorials/community/training.md
@@ -3,6 +3,11 @@ title: How Bioschemas uses the training profiles with GitHub pages and Jekyll
 overviewTutorial:
   link: ./community/
   title: Return to community tutorials overview
+breadcrumb:
+  link1: /tutorials/
+  title1: Getting Started
+  link2: /tutorials/community/
+  title2: "Community-based"
 
 
 bioschemas:

--- a/pages/_tutorials/dde/howto_create_new_profile.md
+++ b/pages/_tutorials/dde/howto_create_new_profile.md
@@ -6,6 +6,11 @@ nextTutorial:
 previousTutorial:
   link: ./dde/update_profile
   title: Profile Update
+breadcrumb:
+  link1: /tutorials/
+  title1: Getting Started
+  link2: /tutorials/dde/
+  title2: "DDE"
 
 redirect_from:
 - "/tutorials/howto/howto_create_new_profile"

--- a/pages/_tutorials/dde/index.md
+++ b/pages/_tutorials/dde/index.md
@@ -1,6 +1,10 @@
 ---
 layout: default
 title: Data Discovery Engine
+breadcrumb:
+  link1: /tutorials/
+  title1: Getting Started
+  title2: "DDE"
 ---
 
 # Data Discovery Engine

--- a/pages/_tutorials/dde/new_profile.md
+++ b/pages/_tutorials/dde/new_profile.md
@@ -6,6 +6,11 @@ previousTutorial:
 nextTutorial:
   link: ./dde/update_type
   title: Update a Type
+breadcrumb:
+  link1: /tutorials/
+  title1: Getting Started
+  link2: /tutorials/dde/
+  title2: "DDE"
   
 bioschemas:
   "@context": https://schema.org/

--- a/pages/_tutorials/dde/new_type.md
+++ b/pages/_tutorials/dde/new_type.md
@@ -6,6 +6,11 @@ previousTutorial:
 nextTutorial:
   link: ./dde/review_a_specification_pull_request
   title: Review a pull request on a Bioschemas Specification
+breadcrumb:
+  link1: /tutorials/
+  title1: Getting Started
+  link2: /tutorials/dde/
+  title2: "DDE"
   
 bioschemas:
   "@context": https://schema.org/

--- a/pages/_tutorials/dde/review_a_specification_pull_request.md
+++ b/pages/_tutorials/dde/review_a_specification_pull_request.md
@@ -3,6 +3,11 @@ title: Review a pull request on a Bioschemas Specification
 previousTutorial:
   link: ./dde/new_type
   title: Create New Type
+breadcrumb:
+  link1: /tutorials/
+  title1: Getting Started
+  link2: /tutorials/dde/
+  title2: "DDE"
 
   
 bioschemas:

--- a/pages/_tutorials/dde/update_profile.md
+++ b/pages/_tutorials/dde/update_profile.md
@@ -3,6 +3,11 @@ title: Profile Update
 nextTutorial:
   link: ./dde/howto_create_new_profile
   title: How to create a new draft profile
+breadcrumb:
+  link1: /tutorials/
+  title1: Getting Started
+  link2: /tutorials/dde/
+  title2: "DDE"
 
 redirect_from: 
 - "/tutorials/howto/howto_new_profile_version"

--- a/pages/_tutorials/dde/update_type.md
+++ b/pages/_tutorials/dde/update_type.md
@@ -6,6 +6,11 @@ previousTutorial:
 nextTutorial:
   link: ./dde/new_type
   title: Create a New Type
+breadcrumb:
+  link1: /tutorials/
+  title1: Getting Started
+  link2: /tutorials/dde/
+  title2: "DDE"
   
 bioschemas:
   "@context": https://schema.org/

--- a/pages/_tutorials/dde/validation_editor.md
+++ b/pages/_tutorials/dde/validation_editor.md
@@ -1,6 +1,11 @@
 ---
 layout: default
 title: Data Discovery Engine - Validation Editor
+breadcrumb:
+  link1: /tutorials/
+  title1: Getting Started
+  link2: /tutorials/dde/
+  title2: "DDE"
 ---
 
 ## How to use the Validation Editor to apply constraints to your profile specification

--- a/pages/_tutorials/howto/howto_add_github.md
+++ b/pages/_tutorials/howto/howto_add_github.md
@@ -6,6 +6,10 @@ previousTutorial:
 nextTutorial:
   link: howto/howto_check_deploy
   title: How to check your deployed markup
+breadcrumb:
+  link1: /tutorials/
+  title1: Getting Started
+  title2: "How to..."
 
 bioschemas:
   "@context": https://schema.org/

--- a/pages/_tutorials/howto/howto_add_markup.md
+++ b/pages/_tutorials/howto/howto_add_markup.md
@@ -6,6 +6,10 @@ previousTutorial:
 nextTutorial:
   link: ./howto/howto_add_github
   title: How to add markup to GitHub pages
+breadcrumb:
+  link1: /tutorials/
+  title1: Getting Started
+  title2: "How to..."
 
 bioschemas:
   "@context": https://schema.org/

--- a/pages/_tutorials/howto/howto_check_deploy.md
+++ b/pages/_tutorials/howto/howto_check_deploy.md
@@ -4,6 +4,10 @@ title: Check Deployed Markup
 previousTutorial:
   link: howto/howto_add_github
   title: Adding schema.org to a GitHub Pages site
+breadcrumb:
+  link1: /tutorials/
+  title1: Getting Started
+  title2: "How to..."
 
 bioschemas:
   "@context": https://schema.org/

--- a/pages/_tutorials/howto/howto_right_profile.md
+++ b/pages/_tutorials/howto/howto_right_profile.md
@@ -6,6 +6,10 @@ previousTutorial:
 nextTutorial:
   link: howto/howto_add_markup
   title: How to add markup to your own resource
+breadcrumb:
+  link1: /tutorials/
+  title1: Getting Started
+  title2: "How to..."
 
 bioschemas:
   "@context": https://schema.org/

--- a/pages/_tutorials/index.md
+++ b/pages/_tutorials/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Bioschemas Tutorials
+title: Bioschemas Tutorials Overview
 nextTutorial:
   link: ./what_why_schema
   title: What and why Schema.org

--- a/pages/_tutorials/index.md
+++ b/pages/_tutorials/index.md
@@ -4,6 +4,9 @@ title: Bioschemas Tutorials
 nextTutorial:
   link: ./what_why_schema
   title: What and why Schema.org
+breadcrumb:
+  link1: /tutorials/
+  title1: Getting Started
 redirect_from:
 - "tutorials"
 ---

--- a/pages/_tutorials/markup_examples.md
+++ b/pages/_tutorials/markup_examples.md
@@ -6,6 +6,9 @@ previousTutorial:
 nextTutorial:
   link: ./what_why_bioschemas
   title: What and why Bioschemas
+breadcrumb:
+  link1: /tutorials/
+  title1: Getting Started
 
 bioschemas:
   "@context": https://schema.org/

--- a/pages/_tutorials/what_why_bioschemas.md
+++ b/pages/_tutorials/what_why_bioschemas.md
@@ -6,6 +6,9 @@ previousTutorial:
 nextTutorial:
   link: ./howto/howto_right_profile
   title: How to select the right profile
+breadcrumb:
+  link1: /tutorials/
+  title1: Getting Started
 
 bioschemas:
   "@context": https://schema.org/

--- a/pages/_tutorials/what_why_schema.md
+++ b/pages/_tutorials/what_why_schema.md
@@ -6,6 +6,9 @@ previousTutorial:
 nextTutorial:
   link: ./markup_examples
   title: Schema.org markup examples
+breadcrumb:
+  link1: /tutorials/
+  title1: Getting Started
 
 bioschemas:
   "@context": https://schema.org/

--- a/pages/_types/index.html
+++ b/pages/_types/index.html
@@ -1,6 +1,8 @@
 ---
 layout: default
 title: Bioschemas Types
+breadcrumb:
+  title1: Specifications
 redirect_from:
 - "/devTypes/"
 - "/types/drafts/"

--- a/pages/_useCases/index.html
+++ b/pages/_useCases/index.html
@@ -1,6 +1,9 @@
 ---
 layout: default
 title: Use Cases
+breadcrumb:
+  link1: /community/
+  title1: Community
 ---
 
 <h1>Bioschemas Use Cases</h1>


### PR DESCRIPTION
As raised in [issue 695](https://github.com/BioSchemas/specifications/issues/695), Cologne Hackathon task T7a6 is to add breadcrumbs across the Bioschemas website. We were advised to use Bootstrap (version 5.1 is already used) and to add page frontmatter metadata to determine the locations rather than rely on directories/paths.

I have implemented breadcrumbs on most of the site, with a few exceptions and one workaround (described below). The homepage is unchanged. I have also fixed a few menu items which were put into the wrong order in a previous PR #836. 

### Fly-out submenu workaround
I've also considered task T7a4: Fly-out submenu navigation, [issue 697](https://github.com/BioSchemas/specifications/issues/697). There was no flyout menu directly in the Bootstrap code, it would require much work with Javascript to borrow from elsewhere then thoroughly test. So I have instead put the nested menu items into one level deeper `ul` which means they display with a bullet. I believe this is clearer. I'm looking for feedback on this too.

### Breadcrumbs implemented fully
* `/tutorials/` Getting Started (22 pages)
* `/developer/` Deploy & Develop (2 pages)
* `/community/` Community (5 pages)
* `/groups/` Community > Groups (26 pages)
* `/about/` About (4 pages)
* Several index pages mentioned later.

These pages have additional front-matter page metadata to describe which breadcrumb to show. They use the default layout which calls the new `breadcrumb.html` include file. The new `<nav>` item uses the same design as the side menu boxes (tea green with rounded corners and shadow).

### Breadcrumbs working fine, displays slightly off
* `/profiles/` Specifications > Profiles 
* `/news/` Community > News
* `/meetings/` Community > Meetings
* `/useCases/` Community > Use Cases

These pages have a non-default layout (except their index pages). There are too many pages to add the front-matter to each of them, and I am not touching the mechanics of the specifications. I included the same `breadcrumb.html` file as with the default layout pages, but since it is called from the layout pages _later_, there it is too late to set the page metadata, so there are parameters passed to the included file with the same fields. Unfortunately, it is only possible to call the include from within the `<main>` element, so there is an extra margin above the navigation which I cannot remove. Operationally, the links work fine, but it is a little jarring to see the space appear and disappear when navigating between affected and unaffected pages. 

The Profiles pages work, though they show the breadcrumb with the profile version number but not its name. This is because the page title metadata of a profile is just the version number, without the title of the profile. I believe this to be an error of the profile implementation which is highlighted by my new code. I'm not going to work around it. Perhaps we should raise this matter separately?

### Breadcrumbs not working 
* `/types/` Specifications > Types
* `/properties/` Specifications > Properties.

These pages do not define a layout at all (except their index pages which use default). They are part of the specifications code which I am not touching. So I cannot add breadcrumbs to these.

### Screenshots
<img width="1541" alt="image" src="https://github.com/user-attachments/assets/a80e1d53-11fd-4587-a39a-27717269fc3d" />
<img width="1541" alt="image" src="https://github.com/user-attachments/assets/11a5cb0d-100a-4235-b6a3-d8c6088175f7" />
<img width="1541" alt="image" src="https://github.com/user-attachments/assets/28c6dc7a-88b0-4c57-8942-6e1d35e083ff" />
<img width="1541" alt="image" src="https://github.com/user-attachments/assets/8d97d3e7-bdc7-4fcf-8e70-ca24893e0aeb" />
<img width="1541" alt="image" src="https://github.com/user-attachments/assets/a937004f-c117-44bb-9361-f6497aa3c5f1" />
<img width="1541" alt="image" src="https://github.com/user-attachments/assets/58de1b71-7dcb-4900-bbd6-05589fb70f0c" />
<img width="1541" alt="image" src="https://github.com/user-attachments/assets/c199dc30-99df-4abf-8c5c-a78e6d2cf921" />

<img width="177" alt="image" src="https://github.com/user-attachments/assets/b25be423-ad63-4aec-8fb6-2bd1cb4f4f03" />

