### PR TITLE
Add announcement for Sample and Biosample review

### DIFF
--- a/pages/_news/2026-06-01-Sample-Biosample-Request-Review.md
+++ b/pages/_news/2026-06-01-Sample-Biosample-Request-Review.md
@@ -1,0 +1,28 @@
+---
+layout: post
+title: "Invitation to review draft Sample and Biosample types"
+tags:
+- BioSample 
+- Community 
+- RequestForComment
+- Type 
+---
+
+The draft types for [Sample] (https://bioschemas.org/types/Sample/0.3-DRAFT) and [Biosample] (https://bioschemas.org/types/BioSample/0.2-DRAFT) are now available on the Bioschemas website for community review. 
+
+In line with our [governance] (https://github.com/BioSchemas/governance/blob/v1.1/governance.md), both drafts are open to community review for a period of 2 weeks (close of business (GMT) - 15th June 2026). Comments and feedback on properties  should be provided through the relevant forms here: [Sample] (https://forms.gle/NYph2GW22byw42AX7), [Biosample] (https://forms.gle/shy7ahunpV4P2s12A). 
+
+Additionally, you may comment through the following GitHub issues: [GH722 - Sample review] (https://github.com/BioSchemas/specifications/issues/722), [GH723 - Biosample review] (https://github.com/BioSchemas/specifications/issues/723). 
+
+Please refrain from other means of feedback (e.g. email or direct messages) which may cause a delay in processing, and are more difficult to track. 
+
+We will endeavour to incorporate all relevant feedback prior to full release, but note that some feedback (e.g. descriptions of properties) may be more appropriate to accommodate in the profile creation stage. 
+
+Furthermore, in anticipation of a full release, we are also soliciting feedback on key properties for developing a profile against each draft type. 
+We will summarise our actions in a follow-up correspondence. For further information on this and other matters, please feel free to attend our regular [Community Call] (https://docs.google.com/document/d/1kd5F97ogdiPNhLTnkei-RVR8TC8Ohpc5QSPX3KsfDrk).
+
+Finally, we would like to thank the Bioschemas [Samples Group] (https://bioschemas.org/groups/Samples) for bringing this work together, [ELIXIR] (https://elixir-europe.org/events/biohackathon-europe) and [ELIXIR-DE] (https://www.denbi.de/elixir-de) for hosting hackathon projects, [BGE] (https://biodiversitygenomics.eu/) and [BioDT] (https://biodt.eu/) for targeted contributions, and most importantly the broader community for all their input.
+
+
+
+

--- a/pages/_news/2026-06-01-Sample-Biosample-Request-Review.md
+++ b/pages/_news/2026-06-01-Sample-Biosample-Request-Review.md
@@ -8,20 +8,20 @@ tags:
 - Type 
 ---
 
-The draft types for [Sample] (https://bioschemas.org/types/Sample/0.3-DRAFT) and [Biosample] (https://bioschemas.org/types/BioSample/0.2-DRAFT) are now available on the Bioschemas website for community review. 
+The draft types for [Sample](https://bioschemas.org/types/Sample/0.3-DRAFT) and [Biosample](https://bioschemas.org/types/BioSample/0.2-DRAFT) are now available on the Bioschemas website for community review. 
 
-In line with our [governance] (https://github.com/BioSchemas/governance/blob/v1.1/governance.md), both drafts are open to community review for a period of 2 weeks (close of business (GMT) - 15th June 2026). Comments and feedback on properties  should be provided through the relevant forms here: [Sample] (https://forms.gle/NYph2GW22byw42AX7), [Biosample] (https://forms.gle/shy7ahunpV4P2s12A). 
+In line with our [governance](https://github.com/BioSchemas/governance/blob/v1.1/governance.md), both drafts are open to community review for a period of 2 weeks (close of business (GMT) - 15th June 2026). Comments and feedback on properties  should be provided through the relevant forms here: [Sample](https://forms.gle/NYph2GW22byw42AX7), [Biosample](https://forms.gle/shy7ahunpV4P2s12A). 
 
-Additionally, you may comment through the following GitHub issues: [GH722 - Sample review] (https://github.com/BioSchemas/specifications/issues/722), [GH723 - Biosample review] (https://github.com/BioSchemas/specifications/issues/723). 
+Additionally, you may comment through the following GitHub issues: [GH722 - Sample review](https://github.com/BioSchemas/specifications/issues/722), [GH723 - Biosample review](https://github.com/BioSchemas/specifications/issues/723). 
 
 Please refrain from other means of feedback (e.g. email or direct messages) which may cause a delay in processing, and are more difficult to track. 
 
 We will endeavour to incorporate all relevant feedback prior to full release, but note that some feedback (e.g. descriptions of properties) may be more appropriate to accommodate in the profile creation stage. 
 
 Furthermore, in anticipation of a full release, we are also soliciting feedback on key properties for developing a profile against each draft type. 
-We will summarise our actions in a follow-up correspondence. For further information on this and other matters, please feel free to attend our regular [Community Call] (https://docs.google.com/document/d/1kd5F97ogdiPNhLTnkei-RVR8TC8Ohpc5QSPX3KsfDrk).
+We will summarise our actions in a follow-up correspondence. For further information on this and other matters, please feel free to attend our regular [Community Call](https://docs.google.com/document/d/1kd5F97ogdiPNhLTnkei-RVR8TC8Ohpc5QSPX3KsfDrk).
 
-Finally, we would like to thank the Bioschemas [Samples Group] (https://bioschemas.org/groups/Samples) for bringing this work together, [ELIXIR] (https://elixir-europe.org/events/biohackathon-europe) and [ELIXIR-DE] (https://www.denbi.de/elixir-de) for hosting hackathon projects, [BGE] (https://biodiversitygenomics.eu/) and [BioDT] (https://biodt.eu/) for targeted contributions, and most importantly the broader community for all their input.
+Finally, we would like to thank the Bioschemas [Samples Group](https://bioschemas.org/groups/Samples) for bringing this work together, [ELIXIR](https://elixir-europe.org/events/biohackathon-europe) and [ELIXIR-DE](https://www.denbi.de/elixir-de) for hosting hackathon projects, [BGE](https://biodiversitygenomics.eu/) and [BioDT](https://biodt.eu/) for targeted contributions, and most importantly the broader community for all their input.
 
 
 


### PR DESCRIPTION
The draft types for Sample and Biosample are now available for community review for a period of 2 weeks, with feedback requested through specified forms and GitHub issues.