### PR TITLE
T7A4 Add submenu to navbar

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -32,38 +32,40 @@
             <li>
               <hr class="dropdown-divider">
             </li>
-            <li><a class="dropdown-item" href="{{ '/tutorials/dde/' | relative_url }}">Profile and Type Development in DDE</a>
+            <li><a class="dropdown-item" href="{{ '/tutorials/dde/' | relative_url }}">Profile and Type Development in DDE &raquo; </a>
+              <ul class="dropdown-menu dropdown-submenu">
+                <li><a class="dropdown-item" href="{{ '/tutorials/dde/update_profile' | relative_url }}">Updating a
+                  profile in DDE</a></li>
+                <li><a class="dropdown-item" href="{{ '/tutorials/dde/howto_create_new_profile' | relative_url }}">Developing profiles from scratch</a></li>
+                <li><a class="dropdown-item" href="{{ '/tutorials/dde/new_profile' | relative_url }}">Creating a new
+                  profile in the DDE</a></li>
+                <li><a class="dropdown-item" href="{{ '/tutorials/dde/update_type' | relative_url }}">Updating a
+                  type in DDE</a></li>
+                <li><a class="dropdown-item" href="{{ '/tutorials/dde/new_type' | relative_url }}">Creating a new
+                    type in the DDE</a></li>
+                <li><a class="dropdown-item"
+                  href="{{ '/tutorials/dde/review_a_specification_pull_request' | relative_url }}">Review a Specification
+                  Pull request (PR)</a></li>
+                <li><a class="dropdown-item" href="{{ '/tutorials/dde/validation_editor' | relative_url }}">Using a validation editor</a></li>
+              </ul>
             </li>
-            <ul>
-              <li><a class="dropdown-item" href="{{ '/tutorials/dde/update_profile' | relative_url }}">Updating a
-                profile in DDE</a></li>
-              <li><a class="dropdown-item" href="{{ '/tutorials/dde/howto_create_new_profile' | relative_url }}">Developing profiles from scratch</a></li>
-              <li><a class="dropdown-item" href="{{ '/tutorials/dde/new_profile' | relative_url }}">Creating a new
-                profile in the DDE</a></li>
-              <li><a class="dropdown-item" href="{{ '/tutorials/dde/update_type' | relative_url }}">Updating a
-                type in DDE</a></li>
-              <li><a class="dropdown-item" href="{{ '/tutorials/dde/new_type' | relative_url }}">Creating a new
-                  type in the DDE</a></li>
-              <li><a class="dropdown-item"
-                href="{{ '/tutorials/dde/review_a_specification_pull_request' | relative_url }}">Review a Specification
-                Pull request (PR)</a></li>
-              <li><a class="dropdown-item" href="{{ '/tutorials/dde/validation_editor' | relative_url }}">Using a validation editor</a></li>
-            </ul>
             <li>
               <hr class="dropdown-divider">
             </li>
             <li><a class="dropdown-item" href="{{ '/tutorials/community/' | relative_url }}">Community-based
-                tutorials</a></li>
-            <ul><li><a class="dropdown-item" href="{{ '/tutorials/community/idp' | relative_url }}">Adding markup to IDP
-                resources</a></li>
-            <li><a class="dropdown-item" href="{{ '/tutorials/community/plant' | relative_url }}">Adding markup to Plant
-                resources</a></li>
-            <li><a class="dropdown-item" href="{{ '/tutorials/community/rd' | relative_url }}">Adding markup to Rare
-                Disease resources</a></li>
-            <li><a class="dropdown-item" href="{{ '/tutorials/community/biodiversity' | relative_url }}">Adding markup
-                to Biodiversity-related resources</a></li>
-                <li><a class="dropdown-item" href="{{ '/tutorials/community/training' | relative_url }}">Adding markup to training resources</a></li></ul>
-            </ul>
+                tutorials &raquo; </a>
+              <ul class="dropdown-menu dropdown-submenu">
+                <li><a class="dropdown-item" href="{{ '/tutorials/community/idp' | relative_url }}">Adding markup to IDP
+                  resources</a></li>
+                <li><a class="dropdown-item" href="{{ '/tutorials/community/plant' | relative_url }}">Adding markup to Plant
+                    resources</a></li>
+                <li><a class="dropdown-item" href="{{ '/tutorials/community/rd' | relative_url }}">Adding markup to Rare
+                    Disease resources</a></li>
+                <li><a class="dropdown-item" href="{{ '/tutorials/community/biodiversity' | relative_url }}">Adding markup
+                    to Biodiversity-related resources</a></li>
+                    <li><a class="dropdown-item" href="{{ '/tutorials/community/training' | relative_url }}">Adding markup to training resources</a></li></ul>
+              </ul>
+          </li>
         </li>
         <li class="nav-item dropdown">
           <a class="nav-link dropdown-toggle active mx-2" href="#" id="dropdown02" data-bs-toggle="dropdown"

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -233,3 +233,25 @@ Breadcrumbs
 main .breadcrumb {
     transform: translateY(-3rem);
 }
+
+
+
+/*******************************************************************************
+Nested menu https://mdbootstrap.com/docs/standard/extended/dropdown-multilevel/
+*******************************************************************************/
+.dropdown-menu li {
+    position: relative;
+}
+.dropdown-menu .dropdown-submenu {
+    display: none;
+    position: absolute;
+    left: 100%;
+    top: -7px;
+}
+.dropdown-menu .dropdown-submenu-left {
+    right: 100%;
+    left: auto;
+}
+.dropdown-menu > li:hover > .dropdown-submenu {
+    display: block;
+}


### PR DESCRIPTION
See issue https://github.com/BioSchemas/specifications/issues/697

Use a [little extra Bootstrap code](https://mdbootstrap.com/docs/standard/extended/dropdown-multilevel/) to include submenus for the navbar, specifically the Getting Started menu: DDE and community-based. 

Doesn't work on mobile view, fails gracefully.

![image](https://github.com/user-attachments/assets/14888505-54ee-4550-aedc-59da95af4785)
