### PR TITLE
Move Ivan to former Steering Council members list

### DIFF
--- a/pages/_community/index.html
+++ b/pages/_community/index.html
@@ -37,7 +37,7 @@ title: Community
             </tr>
             <tr>
                 <td><strong>Engagement and Adoption</strong></td>
-                <td><a href="{{ '/people/IvanMicetic' | relative_url }}">Ivan Mi&ccaron;eti&cacute;</a>, BioComputing UP Lab, University of Padua, Italy</td>
+                <td>[Currently vacant]</td>
             </tr>
             <tr>
                 <td><strong>Support Tools</strong></td>
@@ -76,6 +76,7 @@ title: Community
         <li><a href="{{ '/people/LeylaGarcia' | relative_url }}">Leyla Jael Castro</a>, Training 2018-2022</li>
         <li><a href="{{ '/people/AlasdairGray' | relative_url }}">Alasdair Gray</a>, Chair 2017-2022</li>
         <li><a href="{{ '/people/RafaelJimenez' | relative_url }}">Rafael C Jimenez</a>, Community Member 2015-2018</li>
+        <li><a href="{{ '/people/IvanMicetic' | relative_url }}">Ivan Mi&ccaron;eti&cacute;</a>, Engagement and Adoption 2020-2024</li>
         <li><a href="{{ '/people/SaralaWimalaratne' | relative_url }}">Sarala Wimalaratne</a>, Engagement and Adoption 2018-2020</li>
     </ul>
 


### PR DESCRIPTION
Update the Community page, Steering Council, to recognise that Ivan has stepped down.